### PR TITLE
Update all the BC and DC to tune the resource usage

### DIFF
--- a/api/openshift/api.bc.yaml
+++ b/api/openshift/api.bc.yaml
@@ -91,8 +91,8 @@ objects:
           cpu: 1250m
           memory: 3Gi
         requests:
-          cpu: 750m
-          memory: 2Gi
+          cpu: 100m
+          memory: 512Mi
       runPolicy: SerialLatestOnly
       source:
         contextDir: '${SOURCE_CONTEXT_DIR}'

--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -37,11 +37,11 @@ parameters:
     required: true
     value: 'https://oidc.gov.bc.ca/auth/realms/35r1iman/protocol/openid-connect/certs'
   - name: CPU_REQ
-    value: '500m'
+    value: '100m'
   - name: CPU_LIMIT
     value: '750m'
   - name: MEMORY_REQ
-    value: '1Gi'
+    value: '512Mi'
   - name: MEMORY_LIMIT
     value: '2Gi'
   - name: REPLICAS

--- a/app/openshift/app.bc.yaml
+++ b/app/openshift/app.bc.yaml
@@ -88,11 +88,11 @@ objects:
       postCommit: {}
       resources:
         limits:
-          cpu: 1250m
+          cpu: 1000m
           memory: 5Gi
         requests:
-          cpu: 750m
-          memory: 5Gi
+          cpu: 100m
+          memory: 512Mi
       runPolicy: Serial
       source:
         contextDir: '${SOURCE_CONTEXT_DIR}'

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -43,13 +43,13 @@ parameters:
     value: '7100-tcp'
   - name: CPU_REQUEST
     description: CPU REQUEST for deployment config
-    value: '200m'
+    value: '100m'
   - name: CPU_LIMIT
     description: CPU LIMIT for dc
     value: '500m'
   - name: MEMORY_REQUEST
     description: MEMORY REQUEST for dc
-    value: '1Gi'
+    value: '512Mi'
   - name: MEMORY_LIMIT
     description: MEMORY LIMIT for dc
     value: '2Gi'

--- a/database/openshift/db.dc.yaml
+++ b/database/openshift/db.dc.yaml
@@ -74,13 +74,13 @@ parameters:
     name: POSTGIS_EXTENSION
     value: 'Y'
   - name: CPU_LIMIT
-    value: '500m'
+    value: '1000m'
   - name: MEMORY_LIMIT
     value: '2Gi'
   - name: CPU_REQUEST
-    value: '200m'
+    value: '100m'
   - name: MEMORY_REQUEST
-    value: '1.5Gi'
+    value: '512Mi'
 objects:
   - apiVersion: v1
     kind: Secret

--- a/database/openshift/db.setup.bc.yaml
+++ b/database/openshift/db.setup.bc.yaml
@@ -94,7 +94,7 @@ objects:
           cpu: '1'
           memory: 1.5Gi
         requests:
-          cpu: 500m
+          cpu: 100m
           memory: 512Mi
       runPolicy: SerialLatestOnly
       source:

--- a/database/openshift/db.setup.dc.yaml
+++ b/database/openshift/db.setup.dc.yaml
@@ -58,7 +58,7 @@ objects:
               cpu: '1'
               memory: 1.5Gi
             requests:
-              cpu: 500m
+              cpu: 100m
               memory: 512Mi
           env:
             - name: DB_HOST


### PR DESCRIPTION
# Overview

As per guidance from the platform team:

- Set request (memory/CPU) as low as you can
- Set Maximum to what you would reasonably not exceed

This will make sure that we do not have reserved resources that are not used at all. The current Silver environment is currently at 72% and at 75% they cannot support new projects anymore. Realistically only 24% of the capacity is used so there is a lot of over reservation.