### PR TITLE
868 Frontend: IUCN Classifications

### DIFF
--- a/app/src/features/projects/CreateProjectPage.test.tsx
+++ b/app/src/features/projects/CreateProjectPage.test.tsx
@@ -87,6 +87,8 @@ describe('CreateProjectPage', () => {
 
       expect(getByText('Species')).toBeVisible();
 
+      expect(getByText('IUCN Classification')).toBeVisible();
+
       expect(getByText('Funding and Partnerships')).toBeVisible();
 
       expect(asFragment()).toMatchSnapshot();

--- a/app/src/features/projects/CreateProjectPage.tsx
+++ b/app/src/features/projects/CreateProjectPage.tsx
@@ -161,32 +161,6 @@ const CreateProjectPage: React.FC = () => {
     const setFormSteps = () => {
       setSteps([
         {
-          stepTitle: 'IUCN Classification',
-          stepSubTitle: 'Lorem ipsum dolor sit amet, consectur whatever whatever',
-          stepContent: (
-            <ProjectIUCNForm
-              classifications={
-                [
-                  { id: 1, name: 'Class 1' },
-                  { id: 2, name: 'Class 2' }
-                ].map((item) => {
-                  return { value: item.id, label: item.name };
-                }) || []
-              }
-              subClassifications={
-                [
-                  { id: 1, name: 'Sub-class 1' },
-                  { id: 2, name: 'Sub-class 2' }
-                ].map((item) => {
-                  return { value: item.id, label: item.name };
-                }) || []
-              }
-            />
-          ),
-          stepValues: ProjectIUCNFormInitialValues,
-          stepValidation: ProjectIUCNFormYupSchema
-        },
-        {
           stepTitle: 'Project Coordinator',
           stepSubTitle: 'Enter contact details for the project coordinator',
           stepContent: (
@@ -270,7 +244,32 @@ const CreateProjectPage: React.FC = () => {
           stepValues: ProjectSpeciesFormInitialValues,
           stepValidation: ProjectSpeciesFormYupSchema
         },
-
+        {
+          stepTitle: 'IUCN Classification',
+          stepSubTitle: 'Lorem ipsum dolor sit amet, consectur whatever whatever',
+          stepContent: (
+            <ProjectIUCNForm
+              classifications={
+                [
+                  { id: 1, name: 'Class 1' },
+                  { id: 2, name: 'Class 2' }
+                ].map((item) => {
+                  return { value: item.id, label: item.name };
+                }) || []
+              }
+              subClassifications={
+                [
+                  { id: 1, name: 'Sub-class 1' },
+                  { id: 2, name: 'Sub-class 2' }
+                ].map((item) => {
+                  return { value: item.id, label: item.name };
+                }) || []
+              }
+            />
+          ),
+          stepValues: ProjectIUCNFormInitialValues,
+          stepValidation: ProjectIUCNFormYupSchema
+        },
         {
           stepTitle: 'Funding and Partnerships',
           stepSubTitle: 'Specify funding and partnerships for the project',
@@ -313,8 +312,6 @@ const CreateProjectPage: React.FC = () => {
     setSteps((currentSteps) => {
       let updatedSteps = [...currentSteps];
       updatedSteps[activeStep].stepValues = values;
-
-      console.log(updatedSteps);
       return updatedSteps;
     });
   };

--- a/app/src/features/projects/CreateProjectPage.tsx
+++ b/app/src/features/projects/CreateProjectPage.tsx
@@ -46,6 +46,10 @@ import ProjectObjectivesForm, {
   ProjectObjectivesFormInitialValues,
   ProjectObjectivesFormYupSchema
 } from 'features/projects/components/ProjectObjectivesForm';
+import ProjectIUCNForm, {
+  ProjectIUCNFormInitialValues,
+  ProjectIUCNFormYupSchema
+} from 'features/projects/components/ProjectIUCNForm';
 import { Formik } from 'formik';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { IGetAllCodesResponse, IProjectPostObject } from 'interfaces/useBioHubApi-interfaces';
@@ -157,6 +161,32 @@ const CreateProjectPage: React.FC = () => {
     const setFormSteps = () => {
       setSteps([
         {
+          stepTitle: 'IUCN Classification',
+          stepSubTitle: 'Lorem ipsum dolor sit amet, consectur whatever whatever',
+          stepContent: (
+            <ProjectIUCNForm
+              classifications={
+                [
+                  { id: 1, name: 'Class 1' },
+                  { id: 2, name: 'Class 2' }
+                ].map((item) => {
+                  return { value: item.id, label: item.name };
+                }) || []
+              }
+              subClassifications={
+                [
+                  { id: 1, name: 'Sub-class 1' },
+                  { id: 2, name: 'Sub-class 2' }
+                ].map((item) => {
+                  return { value: item.id, label: item.name };
+                }) || []
+              }
+            />
+          ),
+          stepValues: ProjectIUCNFormInitialValues,
+          stepValidation: ProjectIUCNFormYupSchema
+        },
+        {
           stepTitle: 'Project Coordinator',
           stepSubTitle: 'Enter contact details for the project coordinator',
           stepContent: (
@@ -240,6 +270,7 @@ const CreateProjectPage: React.FC = () => {
           stepValues: ProjectSpeciesFormInitialValues,
           stepValidation: ProjectSpeciesFormYupSchema
         },
+
         {
           stepTitle: 'Funding and Partnerships',
           stepSubTitle: 'Specify funding and partnerships for the project',
@@ -282,6 +313,8 @@ const CreateProjectPage: React.FC = () => {
     setSteps((currentSteps) => {
       let updatedSteps = [...currentSteps];
       updatedSteps[activeStep].stepValues = values;
+
+      console.log(updatedSteps);
       return updatedSteps;
     });
   };

--- a/app/src/features/projects/CreateProjectPage.tsx
+++ b/app/src/features/projects/CreateProjectPage.tsx
@@ -351,7 +351,6 @@ const CreateProjectPage: React.FC = () => {
     setStepForms((currentStepForms) => {
       let updatedStepForms = [...currentStepForms];
       updatedStepForms[activeStep].stepValues = values;
-      console.log(updatedStepForms);
       return updatedStepForms;
     });
   };

--- a/app/src/features/projects/__snapshots__/CreateProjectPage.test.tsx.snap
+++ b/app/src/features/projects/__snapshots__/CreateProjectPage.test.tsx.snap
@@ -760,6 +760,72 @@ exports[`CreateProjectPage adds the extra create project steps if at least 1 per
                     <h2
                       class="MuiTypography-root makeStyles-stepTitle-39 MuiTypography-h2"
                     >
+                      IUCN Classification
+                    </h2>
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle2"
+                    >
+                      Lorem ipsum dolor sit amet, consectur whatever whatever
+                    </h6>
+                  </div>
+                </span>
+              </span>
+            </span>
+            <div
+              class="MuiStepContent-root"
+              disabled=""
+              icon="7"
+            />
+          </div>
+          <div
+            class="MuiStepConnector-root MuiStepConnector-vertical Mui-disabled"
+          >
+            <span
+              class="MuiStepConnector-line MuiStepConnector-lineVertical"
+            />
+          </div>
+          <div
+            class="MuiStep-root MuiStep-vertical"
+          >
+            <span
+              class="MuiStepLabel-root MuiStepLabel-vertical Mui-disabled"
+            >
+              <span
+                class="MuiStepLabel-iconContainer"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiStepIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="12"
+                  />
+                  <text
+                    class="MuiStepIcon-text"
+                    text-anchor="middle"
+                    x="12"
+                    y="16"
+                  >
+                    8
+                  </text>
+                </svg>
+              </span>
+              <span
+                class="MuiStepLabel-labelContainer"
+              >
+                <span
+                  class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+                >
+                  <div
+                    class="MuiBox-root MuiBox-root-83"
+                  >
+                    <h2
+                      class="MuiTypography-root makeStyles-stepTitle-39 MuiTypography-h2"
+                    >
                       Funding and Partnerships
                     </h2>
                     <h6
@@ -774,7 +840,7 @@ exports[`CreateProjectPage adds the extra create project steps if at least 1 per
             <div
               class="MuiStepContent-root MuiStepContent-last"
               disabled=""
-              icon="7"
+              icon="8"
             />
           </div>
         </div>

--- a/app/src/features/projects/components/ProjectDetailsForm.tsx
+++ b/app/src/features/projects/components/ProjectDetailsForm.tsx
@@ -89,7 +89,7 @@ const ProjectDetailsForm: React.FC<IProjectDetailsFormProps> = (props) => {
               error={touched.project_type && Boolean(errors.project_type)}
               displayEmpty
               inputProps={{ 'aria-label': 'Project Type' }}
-              input={<OutlinedInput notched label="Project Type" />}>
+              input={<OutlinedInput label="Project Type" />}>
               {props.project_type.map((item) => (
                 <MenuItem key={item.value} value={item.value}>
                   {item.label}

--- a/app/src/features/projects/components/ProjectDetailsForm.tsx
+++ b/app/src/features/projects/components/ProjectDetailsForm.tsx
@@ -1,12 +1,4 @@
-import {
-  FormControl,
-  FormHelperText,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField
-} from '@material-ui/core';
+import { FormControl, FormHelperText, Grid, InputLabel, MenuItem, Select, TextField } from '@material-ui/core';
 import MultiAutocompleteFieldVariableSize, {
   IMultiAutocompleteFieldOption
 } from 'components/fields/MultiAutocompleteFieldVariableSize';

--- a/app/src/features/projects/components/ProjectIUCNForm.test.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { Formik } from 'formik';
+import React from 'react';
+import { IMultiAutocompleteFieldOption } from 'components/fields/MultiAutocompleteFieldVariableSize';
+import ProjectIUCNForm, {
+  IProjectIUCNForm,
+  ProjectIUCNFormInitialValues,
+  ProjectIUCNFormYupSchema
+} from './ProjectIUCNForm';
+
+const classifications: IMultiAutocompleteFieldOption[] = [
+  {
+    value: 'class_1',
+    label: 'Class 1'
+  },
+  {
+    value: 'class_2',
+    label: 'Class 2'
+  }
+];
+
+const subClassifications: IMultiAutocompleteFieldOption[] = [
+  {
+    value: 'subclass_1',
+    label: 'Sub-class 1'
+  },
+  {
+    value: 'subclass_2',
+    label: 'Sub-class 2'
+  }
+];
+
+describe('ProjectIUCNForm', () => {
+  it('renders correctly with default empty values', () => {
+    const { asFragment } = render(
+      <Formik
+        initialValues={ProjectIUCNFormInitialValues}
+        validationSchema={ProjectIUCNFormYupSchema}
+        validateOnBlur={true}
+        validateOnChange={false}
+        onSubmit={async () => {}}>
+        {() => <ProjectIUCNForm classifications={classifications} subClassifications={subClassifications} />}
+      </Formik>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders correctly with existing details values', () => {
+    const existingFormValues: IProjectIUCNForm = {
+      classificationDetails: [
+        {
+          classification: 'class_1',
+          subClassification1: 'subclass_1',
+          subClassification2: 'subclass_2'
+        }
+      ]
+    };
+
+    const { asFragment } = render(
+      <Formik
+        initialValues={existingFormValues}
+        validationSchema={ProjectIUCNFormYupSchema}
+        validateOnBlur={true}
+        validateOnChange={false}
+        onSubmit={async () => {}}>
+        {() => <ProjectIUCNForm classifications={classifications} subClassifications={subClassifications} />}
+      </Formik>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/app/src/features/projects/components/ProjectIUCNForm.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.tsx
@@ -13,7 +13,7 @@ import Icon from '@mdi/react';
 import { mdiTrashCanOutline, mdiArrowRight } from '@mdi/js';
 import { FieldArray, useFormikContext } from 'formik';
 import { IMultiAutocompleteFieldOption } from 'components/fields/MultiAutocompleteFieldVariableSize';
-import React from 'react';
+import React, { Fragment } from 'react';
 import * as yup from 'yup';
 
 export interface IProjectIUCNFormArrayItem {
@@ -94,54 +94,37 @@ const ProjectIUCNForm: React.FC<IProjectIUCNFormProps> = (props: any) => {
                           <FormHelperText>{classificationMeta.error}</FormHelperText>
                         </FormControl>
                       </Box>
-                      <Box pt={2} pl={2} pr={2}>
-                        <Icon path={mdiArrowRight} size={1} />
-                      </Box>
-                      <Box flexBasis="35%">
-                        <FormControl variant="outlined" style={{ width: '100%' }}>
-                          <InputLabel id="sub-classification-1">Sub-classification</InputLabel>
-                          <Select
-                            id={`classificationDetails.[${index}].subClassification1`}
-                            name={`classificationDetails.[${index}].subClassification1`}
-                            labelId="subClassification1"
-                            label="Sub-classification"
-                            value={classificationDetail.subClassification1}
-                            onChange={handleChange}
-                            error={subClassification1Meta.touched && Boolean(subClassification1Meta.error)}
-                            inputProps={{ 'aria-label': 'Sub-classification-1' }}>
-                            {props.subClassifications.map((item: any) => (
-                              <MenuItem key={item.value} value={item.value}>
-                                {item.label}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                          <FormHelperText>{subClassification1Meta.error}</FormHelperText>
-                        </FormControl>
-                      </Box>
-                      <Box pt={2} pl={2} pr={2}>
-                        <Icon path={mdiArrowRight} size={1} />
-                      </Box>
-                      <Box flexBasis="35%">
-                        <FormControl variant="outlined" style={{ width: '100%' }}>
-                          <InputLabel id="classification">Sub-classification</InputLabel>
-                          <Select
-                            id={`classificationDetails.[${index}].subClassification2`}
-                            name={`classificationDetails.[${index}].subClassification2`}
-                            labelId="subClassification2"
-                            label="Sub-classification"
-                            value={classificationDetail.subClassification2}
-                            onChange={handleChange}
-                            error={subClassification2Meta.touched && Boolean(subClassification2Meta.error)}
-                            inputProps={{ 'aria-label': 'Sub-classification-2' }}>
-                            {props.subClassifications.map((item: any) => (
-                              <MenuItem key={item.value} value={item.value}>
-                                {item.label}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                          <FormHelperText>{subClassification2Meta.error}</FormHelperText>
-                        </FormControl>
-                      </Box>
+                      {['subClassification1', 'subClassification2'].map((subClassification: string, subClassIndex: number) => {
+                        const subClassificationMeta = subClassIndex === 0 ? subClassification1Meta : subClassification2Meta;
+                        return (
+                          <Fragment key={subClassIndex}>
+                            <Box pt={2} pl={2} pr={2}>
+                              <Icon path={mdiArrowRight} size={1} />
+                            </Box>
+                            <Box flexBasis="35%">
+                              <FormControl variant="outlined" style={{ width: '100%' }}>
+                                <InputLabel id={subClassification}>Sub-classification</InputLabel>
+                                <Select
+                                  id={`classificationDetails.[${index}].${subClassification}`}
+                                  name={`classificationDetails.[${index}].${subClassification}`}
+                                  labelId={subClassification}
+                                  label="Sub-classification"
+                                  value={classificationDetail[subClassification]}
+                                  onChange={handleChange}
+                                  error={subClassificationMeta.touched && Boolean(subClassificationMeta.error)}
+                                  inputProps={{ 'aria-label': subClassification }}>
+                                  {props.subClassifications.map((item: any) => (
+                                    <MenuItem key={item.value} value={item.value}>
+                                      {item.label}
+                                    </MenuItem>
+                                  ))}
+                                </Select>
+                                <FormHelperText>{subClassificationMeta.error}</FormHelperText>
+                              </FormControl>
+                            </Box>
+                          </Fragment>
+                        )
+                      })}
                       <Box pt={0.5} pl={1}>
                         <IconButton color="primary" aria-label="delete" onClick={() => arrayHelpers.remove(index)}>
                           <Icon path={mdiTrashCanOutline} size={1} />

--- a/app/src/features/projects/components/ProjectIUCNForm.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.tsx
@@ -96,6 +96,7 @@ const ProjectIUCNForm: React.FC<IProjectIUCNFormProps> = (props: any) => {
                       </Box>
                       {['subClassification1', 'subClassification2'].map((subClassification: string, subClassIndex: number) => {
                         const subClassificationMeta = subClassIndex === 0 ? subClassification1Meta : subClassification2Meta;
+
                         return (
                           <Fragment key={subClassIndex}>
                             <Box pt={2} pl={2} pr={2}>

--- a/app/src/features/projects/components/ProjectIUCNForm.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.tsx
@@ -1,0 +1,172 @@
+import {
+  FormControl,
+  FormHelperText,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Box,
+  IconButton,
+  Button
+} from '@material-ui/core';
+import Icon from '@mdi/react';
+import { mdiTrashCanOutline, mdiArrowRight } from '@mdi/js';
+import { FieldArray, useFormikContext } from 'formik';
+import { IMultiAutocompleteFieldOption } from 'components/fields/MultiAutocompleteFieldVariableSize';
+import React from 'react';
+import * as yup from 'yup';
+
+export interface IProjectIUCNFormArrayItem {
+  classification: string;
+  subClassification1: string;
+  subClassification2: string;
+}
+
+export interface IProjectIUCNForm {
+  classificationDetails: IProjectIUCNFormArrayItem[];
+}
+
+export const ProjectIUCNFormArrayItemInitialValues: IProjectIUCNFormArrayItem = {
+  classification: '',
+  subClassification1: '',
+  subClassification2: ''
+};
+
+export const ProjectIUCNFormInitialValues: IProjectIUCNForm = {
+  classificationDetails: [ProjectIUCNFormArrayItemInitialValues]
+};
+
+export const ProjectIUCNFormYupSchema = yup.object().shape({
+  classificationDetails: yup.array().of(
+    yup.object().shape({
+      classification: yup.string().required('You must specify a classification'),
+      subClassification1: yup.string().required('You must specify a sub-classification'),
+      subClassification2: yup.string().required('You must specify a sub-classification')
+    })
+  )
+});
+
+export interface IProjectIUCNFormProps {
+  classifications: IMultiAutocompleteFieldOption[];
+  subClassifications: IMultiAutocompleteFieldOption[];
+}
+
+/**
+ * Create project - IUCN classification section
+ *
+ * @return {*}
+ */
+const ProjectIUCNForm: React.FC<IProjectIUCNFormProps> = (props: any) => {
+  const { values, handleChange, handleSubmit, getFieldMeta } = useFormikContext<IProjectIUCNForm>();
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <FieldArray
+        name="classificationDetails"
+        render={(arrayHelpers: any) => (
+          <Box>
+            <Grid container direction="row" spacing={3}>
+              {values.classificationDetails.map((classificationDetail, index) => {
+                const classificationMeta = getFieldMeta(`classificationDetails.[${index}].classification`);
+                const subClassification1Meta = getFieldMeta(`classificationDetails.[${index}].subClassification1`);
+                const subClassification2Meta = getFieldMeta(`classificationDetails.[${index}].subClassification2`);
+                return (
+                  <Grid item xs={12} key={index}>
+                    <Box display="flex">
+                      <Box flexBasis="30%">
+                        <FormControl variant="outlined" style={{ width: '100%' }}>
+                          <InputLabel id="classification">Classification</InputLabel>
+                          <Select
+                            id={`classificationDetails.[${index}].classification`}
+                            name={`classificationDetails.[${index}].classification`}
+                            labelId="classification"
+                            label="Classification"
+                            value={classificationDetail.classification}
+                            onChange={handleChange}
+                            error={classificationMeta.touched && Boolean(classificationMeta.error)}
+                            inputProps={{ 'aria-label': 'Classification' }}>
+                            {props.classifications.map((item: any) => (
+                              <MenuItem key={item.value} value={item.value}>
+                                {item.label}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                          <FormHelperText>{classificationMeta.error}</FormHelperText>
+                        </FormControl>
+                      </Box>
+                      <Box pt={2} pl={2} pr={2}>
+                        <Icon path={mdiArrowRight} size={1} />
+                      </Box>
+                      <Box flexBasis="35%">
+                        <FormControl variant="outlined" style={{ width: '100%' }}>
+                          <InputLabel id="sub-classification-1">Sub-classification</InputLabel>
+                          <Select
+                            id={`classificationDetails.[${index}].subClassification1`}
+                            name={`classificationDetails.[${index}].subClassification1`}
+                            labelId="subClassification1"
+                            label="Sub-classification"
+                            value={classificationDetail.subClassification1}
+                            onChange={handleChange}
+                            error={subClassification1Meta.touched && Boolean(subClassification1Meta.error)}
+                            inputProps={{ 'aria-label': 'Sub-classification-1' }}>
+                            {props.subClassifications.map((item: any) => (
+                              <MenuItem key={item.value} value={item.value}>
+                                {item.label}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                          <FormHelperText>{subClassification1Meta.error}</FormHelperText>
+                        </FormControl>
+                      </Box>
+                      <Box pt={2} pl={2} pr={2}>
+                        <Icon path={mdiArrowRight} size={1} />
+                      </Box>
+                      <Box flexBasis="35%">
+                        <FormControl variant="outlined" style={{ width: '100%' }}>
+                          <InputLabel id="classification">Sub-classification</InputLabel>
+                          <Select
+                            id={`classificationDetails.[${index}].subClassification2`}
+                            name={`classificationDetails.[${index}].subClassification2`}
+                            labelId="subClassification2"
+                            label="Sub-classification"
+                            value={classificationDetail.subClassification2}
+                            onChange={handleChange}
+                            error={subClassification2Meta.touched && Boolean(subClassification2Meta.error)}
+                            inputProps={{ 'aria-label': 'Sub-classification-2' }}>
+                            {props.subClassifications.map((item: any) => (
+                              <MenuItem key={item.value} value={item.value}>
+                                {item.label}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                          <FormHelperText>{subClassification2Meta.error}</FormHelperText>
+                        </FormControl>
+                      </Box>
+                      <Box pt={0.5} pl={1}>
+                        <IconButton color="primary" aria-label="delete" onClick={() => arrayHelpers.remove(index)}>
+                          <Icon path={mdiTrashCanOutline} size={1} />
+                        </IconButton>
+                      </Box>
+                    </Box>
+                  </Grid>
+                );
+              })}
+            </Grid>
+            <Box pt={2}>
+              <Button
+                type="button"
+                variant="outlined"
+                color="primary"
+                aria-label="Add Another"
+                onClick={() => arrayHelpers.push(ProjectIUCNFormArrayItemInitialValues)}>
+                Add Another
+              </Button>
+            </Box>
+          </Box>
+        )}
+      />
+    </form>
+  );
+};
+
+export default ProjectIUCNForm;

--- a/app/src/features/projects/components/ProjectIUCNForm.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.tsx
@@ -95,38 +95,41 @@ const ProjectIUCNForm: React.FC<IProjectIUCNFormProps> = (props: any) => {
                           <FormHelperText>{classificationMeta.error}</FormHelperText>
                         </FormControl>
                       </Box>
-                      {['subClassification1', 'subClassification2'].map((subClassification: string, subClassIndex: number) => {
-                        const subClassificationMeta = subClassIndex === 0 ? subClassification1Meta : subClassification2Meta;
+                      {['subClassification1', 'subClassification2'].map(
+                        (subClassification: string, subClassIndex: number) => {
+                          const subClassificationMeta =
+                            subClassIndex === 0 ? subClassification1Meta : subClassification2Meta;
 
-                        return (
-                          <Fragment key={subClassIndex}>
-                            <Box pt={2} pl={2} pr={2}>
-                              <Icon path={mdiArrowRight} size={1} />
-                            </Box>
-                            <Box flexBasis="35%">
-                              <FormControl variant="outlined" style={{ width: '100%' }}>
-                                <InputLabel id={subClassification}>Sub-classification</InputLabel>
-                                <Select
-                                  id={`classificationDetails.[${index}].${subClassification}`}
-                                  name={`classificationDetails.[${index}].${subClassification}`}
-                                  labelId={subClassification}
-                                  label="Sub-classification"
-                                  value={classificationDetail[subClassification]}
-                                  onChange={handleChange}
-                                  error={subClassificationMeta.touched && Boolean(subClassificationMeta.error)}
-                                  inputProps={{ 'aria-label': subClassification }}>
-                                  {props.subClassifications.map((item: any) => (
-                                    <MenuItem key={item.value} value={item.value}>
-                                      {item.label}
-                                    </MenuItem>
-                                  ))}
-                                </Select>
-                                <FormHelperText>{subClassificationMeta.error}</FormHelperText>
-                              </FormControl>
-                            </Box>
-                          </Fragment>
-                        )
-                      })}
+                          return (
+                            <Fragment key={subClassIndex}>
+                              <Box pt={2} pl={2} pr={2}>
+                                <Icon path={mdiArrowRight} size={1} />
+                              </Box>
+                              <Box flexBasis="35%">
+                                <FormControl variant="outlined" style={{ width: '100%' }}>
+                                  <InputLabel id={subClassification}>Sub-classification</InputLabel>
+                                  <Select
+                                    id={`classificationDetails.[${index}].${subClassification}`}
+                                    name={`classificationDetails.[${index}].${subClassification}`}
+                                    labelId={subClassification}
+                                    label="Sub-classification"
+                                    value={classificationDetail[subClassification]}
+                                    onChange={handleChange}
+                                    error={subClassificationMeta.touched && Boolean(subClassificationMeta.error)}
+                                    inputProps={{ 'aria-label': subClassification }}>
+                                    {props.subClassifications.map((item: any) => (
+                                      <MenuItem key={item.value} value={item.value}>
+                                        {item.label}
+                                      </MenuItem>
+                                    ))}
+                                  </Select>
+                                  <FormHelperText>{subClassificationMeta.error}</FormHelperText>
+                                </FormControl>
+                              </Box>
+                            </Fragment>
+                          );
+                        }
+                      )}
                       <Box pt={0.5} pl={1}>
                         <IconButton color="primary" aria-label="delete" onClick={() => arrayHelpers.remove(index)}>
                           <Icon path={mdiTrashCanOutline} size={1} />

--- a/app/src/features/projects/components/ProjectIUCNForm.tsx
+++ b/app/src/features/projects/components/ProjectIUCNForm.tsx
@@ -70,6 +70,7 @@ const ProjectIUCNForm: React.FC<IProjectIUCNFormProps> = (props: any) => {
                 const classificationMeta = getFieldMeta(`classificationDetails.[${index}].classification`);
                 const subClassification1Meta = getFieldMeta(`classificationDetails.[${index}].subClassification1`);
                 const subClassification2Meta = getFieldMeta(`classificationDetails.[${index}].subClassification2`);
+
                 return (
                   <Grid item xs={12} key={index}>
                     <Box display="flex">

--- a/app/src/features/projects/components/__snapshots__/ProjectDetailsForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectDetailsForm.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`ProjectDetailsForm renders correctly with default empty values 1`] = `
               class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                class="PrivateNotchedOutline-legendLabelled-3"
               >
                 <span>
                   Project Type

--- a/app/src/features/projects/components/__snapshots__/ProjectFundingItemForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectFundingItemForm.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`ProjectFundingItemForm renders correctly with default empty values 1`] 
                       class="PrivateNotchedOutline-root-2 MuiOutlinedInput-notchedOutline"
                     >
                       <legend
-                        class="PrivateNotchedOutline-legendLabelled-4 PrivateNotchedOutline-legendNotched-5"
+                        class="PrivateNotchedOutline-legendLabelled-4"
                       >
                         <span>
                           Agency Name

--- a/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
@@ -109,16 +109,16 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                   Sub-classification
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                  class="MuiInputBase-root MuiOutlinedInput-root Mui-disabled Mui-disabled MuiInputBase-formControl"
                 >
                   <div
+                    aria-disabled="true"
                     aria-haspopup="listbox"
                     aria-label="subClassification1"
                     aria-labelledby="subClassification1 classificationDetails.[0].subClassification1"
-                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input Mui-disabled Mui-disabled Mui-disabled"
                     id="classificationDetails.[0].subClassification1"
                     role="button"
-                    tabindex="0"
                   >
                     <span>
                       ​
@@ -133,7 +133,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined Mui-disabled"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -188,16 +188,16 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                   Sub-classification
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                  class="MuiInputBase-root MuiOutlinedInput-root Mui-disabled Mui-disabled MuiInputBase-formControl"
                 >
                   <div
+                    aria-disabled="true"
                     aria-haspopup="listbox"
                     aria-label="subClassification2"
                     aria-labelledby="subClassification2 classificationDetails.[0].subClassification2"
-                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input Mui-disabled Mui-disabled Mui-disabled"
                     id="classificationDetails.[0].subClassification2"
                     role="button"
-                    tabindex="0"
                   >
                     <span>
                       ​
@@ -212,7 +212,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined Mui-disabled"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >

--- a/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
                   data-shrink="false"
-                  id="sub-classification-1"
+                  id="subClassification1"
                 >
                   Sub-classification
                 </label>
@@ -113,7 +113,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                 >
                   <div
                     aria-haspopup="listbox"
-                    aria-label="Sub-classification-1"
+                    aria-label="subClassification1"
                     aria-labelledby="subClassification1 classificationDetails.[0].subClassification1"
                     class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
                     id="classificationDetails.[0].subClassification1"
@@ -183,7 +183,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
                   data-shrink="false"
-                  id="classification"
+                  id="subClassification2"
                 >
                   Sub-classification
                 </label>
@@ -192,7 +192,7 @@ exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
                 >
                   <div
                     aria-haspopup="listbox"
-                    aria-label="Sub-classification-2"
+                    aria-label="subClassification2"
                     aria-labelledby="subClassification2 classificationDetails.[0].subClassification2"
                     class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
                     id="classificationDetails.[0].subClassification2"
@@ -395,7 +395,7 @@ exports[`ProjectIUCNForm renders correctly with existing details values 1`] = `
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
                   data-shrink="true"
-                  id="sub-classification-1"
+                  id="subClassification1"
                 >
                   Sub-classification
                 </label>
@@ -404,7 +404,7 @@ exports[`ProjectIUCNForm renders correctly with existing details values 1`] = `
                 >
                   <div
                     aria-haspopup="listbox"
-                    aria-label="Sub-classification-1"
+                    aria-label="subClassification1"
                     aria-labelledby="subClassification1 classificationDetails.[0].subClassification1"
                     class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
                     id="classificationDetails.[0].subClassification1"
@@ -472,7 +472,7 @@ exports[`ProjectIUCNForm renders correctly with existing details values 1`] = `
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
                   data-shrink="true"
-                  id="classification"
+                  id="subClassification2"
                 >
                   Sub-classification
                 </label>
@@ -481,7 +481,7 @@ exports[`ProjectIUCNForm renders correctly with existing details values 1`] = `
                 >
                   <div
                     aria-haspopup="listbox"
-                    aria-label="Sub-classification-2"
+                    aria-label="subClassification2"
                     aria-labelledby="subClassification2 classificationDetails.[0].subClassification2"
                     class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
                     id="classificationDetails.[0].subClassification2"

--- a/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
+++ b/app/src/features/projects/components/__snapshots__/ProjectIUCNForm.test.tsx.snap
@@ -1,0 +1,581 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectIUCNForm renders correctly with default empty values 1`] = `
+<DocumentFragment>
+  <form>
+    <div
+      class="MuiBox-root MuiBox-root-1"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        >
+          <div
+            class="MuiBox-root MuiBox-root-2"
+          >
+            <div
+              class="MuiBox-root MuiBox-root-3"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                  data-shrink="false"
+                  id="classification"
+                >
+                  Classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Classification"
+                    aria-labelledby="classification classificationDetails.[0].classification"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].classification"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].classification"
+                    tabindex="-1"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-6"
+                    >
+                      <span>
+                        Classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-8"
+            >
+              <svg
+                role="presentation"
+                style="width: 1.5rem; height: 1.5rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+                  style="fill: currentColor;"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-9"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                  data-shrink="false"
+                  id="sub-classification-1"
+                >
+                  Sub-classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Sub-classification-1"
+                    aria-labelledby="subClassification1 classificationDetails.[0].subClassification1"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].subClassification1"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].subClassification1"
+                    tabindex="-1"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-6"
+                    >
+                      <span>
+                        Sub-classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-10"
+            >
+              <svg
+                role="presentation"
+                style="width: 1.5rem; height: 1.5rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+                  style="fill: currentColor;"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-11"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                  data-shrink="false"
+                  id="classification"
+                >
+                  Sub-classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Sub-classification-2"
+                    aria-labelledby="subClassification2 classificationDetails.[0].subClassification2"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].subClassification2"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].subClassification2"
+                    tabindex="-1"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-4 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-6"
+                    >
+                      <span>
+                        Sub-classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-12"
+            >
+              <button
+                aria-label="delete"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    role="presentation"
+                    style="width: 1.5rem; height: 1.5rem;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z"
+                      style="fill: currentColor;"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-13"
+      >
+        <button
+          aria-label="Add Another"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Add Another
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`ProjectIUCNForm renders correctly with existing details values 1`] = `
+<DocumentFragment>
+  <form>
+    <div
+      class="MuiBox-root MuiBox-root-14"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        >
+          <div
+            class="MuiBox-root MuiBox-root-15"
+          >
+            <div
+              class="MuiBox-root MuiBox-root-16"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                  data-shrink="true"
+                  id="classification"
+                >
+                  Classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Classification"
+                    aria-labelledby="classification classificationDetails.[0].classification"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].classification"
+                    role="button"
+                    tabindex="0"
+                  >
+                    Class 1
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].classification"
+                    tabindex="-1"
+                    value="class_1"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-17 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-19 PrivateNotchedOutline-legendNotched-20"
+                    >
+                      <span>
+                        Classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-21"
+            >
+              <svg
+                role="presentation"
+                style="width: 1.5rem; height: 1.5rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+                  style="fill: currentColor;"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-22"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                  data-shrink="true"
+                  id="sub-classification-1"
+                >
+                  Sub-classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Sub-classification-1"
+                    aria-labelledby="subClassification1 classificationDetails.[0].subClassification1"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].subClassification1"
+                    role="button"
+                    tabindex="0"
+                  >
+                    Sub-class 1
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].subClassification1"
+                    tabindex="-1"
+                    value="subclass_1"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-17 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-19 PrivateNotchedOutline-legendNotched-20"
+                    >
+                      <span>
+                        Sub-classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-23"
+            >
+              <svg
+                role="presentation"
+                style="width: 1.5rem; height: 1.5rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+                  style="fill: currentColor;"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-24"
+            >
+              <div
+                class="MuiFormControl-root"
+                style="width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                  data-shrink="true"
+                  id="classification"
+                >
+                  Sub-classification
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="Sub-classification-2"
+                    aria-labelledby="subClassification2 classificationDetails.[0].subClassification2"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="classificationDetails.[0].subClassification2"
+                    role="button"
+                    tabindex="0"
+                  >
+                    Sub-class 2
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    name="classificationDetails.[0].subClassification2"
+                    tabindex="-1"
+                    value="subclass_2"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-17 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-19 PrivateNotchedOutline-legendNotched-20"
+                    >
+                      <span>
+                        Sub-classification
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled"
+                />
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-25"
+            >
+              <button
+                aria-label="delete"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    role="presentation"
+                    style="width: 1.5rem; height: 1.5rem;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z"
+                      style="fill: currentColor;"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-26"
+      >
+        <button
+          aria-label="Add Another"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Add Another
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </form>
+</DocumentFragment>
+`;


### PR DESCRIPTION
# Overview

## Links to jira tickets

- https://quartech.atlassian.net/browse/BHBC-868

## This PR contains the following changes

- Frontend UI changes to enable capturing IUCN Classifications and sub-classifications as a step in the create project workflow

## This PR contains the following types of changes

- [x] New feature (change which adds functionality)

### General

- [x] I have performed a self-review of my own code

## How Has This Been Tested?

- Locally

## Screenshots

<img width="649" alt="lets go" src="https://user-images.githubusercontent.com/28017034/110699267-853dbc00-81a3-11eb-8715-7055393c96ab.png">