### PR TITLE
Create toDraft.yml

### DIFF
--- a/.github/workflows/toDraft.yml
+++ b/.github/workflows/toDraft.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_ID: ${{ github.event.number }}
-    needs:
-      - checkEnv
     steps:
       # Log in to OpenShift.
       # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.

--- a/.github/workflows/toDraft.yml
+++ b/.github/workflows/toDraft.yml
@@ -1,0 +1,27 @@
+# Switch to Draft
+# Scales down running PODS when switching to Draft
+name: Draft Scale Down
+
+on:
+  pull_request:
+    types: [converted_to_draft]
+
+jobs:
+  scaleDownPods:
+    name: Scale down the pods for this PR
+    runs-on: ubuntu-latest
+    env:
+      BUILD_ID: ${{ github.event.number }}
+    needs:
+      - checkEnv
+    steps:
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      - name: Scale down
+        run: |
+          oc project af2668-dev
+          oc get deploymentconfig --selector env-id=$BUILD_ID -o name | awk '{print "oc scale --replicas=0  " $1}' | bash


### PR DESCRIPTION
# Overview

When you convert a PR in flight to draft, this will automatically scale down the PR pods that were created on OpenShift.

Before setting to draft:
![image](https://user-images.githubusercontent.com/22899001/167970125-63c512b2-41be-4feb-b343-2fb76035f98e.png)

After switching to draft:
![image](https://user-images.githubusercontent.com/22899001/167970888-e980b7b8-d713-414c-a47f-4e2bc6ba8991.png)
