### PR TITLE
Fix issue where making an attachment private makes all other attachments private too

### DIFF
--- a/api/src/paths/project/{projectId}/attachments/{attachmentId}/toggleVisibility.ts
+++ b/api/src/paths/project/{projectId}/attachments/{attachmentId}/toggleVisibility.ts
@@ -101,7 +101,7 @@ export function toggleProjectAttachmentVisibility(): RequestHandler {
         let securityRuleId: number | null = null;
 
         // Step 1: Check if security rule already exists
-        const getSecurityRuleSQLStatement = getProjectAttachmentSecurityRuleSQL(Number(req.params.projectId));
+        const getSecurityRuleSQLStatement = getProjectAttachmentSecurityRuleSQL(Number(req.params.attachmentId));
 
         if (!getSecurityRuleSQLStatement) {
           throw new HTTP400('Failed to build SQL get project attachment security rule statement');
@@ -121,7 +121,10 @@ export function toggleProjectAttachmentVisibility(): RequestHandler {
 
         // Step 2: Create security rule if it does not exist
         if (!securityRuleId) {
-          const createSecurityRuleSQLStatement = addProjectAttachmentSecurityRuleSQL(Number(req.params.projectId));
+          const createSecurityRuleSQLStatement = addProjectAttachmentSecurityRuleSQL(
+            Number(req.params.projectId),
+            Number(req.params.attachmentId)
+          );
 
           if (!createSecurityRuleSQLStatement) {
             throw new HTTP400('Failed to build SQL insert project attachment security rule statement');

--- a/api/src/queries/project/project-attachments-queries.test.ts
+++ b/api/src/queries/project/project-attachments-queries.test.ts
@@ -44,26 +44,32 @@ describe('applyProjectAttachmentSecurityRuleSQL', () => {
 
 describe('addProjectAttachmentSecurityRuleSQL', () => {
   it('returns null response when null projectId provided', () => {
-    const response = addProjectAttachmentSecurityRuleSQL((null as unknown) as number);
+    const response = addProjectAttachmentSecurityRuleSQL((null as unknown) as number, 1);
+
+    expect(response).to.be.null;
+  });
+
+  it('returns null response when null attachmentId provided', () => {
+    const response = addProjectAttachmentSecurityRuleSQL(1, (null as unknown) as number);
 
     expect(response).to.be.null;
   });
 
   it('returns non null response when valid projectId provided', () => {
-    const response = addProjectAttachmentSecurityRuleSQL(1);
+    const response = addProjectAttachmentSecurityRuleSQL(1, 2);
 
     expect(response).to.not.be.null;
   });
 });
 
 describe('getProjectAttachmentSecurityRuleSQL', () => {
-  it('returns null response when null projectId provided', () => {
+  it('returns null response when null attachmentId provided', () => {
     const response = getProjectAttachmentSecurityRuleSQL((null as unknown) as number);
 
     expect(response).to.be.null;
   });
 
-  it('returns non null response when valid projectId provided', () => {
+  it('returns non null response when valid attachmentId provided', () => {
     const response = getProjectAttachmentSecurityRuleSQL(1);
 
     expect(response).to.not.be.null;

--- a/api/src/queries/project/project-attachments-queries.ts
+++ b/api/src/queries/project/project-attachments-queries.ts
@@ -32,16 +32,17 @@ export const applyProjectAttachmentSecurityRuleSQL = (securityRuleId: number | n
  * SQL query to add security rule for project attachments table
  *
  * @param {number} projectId
+ * @param {number} attachmentId
  * @returns {SQLStatement} sql query object
  */
-export const addProjectAttachmentSecurityRuleSQL = (projectId: number): SQLStatement | null => {
-  defaultLog.debug({ label: 'addProjectAttachmentSecurityRuleSQL', message: 'params', projectId });
+export const addProjectAttachmentSecurityRuleSQL = (projectId: number, attachmentId: number): SQLStatement | null => {
+  defaultLog.debug({ label: 'addProjectAttachmentSecurityRuleSQL', message: 'params', projectId, attachmentId });
 
-  if (!projectId) {
+  if (!projectId || !attachmentId) {
     return null;
   }
 
-  const ruleDefinition = [{ target: 'project_attachment', rule: `project_id=${projectId}` }];
+  const ruleDefinition = [{ target: 'project_attachment', rule: `project_attachment_id=${attachmentId}` }];
 
   const sqlStatement: SQLStatement = SQL`
     INSERT INTO security_rule (
@@ -70,20 +71,22 @@ export const addProjectAttachmentSecurityRuleSQL = (projectId: number): SQLState
 /**
  * SQL query to get security rule for project attachments table
  *
- * @param {number} projectId
+ * @param {number} attachmentId
  * @returns {SQLStatement} sql query object
  */
-export const getProjectAttachmentSecurityRuleSQL = (projectId: number): SQLStatement | null => {
-  defaultLog.debug({ label: 'getProjectAttachmentSecurityRuleSQL', message: 'params', projectId });
+export const getProjectAttachmentSecurityRuleSQL = (attachmentId: number): SQLStatement | null => {
+  defaultLog.debug({ label: 'getProjectAttachmentSecurityRuleSQL', message: 'params', attachmentId });
 
-  if (!projectId) {
+  if (!attachmentId) {
     return null;
   }
 
+  const query = `project_attachment_id=${attachmentId}`;
+
   const sqlStatement: SQLStatement = SQL`
-    SELECT security_rule_id as id
-    FROM security_rule
-    WHERE project_id = ${projectId};
+    select security_rule_id as id
+    from security_rule sr
+    where sr.rule_definition->0 ->> 'rule' = ${query};
   `;
 
   defaultLog.debug({


### PR DESCRIPTION
# Overview

Fix issue where making an attachment private makes all other attachments private too

This was because the rule was being defined based on project id and not based on project attachment id