### PR TITLE
Drawing a circlemarker or marker to create the project boundary creates an error on the map display

### DIFF
--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -119,6 +119,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
       id={mapId}
       center={[55, -128]}
       zoom={zoom || 5}
+      maxZoom={17}
       scrollWheelZoom={scrollWheelZoom || false}>
       <MapBounds bounds={bounds} />
 

--- a/app/src/features/projects/view/__snapshots__/ProjectDetails.test.tsx.snap
+++ b/app/src/features/projects/view/__snapshots__/ProjectDetails.test.tsx.snap
@@ -520,8 +520,8 @@ exports[`ProjectDetails renders correctly 1`] = `
                       alt=""
                       class="leaflet-tile"
                       role="presentation"
-                      src="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/18/123679/222531"
-                      style="width: 256px; height: 256px; left: -33px; top: -4px;"
+                      src="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/17/61839/111265"
+                      style="width: 256px; height: 256px; left: -144px; top: -130px;"
                     />
                   </div>
                 </div>
@@ -546,7 +546,7 @@ exports[`ProjectDetails renders correctly 1`] = `
                   alt=""
                   class="leaflet-marker-icon leaflet-zoom-hide leaflet-interactive"
                   src="marker-icon.png"
-                  style="margin-left: -12px; margin-top: -41px; width: 25px; height: 41px; z-index: 0; left: 0px; top: 0px; z-index: 0; z-index: 0;"
+                  style="margin-left: -12px; margin-top: -41px; width: 25px; height: 41px; left: 0px; top: 0px; z-index: 0;"
                   tabindex="0"
                 />
               </div>

--- a/app/src/utils/mapBoundaryUploadHelpers.ts
+++ b/app/src/utils/mapBoundaryUploadHelpers.ts
@@ -170,9 +170,14 @@ export const generateValidGeometryCollection = (geometry: any, id?: string) => {
     type: 'FeatureCollection',
     features: geometryCollection
   };
-  const bboxCoords = bbox(allGeosFeatureCollection);
 
-  bounds.push([bboxCoords[1], bboxCoords[0]], [bboxCoords[3], bboxCoords[2]]);
+  if (geometry[0]?.type !== 'Point') {
+    const bboxCoords = bbox(allGeosFeatureCollection);
 
-  return { geometryCollection, bounds };
+    bounds.push([bboxCoords[1], bboxCoords[0]], [bboxCoords[3], bboxCoords[2]]);
+
+    return { geometryCollection, bounds };
+  }
+
+  return { geometryCollection };
 };


### PR DESCRIPTION
# Overview

## Links to jira tickets

- https://quartech.atlassian.net/browse/BHBC-1200

## This PR contains the following changes

- Drawing a circlemarker or marker to create the project boundary creates an error on the map display

## This PR contains the following types of changes

- [x] Enhancement (improvements to existing functionality)
- [x] Bug fix (change which fixes an issue)

## How Has This Been Tested?

- Locally