### PR TITLE
fix sonarcloud bugs

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/update.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/update.ts
@@ -412,15 +412,15 @@ export const updateSurveyDetailsData = async (
 
   const promises: Promise<any>[] = [];
 
-  putDetailsData.focal_species.map((focalSpeciesId: number) =>
+  putDetailsData.focal_species.forEach((focalSpeciesId: number) =>
     promises.push(insertFocalSpecies(focalSpeciesId, surveyId, connection))
   );
 
-  putDetailsData.ancillary_species.map((ancillarySpeciesId: number) =>
+  putDetailsData.ancillary_species.forEach((ancillarySpeciesId: number) =>
     promises.push(insertAncillarySpecies(ancillarySpeciesId, surveyId, connection))
   );
 
-  putDetailsData.funding_sources.map((fsId: number) =>
+  putDetailsData.funding_sources.forEach((fsId: number) =>
     promises.push(insertSurveyFundingSource(fsId, surveyId, connection))
   );
 


### PR DESCRIPTION
# Overview

Consider using "forEach" instead of "map" as its return value is not being used here.

When the call to a function doesn’t have any side effects, what is the point of making the call if the results are ignored? In such case, either the function call is useless and should be dropped or the source code doesn’t behave as expected.

To prevent generating any false-positives, this rule triggers an issues only on a predefined list of known objects & functions.