### PR TITLE
File size in the attachment table should only have 1 decimal #

### DIFF
--- a/app/src/components/attachments/AttachmentsList.test.tsx
+++ b/app/src/components/attachments/AttachmentsList.test.tsx
@@ -30,6 +30,18 @@ describe('AttachmentsList', () => {
       fileName: 'filename.test',
       lastModified: '2021-04-09 11:53:53',
       size: 3028
+    },
+    {
+      id: 20,
+      fileName: 'filename20.test',
+      lastModified: '2021-04-09 11:53:53',
+      size: 30280000
+    },
+    {
+      id: 30,
+      fileName: 'filename30.test',
+      lastModified: '2021-04-09 11:53:53',
+      size: 30280000000
     }
   ];
 
@@ -39,12 +51,14 @@ describe('AttachmentsList', () => {
     expect(getByText('No Attachments')).toBeInTheDocument();
   });
 
-  it('renders correctly with attachments', async () => {
+  it('renders correctly with attachments (of various sizes)', async () => {
     const { getByText } = render(
       <AttachmentsList projectId={1} attachmentsList={attachmentsList} getAttachments={jest.fn()} />
     );
 
     expect(getByText('filename.test')).toBeInTheDocument();
+    expect(getByText('filename20.test')).toBeInTheDocument();
+    expect(getByText('filename30.test')).toBeInTheDocument();
   });
 
   it('viewing file contents in new tab works as expected', async () => {

--- a/app/src/components/attachments/AttachmentsList.tsx
+++ b/app/src/components/attachments/AttachmentsList.tsx
@@ -84,6 +84,21 @@ const AttachmentsList: React.FC<IAttachmentsListProps> = (props) => {
     }
   };
 
+  const getFormattedFileSize = (fileSize: number) => {
+    // kilobyte size
+    if (fileSize < 1000000) {
+      return `${(fileSize / 1000).toFixed(1)} KB`;
+    }
+
+    // megabyte size
+    if (fileSize < 1000000000) {
+      return `${(fileSize / 1000000).toFixed(1)} MB`;
+    }
+
+    // gigabyte size
+    return `${(fileSize / 1000000000).toFixed(1)} GB`;
+  };
+
   return (
     <>
       <YesNoDialog
@@ -118,7 +133,7 @@ const AttachmentsList: React.FC<IAttachmentsListProps> = (props) => {
                       </Link>
                     </TableCell>
                     <TableCell>{getFormattedDate(DATE_FORMAT.ShortDateFormatMonthFirst, row.lastModified)}</TableCell>
-                    <TableCell>{row.size / 1000000} MB</TableCell>
+                    <TableCell>{getFormattedFileSize(row.size)}</TableCell>
                     <TableCell align="right" className={clsx(index === 0 && classes.tableCellBorderTop)}>
                       <IconButton
                         color="primary"


### PR DESCRIPTION
# Overview

## Links to jira tickets

- https://quartech.atlassian.net/browse/BHBC-979

## This PR contains the following changes

- File size in the attachment table should only have 1 decimal #

## This PR contains the following types of changes

- [x] Enhancement (improvements to existing functionality)
- [x] Bug fix (change which fixes an issue)

## How Has This Been Tested?

- Locally with various file sizes
