### PR TITLE
Editing pop-ups allow users to click out of it without saving changes

### DIFF
--- a/app/src/components/dialog/EditDialog.test.tsx
+++ b/app/src/components/dialog/EditDialog.test.tsx
@@ -41,7 +41,6 @@ const SampleFormikForm = () => {
 
 const handleOnSave = jest.fn();
 const handleOnCancel = jest.fn();
-const handleOnClose = jest.fn();
 
 const renderContainer = ({
   testFieldValue,
@@ -63,7 +62,6 @@ const renderContainer = ({
           initialValues: { testField: testFieldValue },
           validationSchema: SampleFormikFormYupSchema
         }}
-        onClose={handleOnClose}
         onCancel={handleOnCancel}
         onSave={handleOnSave}
       />

--- a/app/src/components/dialog/EditDialog.tsx
+++ b/app/src/components/dialog/EditDialog.tsx
@@ -38,12 +38,6 @@ export interface IEditDialogProps {
   dialogError?: string;
 
   /**
-   * Callback fired if the dialog is closed.
-   *
-   * @memberof IEditDialogProps
-   */
-  onClose: () => void;
-  /**
    * Callback fired if the 'No' button is clicked.
    *
    * @memberof IEditDialogProps
@@ -89,7 +83,6 @@ export const EditDialog: React.FC<IEditDialogProps> = (props) => {
             fullScreen={fullScreen}
             maxWidth="xl"
             open={props.open}
-            onClose={props.onClose}
             aria-labelledby="edit-dialog-title"
             aria-describedby="edit-dialog-description">
             <DialogTitle id="edit-dialog-title">{props.dialogTitle}</DialogTitle>

--- a/app/src/features/projects/view/components/GeneralInformation.test.tsx
+++ b/app/src/features/projects/view/components/GeneralInformation.test.tsx
@@ -69,7 +69,7 @@ describe('ProjectDetails', () => {
       }
     });
 
-    const { getByText, queryByText, getAllByRole } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('General Information')).toBeVisible();
@@ -88,20 +88,6 @@ describe('ProjectDetails', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit General Information')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit General Information')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit General Information')).not.toBeInTheDocument();

--- a/app/src/features/projects/view/components/GeneralInformation.tsx
+++ b/app/src/features/projects/view/components/GeneralInformation.tsx
@@ -132,7 +132,6 @@ const GeneralInformation: React.FC<IProjectDetailsProps> = (props) => {
           initialValues: detailsFormData,
           validationSchema: ProjectDetailsFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/IUCNClassification.test.tsx
+++ b/app/src/features/projects/view/components/IUCNClassification.test.tsx
@@ -73,7 +73,7 @@ describe('IUCNClassification', () => {
       }
     });
 
-    const { getByText, getAllByRole, queryByText } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('IUCN Classification')).toBeVisible();
@@ -92,20 +92,6 @@ describe('IUCNClassification', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit IUCN Classification')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit IUCN Classification')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit IUCN Classification')).not.toBeInTheDocument();
@@ -164,7 +150,7 @@ describe('IUCNClassification', () => {
   it('shows error dialog with API error message when getting IUCN data for update fails', async () => {
     mockBiohubApi().project.getProjectForUpdate = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText, getAllByRole } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('IUCN Classification')).toBeVisible();
@@ -176,9 +162,7 @@ describe('IUCNClassification', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();
@@ -199,7 +183,7 @@ describe('IUCNClassification', () => {
     });
     mockBiohubApi().project.updateProject = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText } = renderContainer();
+    const { getByText, queryByText, getAllByRole } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('IUCN Classification')).toBeVisible();
@@ -223,7 +207,9 @@ describe('IUCNClassification', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Ok'));
+    // Get the backdrop, then get the firstChild because this is where the event listener is attached
+    //@ts-ignore
+    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();

--- a/app/src/features/projects/view/components/IUCNClassification.tsx
+++ b/app/src/features/projects/view/components/IUCNClassification.tsx
@@ -138,7 +138,6 @@ const IUCNClassification: React.FC<IIUCNClassificationProps> = (props) => {
             : { classificationDetails: [ProjectIUCNFormArrayItemInitialValues] },
           validationSchema: ProjectIUCNFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/LocationBoundary.test.tsx
+++ b/app/src/features/projects/view/components/LocationBoundary.test.tsx
@@ -200,7 +200,7 @@ describe('LocationBoundary', () => {
       }
     });
 
-    const { getByText, queryByText, getAllByRole } = render(
+    const { getByText, queryByText } = render(
       <LocationBoundary projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -221,20 +221,6 @@ describe('LocationBoundary', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit Location / Project Boundary')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit Location / Project Boundary')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit Location / Project Boundary')).not.toBeInTheDocument();
@@ -292,7 +278,7 @@ describe('LocationBoundary', () => {
   it('shows error dialog with API error message when getting location data for update fails', async () => {
     mockBiohubApi().project.getProjectForUpdate = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText, getAllByRole } = render(
+    const { getByText, queryByText } = render(
       <LocationBoundary projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -306,9 +292,7 @@ describe('LocationBoundary', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();
@@ -326,7 +310,7 @@ describe('LocationBoundary', () => {
     });
     mockBiohubApi().project.updateProject = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText, getAllByRole } = render(
       <LocationBoundary projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -352,7 +336,9 @@ describe('LocationBoundary', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Ok'));
+    // Get the backdrop, then get the firstChild because this is where the event listener is attached
+    //@ts-ignore
+    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();

--- a/app/src/features/projects/view/components/LocationBoundary.tsx
+++ b/app/src/features/projects/view/components/LocationBoundary.tsx
@@ -180,7 +180,6 @@ const LocationBoundary: React.FC<ILocationBoundaryProps> = (props) => {
           initialValues: locationFormData,
           validationSchema: ProjectLocationFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/Partnerships.test.tsx
+++ b/app/src/features/projects/view/components/Partnerships.test.tsx
@@ -83,7 +83,7 @@ describe('Partnerships', () => {
       }
     });
 
-    const { getByText, getAllByRole, queryByText } = render(
+    const { getByText, queryByText } = render(
       <Partnerships projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -104,20 +104,6 @@ describe('Partnerships', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit Partnerships')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit Partnerships')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit Partnerships')).not.toBeInTheDocument();

--- a/app/src/features/projects/view/components/Partnerships.tsx
+++ b/app/src/features/projects/view/components/Partnerships.tsx
@@ -128,7 +128,6 @@ const Partnerships: React.FC<IPartnershipsProps> = (props) => {
           initialValues: partnershipsForUpdate,
           validationSchema: ProjectPartnershipsFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/ProjectCoordinator.test.tsx
+++ b/app/src/features/projects/view/components/ProjectCoordinator.test.tsx
@@ -55,7 +55,7 @@ describe('ProjectCoordinator', () => {
       }
     });
 
-    const { getByText, getAllByRole, queryByText } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Coordinator')).toBeVisible();
@@ -74,20 +74,6 @@ describe('ProjectCoordinator', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit Project Coordinator')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit Project Coordinator')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit Project Coordinator')).not.toBeInTheDocument();
@@ -145,7 +131,7 @@ describe('ProjectCoordinator', () => {
   it('shows error dialog with API error message when getting coordinator data for update fails', async () => {
     mockBiohubApi().project.getProjectForUpdate = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText, getAllByRole } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Coordinator')).toBeVisible();
@@ -157,9 +143,7 @@ describe('ProjectCoordinator', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();
@@ -179,7 +163,7 @@ describe('ProjectCoordinator', () => {
     });
     mockBiohubApi().project.updateProject = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText } = renderContainer();
+    const { getByText, queryByText, getAllByRole } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Coordinator')).toBeVisible();
@@ -203,7 +187,9 @@ describe('ProjectCoordinator', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Ok'));
+    // Get the backdrop, then get the firstChild because this is where the event listener is attached
+    //@ts-ignore
+    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();

--- a/app/src/features/projects/view/components/ProjectCoordinator.tsx
+++ b/app/src/features/projects/view/components/ProjectCoordinator.tsx
@@ -121,7 +121,6 @@ const ProjectCoordinator: React.FC<IProjectCoordinatorProps> = (props) => {
           initialValues: coordinatorFormData,
           validationSchema: ProjectCoordinatorYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/ProjectObjectives.test.tsx
+++ b/app/src/features/projects/view/components/ProjectObjectives.test.tsx
@@ -162,7 +162,7 @@ describe('ProjectObjectives', () => {
       }
     });
 
-    const { getByText, getAllByRole, queryByText } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Objectives')).toBeVisible();
@@ -181,20 +181,6 @@ describe('ProjectObjectives', () => {
     });
 
     fireEvent.click(getByText('Cancel'));
-
-    await waitFor(() => {
-      expect(queryByText('Edit Project Objectives')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit Project Objectives')).toBeVisible();
-    });
-
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('Edit Project Objectives')).not.toBeInTheDocument();
@@ -226,7 +212,7 @@ describe('ProjectObjectives', () => {
       objectives: undefined
     });
 
-    const { getByText, getAllByRole, queryByText } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Objectives')).toBeVisible();
@@ -238,9 +224,7 @@ describe('ProjectObjectives', () => {
       expect(getByText('Error Editing Project Objectives')).toBeVisible();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('Error Editing Project Objectives')).not.toBeInTheDocument();
@@ -250,7 +234,7 @@ describe('ProjectObjectives', () => {
   it('shows error dialog with API error message when getting objectives data for update fails', async () => {
     mockBiohubApi().project.getProjectForUpdate = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText, getAllByRole } = renderContainer();
+    const { getByText, queryByText } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Objectives')).toBeVisible();
@@ -262,9 +246,7 @@ describe('ProjectObjectives', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();
@@ -281,7 +263,7 @@ describe('ProjectObjectives', () => {
     });
     mockBiohubApi().project.updateProject = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText } = renderContainer();
+    const { getByText, queryByText, getAllByRole } = renderContainer();
 
     await waitFor(() => {
       expect(getByText('Project Objectives')).toBeVisible();
@@ -305,7 +287,9 @@ describe('ProjectObjectives', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Ok'));
+    // Get the backdrop, then get the firstChild because this is where the event listener is attached
+    //@ts-ignore
+    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();

--- a/app/src/features/projects/view/components/ProjectObjectives.tsx
+++ b/app/src/features/projects/view/components/ProjectObjectives.tsx
@@ -120,7 +120,6 @@ const ProjectObjectives: React.FC<IProjectObjectivesProps> = (props) => {
           initialValues: objectivesFormData,
           validationSchema: ProjectObjectivesFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />

--- a/app/src/features/projects/view/components/Species.test.tsx
+++ b/app/src/features/projects/view/components/Species.test.tsx
@@ -77,7 +77,7 @@ describe('Species', () => {
       }
     });
 
-    const { getByText, getAllByRole, queryByText } = render(
+    const { getByText, queryByText } = render(
       <Species projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -109,20 +109,6 @@ describe('Species', () => {
       expect(getByText('Edit Species')).toBeVisible();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
-
-    await waitFor(() => {
-      expect(queryByText('Edit Species')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText('EDIT'));
-
-    await waitFor(() => {
-      expect(getByText('Edit Species')).toBeVisible();
-    });
-
     fireEvent.click(getByText('Save Changes'));
 
     await waitFor(() => {
@@ -143,7 +129,7 @@ describe('Species', () => {
       species: null
     });
 
-    const { getByText, getAllByRole, queryByText } = render(
+    const { getByText, queryByText } = render(
       <Species projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -157,9 +143,7 @@ describe('Species', () => {
       expect(getByText('Error Editing Species')).toBeVisible();
     });
 
-    // Get the backdrop, then get the firstChild because this is where the event listener is attached
-    //@ts-ignore
-    fireEvent.click(getAllByRole('presentation')[0].firstChild);
+    fireEvent.click(getByText('Ok'));
 
     await waitFor(() => {
       expect(queryByText('Error Editing Species')).not.toBeInTheDocument();
@@ -199,7 +183,7 @@ describe('Species', () => {
     });
     mockBiohubApi().project.updateProject = jest.fn(() => Promise.reject(new Error('API Error is Here')));
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText, getAllByRole } = render(
       <Species projectForViewData={getProjectForViewResponse} codes={codes} refresh={mockRefresh} />
     );
 
@@ -225,7 +209,9 @@ describe('Species', () => {
       expect(queryByText('API Error is Here')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Ok'));
+    // Get the backdrop, then get the firstChild because this is where the event listener is attached
+    //@ts-ignore
+    fireEvent.click(getAllByRole('presentation')[0].firstChild);
 
     await waitFor(() => {
       expect(queryByText('API Error is Here')).toBeNull();

--- a/app/src/features/projects/view/components/Species.tsx
+++ b/app/src/features/projects/view/components/Species.tsx
@@ -127,7 +127,6 @@ const Species: React.FC<ISpeciesProps> = (props) => {
           initialValues: speciesForUpdate,
           validationSchema: ProjectSpeciesFormYupSchema
         }}
-        onClose={() => setOpenEditDialog(false)}
         onCancel={() => setOpenEditDialog(false)}
         onSave={handleDialogEditSave}
       />


### PR DESCRIPTION
# Overview

## This PR contains the following changes

- Editing pop-ups allow users to click out of it without saving changes
- Don't allow handleClose callback on editdialog (only way to close editdialog will be to click cancel)
- https://quartech.atlassian.net/browse/BHBC-957

## This PR contains the following types of changes

- [x] Bug fix (change which fixes an issue)

## How Has This Been Tested?

- Local and unit tests