### PR TITLE
Fix bug related to KML and GPX file simultaneous upload

### DIFF
--- a/api/src/queries/generate-geometry-collection.ts
+++ b/api/src/queries/generate-geometry-collection.ts
@@ -8,7 +8,7 @@ export function generateGeometryCollectionSQL(geometry: Feature[]): SQLStatement
   if (geometry.length === 1) {
     const geo = JSON.stringify(geometry[0].geometry);
 
-    return SQL`public.ST_GeomFromGeoJSON(${geo})`;
+    return SQL`public.ST_Force2D(public.ST_GeomFromGeoJSON(${geo}))`;
   }
 
   const sqlStatement: SQLStatement = SQL`public.ST_AsText(public.ST_Collect(array[`;
@@ -19,11 +19,11 @@ export function generateGeometryCollectionSQL(geometry: Feature[]): SQLStatement
     // as long as it is not the last geometry, keep adding to the ST_collect
     if (index !== geometry.length - 1) {
       sqlStatement.append(SQL`
-        public.ST_GeomFromGeoJSON(${geo}),
+        public.ST_Force2D(public.ST_GeomFromGeoJSON(${geo})),
       `);
     } else {
       sqlStatement.append(SQL`
-        public.ST_GeomFromGeoJSON(${geo})]))
+        public.ST_Force2D(public.ST_GeomFromGeoJSON(${geo}))]))
       `);
     }
   });


### PR DESCRIPTION
# Overview

## Links to jira tickets

- https://quartech.atlassian.net/browse/BHBC-1388

## This PR contains the following changes

- When uploading a KML and GPX file in project location - saving the project will crash
- Fix issue by making all geometries 2D before uploading so no discrepancies between multiline and polygon

Useful reference:
- https://trac.osgeo.org/postgis/ticket/834

## This PR contains the following types of changes

- [x] Bug fix (change which fixes an issue)

## How Has This Been Tested?

- Locally
- You can now upload both gpx and kml together
