### PR TITLE
Form placeholder cleanup/shrink

### DIFF
--- a/app/src/components/fields/AutocompleteField.tsx
+++ b/app/src/components/fields/AutocompleteField.tsx
@@ -57,10 +57,6 @@ const AutocompleteField: React.FC<IAutocompleteField> = (props) => {
           fullWidth
           error={touched[props.id] && Boolean(errors[props.id])}
           helperText={errors[props.id]}
-          placeholder={'Begin typing to filter results...'}
-          InputLabelProps={{
-            shrink: true
-          }}
           onChange={(event) => {
             setFieldValue(props.id, event.target.value);
           }}

--- a/app/src/components/fields/MultiAutocompleteFieldVariableSize.tsx
+++ b/app/src/components/fields/MultiAutocompleteFieldVariableSize.tsx
@@ -171,10 +171,6 @@ const MultiAutocompleteFieldVariableSize: React.FC<IMultiAutocompleteField> = (p
           fullWidth
           error={touched[props.id] && Boolean(errors[props.id])}
           helperText={errors[props.id]}
-          placeholder={'Begin typing to filter results...'}
-          InputLabelProps={{
-            shrink: true
-          }}
         />
       )}
     />

--- a/app/src/features/projects/components/ProjectCoordinatorForm.tsx
+++ b/app/src/features/projects/components/ProjectCoordinatorForm.tsx
@@ -63,9 +63,6 @@ const ProjectCoordinatorForm: React.FC<IProjectCoordinatorFormProps> = (props) =
           onChange={handleChange}
           error={touched.first_name && Boolean(errors.first_name)}
           helperText={errors.first_name}
-          InputLabelProps={{
-            shrink: true
-          }}
         />
       </Grid>
       <Grid item xs={12} md={6}>
@@ -80,9 +77,6 @@ const ProjectCoordinatorForm: React.FC<IProjectCoordinatorFormProps> = (props) =
           onChange={handleChange}
           error={touched.last_name && Boolean(errors.last_name)}
           helperText={errors.last_name}
-          InputLabelProps={{
-            shrink: true
-          }}
         />
       </Grid>
       <Grid item xs={12}>
@@ -97,9 +91,6 @@ const ProjectCoordinatorForm: React.FC<IProjectCoordinatorFormProps> = (props) =
           onChange={handleChange}
           error={touched.email_address && Boolean(errors.email_address)}
           helperText={errors.email_address}
-          InputLabelProps={{
-            shrink: true
-          }}
         />
       </Grid>
 

--- a/app/src/features/projects/components/ProjectDetailsForm.tsx
+++ b/app/src/features/projects/components/ProjectDetailsForm.tsx
@@ -73,16 +73,11 @@ const ProjectDetailsForm: React.FC<IProjectDetailsFormProps> = (props) => {
             onChange={handleChange}
             error={touched.project_name && Boolean(errors.project_name)}
             helperText={errors.project_name}
-            InputLabelProps={{
-              shrink: true
-            }}
           />
         </Grid>
         <Grid item xs={12}>
           <FormControl fullWidth variant="outlined" required={true} style={{ width: '100%' }}>
-            <InputLabel id="project_type-label" shrink={true}>
-              Project Type
-            </InputLabel>
+            <InputLabel id="project_type-label">Project Type</InputLabel>
             <Select
               id="project_type"
               name="project_type"

--- a/app/src/features/projects/components/ProjectFundingItemForm.tsx
+++ b/app/src/features/projects/components/ProjectFundingItemForm.tsx
@@ -102,9 +102,7 @@ const ProjectFundingItemForm: React.FC<IProjectFundingItemFormProps> = (props) =
                 <Grid container spacing={3}>
                   <Grid item xs={12}>
                     <FormControl fullWidth variant="outlined" required={true} style={{ width: '100%' }}>
-                      <InputLabel id="agency_id-label" shrink={true}>
-                        Agency Name
-                      </InputLabel>
+                      <InputLabel id="agency_id-label">Agency Name</InputLabel>
                       <Select
                         id="agency_id"
                         name="agency_id"
@@ -145,7 +143,7 @@ const ProjectFundingItemForm: React.FC<IProjectFundingItemFormProps> = (props) =
                   {investment_action_category_label && (
                     <Grid item xs={12}>
                       <FormControl fullWidth variant="outlined" required={false} style={{ width: '100%' }}>
-                        <InputLabel id="investment_action_category-label" shrink={true}>
+                        <InputLabel id="investment_action_category-label">
                           {investment_action_category_label}
                         </InputLabel>
                         <Select
@@ -184,9 +182,6 @@ const ProjectFundingItemForm: React.FC<IProjectFundingItemFormProps> = (props) =
                       onChange={handleChange}
                       error={touched.agency_project_id && Boolean(errors.agency_project_id)}
                       helperText={errors.agency_project_id}
-                      InputLabelProps={{
-                        shrink: true
-                      }}
                     />
                   </Grid>
                   <Grid item xs={12}>

--- a/app/src/features/projects/components/ProjectLocationForm.tsx
+++ b/app/src/features/projects/components/ProjectLocationForm.tsx
@@ -123,9 +123,6 @@ const ProjectLocationForm: React.FC<IProjectLocationFormProps> = (props) => {
             onChange={handleChange}
             error={touched.location_description && Boolean(errors.location_description)}
             helperText={errors.location_description}
-            InputLabelProps={{
-              shrink: true
-            }}
           />
         </Grid>
         <Grid item xs={12}>

--- a/app/src/features/projects/components/ProjectObjectivesForm.tsx
+++ b/app/src/features/projects/components/ProjectObjectivesForm.tsx
@@ -45,9 +45,6 @@ const ProjectObjectivesForm = () => {
             onChange={handleChange}
             error={touched.objectives && Boolean(errors.objectives)}
             helperText={errors.objectives}
-            InputLabelProps={{
-              shrink: true
-            }}
           />
         </Grid>
 
@@ -64,9 +61,6 @@ const ProjectObjectivesForm = () => {
             onChange={handleChange}
             error={touched.caveats && Boolean(errors.caveats)}
             helperText={errors.caveats}
-            InputLabelProps={{
-              shrink: true
-            }}
           />
         </Grid>
       </Grid>

--- a/app/src/features/projects/components/ProjectPermitForm.tsx
+++ b/app/src/features/projects/components/ProjectPermitForm.tsx
@@ -74,16 +74,11 @@ const ProjectPermitForm: React.FC = () => {
                         onChange={handleChange}
                         error={permitNumberMeta.touched && Boolean(permitNumberMeta.error)}
                         helperText={permitNumberMeta.error}
-                        InputLabelProps={{
-                          shrink: true
-                        }}
                       />
                     </Grid>
                     <Grid item xs={12} md={4}>
                       <FormControl variant="outlined" style={{ width: '100%' }}>
-                        <InputLabel id="sampling_conducted" shrink={true}>
-                          Sampling Conducted
-                        </InputLabel>
+                        <InputLabel id="sampling_conducted">Sampling Conducted</InputLabel>
                         <Select
                           id={`permits.[${index}].sampling_conducted`}
                           name={`permits.[${index}].sampling_conducted`}

--- a/app/src/features/projects/components/__snapshots__/ProjectCoordinatorForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectCoordinatorForm.test.tsx.snap
@@ -12,8 +12,8 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-          data-shrink="true"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+          data-shrink="false"
           for="first_name"
           id="first_name-label"
         >
@@ -42,7 +42,7 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
             class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+              class="PrivateNotchedOutline-legendLabelled-3"
             >
               <span>
                 First Name *
@@ -59,8 +59,8 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-          data-shrink="true"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+          data-shrink="false"
           for="last_name"
           id="last_name-label"
         >
@@ -89,7 +89,7 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
             class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+              class="PrivateNotchedOutline-legendLabelled-3"
             >
               <span>
                 Last Name *
@@ -106,8 +106,8 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-          data-shrink="true"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+          data-shrink="false"
           for="email_address"
           id="email_address-label"
         >
@@ -136,7 +136,7 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
             class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+              class="PrivateNotchedOutline-legendLabelled-3"
             >
               <span>
                 Business Email Address *
@@ -158,8 +158,8 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+            data-shrink="false"
             for="coordinator_agency"
             id="coordinator_agency-label"
           >
@@ -181,7 +181,6 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
               autocomplete="off"
               class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
               id="coordinator_agency"
-              placeholder="Begin typing to filter results..."
               required=""
               spellcheck="false"
               type="text"
@@ -221,7 +220,7 @@ exports[`Project Coordinator Form renders correctly the empty component correctl
               class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                class="PrivateNotchedOutline-legendLabelled-3"
               >
                 <span>
                   Coordinator Agency *
@@ -550,7 +549,6 @@ exports[`Project Coordinator Form renders correctly the filled component correct
               autocomplete="off"
               class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
               id="coordinator_agency"
-              placeholder="Begin typing to filter results..."
               required=""
               spellcheck="false"
               type="text"

--- a/app/src/features/projects/components/__snapshots__/ProjectDetailsForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectDetailsForm.test.tsx.snap
@@ -13,8 +13,8 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+            data-shrink="false"
             for="project_name"
             id="project_name-label"
           >
@@ -43,7 +43,7 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
               class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                class="PrivateNotchedOutline-legendLabelled-3"
               >
                 <span>
                   Project Name *
@@ -61,8 +61,8 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
           style="width: 100%;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+            data-shrink="false"
             id="project_type-label"
           >
             Project Type
@@ -137,8 +137,8 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="project_activities"
               id="project_activities-label"
             >
@@ -154,7 +154,6 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="project_activities"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -218,7 +217,7 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                  class="PrivateNotchedOutline-legendLabelled-3"
                 >
                   <span>
                     Project Activities
@@ -241,8 +240,8 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="climate_change_initiatives"
               id="climate_change_initiatives-label"
             >
@@ -258,7 +257,6 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="climate_change_initiatives"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -322,7 +320,7 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                  class="PrivateNotchedOutline-legendLabelled-3"
                 >
                   <span>
                     Climate Change Initiatives
@@ -625,7 +623,6 @@ exports[`ProjectDetailsForm renders correctly with existing details values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="project_activities"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -773,7 +770,6 @@ exports[`ProjectDetailsForm renders correctly with existing details values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="climate_change_initiatives"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""

--- a/app/src/features/projects/components/__snapshots__/ProjectFundingForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectFundingForm.test.tsx.snap
@@ -63,8 +63,8 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="indigenous_partnerships"
               id="indigenous_partnerships-label"
             >
@@ -80,7 +80,6 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="indigenous_partnerships"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -144,7 +143,7 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-5 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-7 PrivateNotchedOutline-legendNotched-8"
+                  class="PrivateNotchedOutline-legendLabelled-7"
                 >
                   <span>
                     Indigenous Partnerships
@@ -167,8 +166,8 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="stakeholder_partnerships"
               id="stakeholder_partnerships-label"
             >
@@ -184,7 +183,6 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="stakeholder_partnerships"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -248,7 +246,7 @@ exports[`ProjectFundingForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-5 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-7 PrivateNotchedOutline-legendNotched-8"
+                  class="PrivateNotchedOutline-legendLabelled-7"
                 >
                   <span>
                     Stakeholder Partnerships
@@ -526,7 +524,6 @@ exports[`ProjectFundingForm renders correctly with existing funding values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="indigenous_partnerships"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -613,8 +610,8 @@ exports[`ProjectFundingForm renders correctly with existing funding values 1`] =
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="stakeholder_partnerships"
               id="stakeholder_partnerships-label"
             >
@@ -630,7 +627,6 @@ exports[`ProjectFundingForm renders correctly with existing funding values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="stakeholder_partnerships"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -694,7 +690,7 @@ exports[`ProjectFundingForm renders correctly with existing funding values 1`] =
                 class="PrivateNotchedOutline-root-17 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-19 PrivateNotchedOutline-legendNotched-20"
+                  class="PrivateNotchedOutline-legendLabelled-19"
                 >
                   <span>
                     Stakeholder Partnerships

--- a/app/src/features/projects/components/__snapshots__/ProjectFundingItemForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectFundingItemForm.test.tsx.snap
@@ -139,8 +139,8 @@ exports[`ProjectFundingItemForm renders correctly with default empty values 1`] 
                 class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-                  data-shrink="true"
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                  data-shrink="false"
                   for="agency_project_id"
                   id="agency_project_id-label"
                 >
@@ -162,7 +162,7 @@ exports[`ProjectFundingItemForm renders correctly with default empty values 1`] 
                     class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                      class="PrivateNotchedOutline-legendLabelled-3"
                     >
                       <span>
                         Agency Project ID

--- a/app/src/features/projects/components/__snapshots__/ProjectLocationForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectLocationForm.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`ProjectLocationForm displays the uploaded geo on the map when the spati
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
               for="regions"
               id="regions-label"
             >
@@ -41,7 +41,6 @@ exports[`ProjectLocationForm displays the uploaded geo on the map when the spati
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="regions"
-                placeholder="Begin typing to filter results..."
                 required=""
                 spellcheck="false"
                 type="text"
@@ -106,7 +105,7 @@ exports[`ProjectLocationForm displays the uploaded geo on the map when the spati
                 class="PrivateNotchedOutline-root-30 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-32 PrivateNotchedOutline-legendNotched-33"
+                  class="PrivateNotchedOutline-legendLabelled-32"
                 >
                   <span>
                     Regions *
@@ -124,8 +123,8 @@ exports[`ProjectLocationForm displays the uploaded geo on the map when the spati
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+            data-shrink="false"
             for="location_description"
             id="location_description-label"
           >
@@ -146,7 +145,7 @@ exports[`ProjectLocationForm displays the uploaded geo on the map when the spati
               class="PrivateNotchedOutline-root-30 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-32 PrivateNotchedOutline-legendNotched-33"
+                class="PrivateNotchedOutline-legendLabelled-32"
               >
                 <span>
                   Location Description
@@ -512,8 +511,8 @@ exports[`ProjectLocationForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
               for="regions"
               id="regions-label"
             >
@@ -535,7 +534,6 @@ exports[`ProjectLocationForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="regions"
-                placeholder="Begin typing to filter results..."
                 required=""
                 spellcheck="false"
                 type="text"
@@ -600,7 +598,7 @@ exports[`ProjectLocationForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-3 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-5 PrivateNotchedOutline-legendNotched-6"
+                  class="PrivateNotchedOutline-legendLabelled-5"
                 >
                   <span>
                     Regions *
@@ -618,8 +616,8 @@ exports[`ProjectLocationForm renders correctly with default empty values 1`] = `
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+            data-shrink="false"
             for="location_description"
             id="location_description-label"
           >
@@ -640,7 +638,7 @@ exports[`ProjectLocationForm renders correctly with default empty values 1`] = `
               class="PrivateNotchedOutline-root-3 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-5 PrivateNotchedOutline-legendNotched-6"
+                class="PrivateNotchedOutline-legendLabelled-5"
               >
                 <span>
                   Location Description
@@ -983,8 +981,8 @@ exports[`ProjectLocationForm renders correctly with existing location values 1`]
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+              data-shrink="false"
               for="regions"
               id="regions-label"
             >
@@ -1006,7 +1004,6 @@ exports[`ProjectLocationForm renders correctly with existing location values 1`]
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="regions"
-                placeholder="Begin typing to filter results..."
                 required=""
                 spellcheck="false"
                 type="text"
@@ -1071,7 +1068,7 @@ exports[`ProjectLocationForm renders correctly with existing location values 1`]
                 class="PrivateNotchedOutline-root-12 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-14 PrivateNotchedOutline-legendNotched-15"
+                  class="PrivateNotchedOutline-legendLabelled-14"
                 >
                   <span>
                     Regions *

--- a/app/src/features/projects/components/__snapshots__/ProjectObjectivesForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectObjectivesForm.test.tsx.snap
@@ -13,8 +13,8 @@ exports[`ProjectObjectivesForm renders correctly with default empty values 1`] =
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+            data-shrink="false"
             for="objectives"
             id="objectives-label"
           >
@@ -42,7 +42,7 @@ exports[`ProjectObjectivesForm renders correctly with default empty values 1`] =
               class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                class="PrivateNotchedOutline-legendLabelled-3"
               >
                 <span>
                   Objectives *
@@ -59,8 +59,8 @@ exports[`ProjectObjectivesForm renders correctly with default empty values 1`] =
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+            data-shrink="false"
             for="caveats"
             id="caveats-label"
           >
@@ -81,7 +81,7 @@ exports[`ProjectObjectivesForm renders correctly with default empty values 1`] =
               class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                class="PrivateNotchedOutline-legendLabelled-3"
               >
                 <span>
                   Caveats (Optional)

--- a/app/src/features/projects/components/__snapshots__/ProjectPermitForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectPermitForm.test.tsx.snap
@@ -19,8 +19,8 @@ exports[`ProjectPermitForm renders correctly with default empty values 1`] = `
               class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-required Mui-required"
-                data-shrink="true"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-required Mui-required"
+                data-shrink="false"
                 for="permits.[0].permit_number"
                 id="permits.[0].permit_number-label"
               >
@@ -49,7 +49,7 @@ exports[`ProjectPermitForm renders correctly with default empty values 1`] = `
                   class="PrivateNotchedOutline-root-3 MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="PrivateNotchedOutline-legendLabelled-5 PrivateNotchedOutline-legendNotched-6"
+                    class="PrivateNotchedOutline-legendLabelled-5"
                   >
                     <span>
                       Permit Number *

--- a/app/src/features/projects/components/__snapshots__/ProjectSpeciesForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectSpeciesForm.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="focal_species"
               id="focal_species-label"
             >
@@ -35,7 +35,6 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="focal_species"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -99,7 +98,7 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-4 PrivateNotchedOutline-legendNotched-5"
+                  class="PrivateNotchedOutline-legendLabelled-4"
                 >
                   <span>
                     Focal Species
@@ -122,8 +121,8 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="ancillary_species"
               id="ancillary_species-label"
             >
@@ -139,7 +138,6 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="ancillary_species"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -203,7 +201,7 @@ exports[`ProjectSpeciesForm renders correctly with default empty values 1`] = `
                 class="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-4 PrivateNotchedOutline-legendNotched-5"
+                  class="PrivateNotchedOutline-legendLabelled-4"
                 >
                   <span>
                     Ancillary Species
@@ -237,8 +235,8 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="focal_species"
               id="focal_species-label"
             >
@@ -254,7 +252,6 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="focal_species"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -318,7 +315,7 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
                 class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+                  class="PrivateNotchedOutline-legendLabelled-9"
                 >
                   <span>
                     Focal Species
@@ -341,8 +338,8 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
             class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
-              data-shrink="true"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+              data-shrink="false"
               for="ancillary_species"
               id="ancillary_species-label"
             >
@@ -358,7 +355,6 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
                 autocomplete="off"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                 id="ancillary_species"
-                placeholder="Begin typing to filter results..."
                 spellcheck="false"
                 type="text"
                 value=""
@@ -422,7 +418,7 @@ exports[`ProjectSpeciesForm renders correctly with existing species values 1`] =
                 class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+                  class="PrivateNotchedOutline-legendLabelled-9"
                 >
                   <span>
                     Ancillary Species


### PR DESCRIPTION
## Overview

- Form placeholder cleanup/shrink props so that the input fields have the placeholder and label in the field itself rather than on top of the field (for applicable fields)

## Tested

- Locally

## Screenshots

- Sample is shown below:

<img width="1190" alt="Screenshot 2021-03-09 105039" src="https://user-images.githubusercontent.com/28017034/110522036-54875500-80c5-11eb-8542-df2f7b32fc48.png">