### PR TITLE
Fix word break issue in project coordinator section (view page)

### DIFF
--- a/app/src/features/projects/view/__snapshots__/ProjectDetails.test.tsx.snap
+++ b/app/src/features/projects/view/__snapshots__/ProjectDetails.test.tsx.snap
@@ -635,6 +635,7 @@ exports[`ProjectDetails renders correctly 1`] = `
               >
                 <h6
                   class="MuiTypography-root MuiTypography-subtitle1"
+                  style="word-break: break-all;"
                 >
                   Amanda Christensen
                 </h6>
@@ -657,6 +658,7 @@ exports[`ProjectDetails renders correctly 1`] = `
               >
                 <h6
                   class="MuiTypography-root MuiTypography-subtitle1"
+                  style="word-break: break-all;"
                 >
                   amanda@christensen.com
                 </h6>
@@ -679,6 +681,7 @@ exports[`ProjectDetails renders correctly 1`] = `
               >
                 <h6
                   class="MuiTypography-root MuiTypography-subtitle1"
+                  style="word-break: break-all;"
                 >
                   Amanda and associates
                 </h6>

--- a/app/src/features/projects/view/components/ProjectCoordinator.tsx
+++ b/app/src/features/projects/view/components/ProjectCoordinator.tsx
@@ -37,7 +37,7 @@ const ProjectCoordinator: React.FC<IProjectDetailsProps> = (props) => {
               <Typography variant="caption">Name</Typography>
             </Box>
             <Box>
-              <Typography variant="subtitle1">
+              <Typography style={{ wordBreak: 'break-all' }} variant="subtitle1">
                 {coordinator.first_name} {coordinator.last_name}
               </Typography>
             </Box>
@@ -47,7 +47,9 @@ const ProjectCoordinator: React.FC<IProjectDetailsProps> = (props) => {
               <Typography variant="caption">Email Address</Typography>
             </Box>
             <Box>
-              <Typography variant="subtitle1">{coordinator.email_address}</Typography>
+              <Typography style={{ wordBreak: 'break-all' }} variant="subtitle1">
+                {coordinator.email_address}
+              </Typography>
             </Box>
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
@@ -55,7 +57,9 @@ const ProjectCoordinator: React.FC<IProjectDetailsProps> = (props) => {
               <Typography variant="caption">Agency</Typography>
             </Box>
             <Box>
-              <Typography variant="subtitle1">{coordinator.coordinator_agency}</Typography>
+              <Typography style={{ wordBreak: 'break-all' }} variant="subtitle1">
+                {coordinator.coordinator_agency}
+              </Typography>
             </Box>
           </Grid>
         </Grid>

--- a/app/src/features/projects/view/components/__snapshots__/ProjectCoordinator.test.tsx.snap
+++ b/app/src/features/projects/view/components/__snapshots__/ProjectCoordinator.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`ProjectCoordinator renders correctly 1`] = `
         >
           <h6
             class="MuiTypography-root MuiTypography-subtitle1"
+            style="word-break: break-all;"
           >
             Amanda Christensen
           </h6>
@@ -94,6 +95,7 @@ exports[`ProjectCoordinator renders correctly 1`] = `
         >
           <h6
             class="MuiTypography-root MuiTypography-subtitle1"
+            style="word-break: break-all;"
           >
             amanda@christensen.com
           </h6>
@@ -116,6 +118,7 @@ exports[`ProjectCoordinator renders correctly 1`] = `
         >
           <h6
             class="MuiTypography-root MuiTypography-subtitle1"
+            style="word-break: break-all;"
           >
             Amanda and associates
           </h6>


### PR DESCRIPTION
# Overview

Fix word break issue in project coordinator section (view page)

## Before
<img width="674" alt="before" src="https://user-images.githubusercontent.com/28017034/111506263-b1f35580-8706-11eb-8009-fcfe10395dd0.png">

## After
<img width="677" alt="after" src="https://user-images.githubusercontent.com/28017034/111506272-b4ee4600-8706-11eb-85e7-671e2a155ebd.png">
