### PR TITLE
Fixed horizontal autoscaler and consolidate deployment files

### DIFF
--- a/api/.pipeline/config.js
+++ b/api/.pipeline/config.js
@@ -87,7 +87,7 @@ const phases = {
     tz: config.timezone.api,
     certificateURL: config.certificateURL.dev,
     replicas: 1,
-    maxReplicas: 2,
+    maxReplicas: 1,
     logLevel: isStaticDeployment && 'info' || 'debug'
   },
   test: {
@@ -102,7 +102,7 @@ const phases = {
     tag: `test-${version}`,
     host: staticUrlsAPI.test,
     env: 'test',
-    elasticsearchURL: 'https://elasticsearch-af2668-dev.apps.silver.devops.gov.bc.ca',
+    elasticsearchURL: 'http://es01:9200',
     tz: config.timezone.api,
     certificateURL: config.certificateURL.test,
     replicas: 3,

--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -350,7 +350,7 @@ objects:
       wildcardPolicy: None
     status:
       ingress: null
-  - apiVersion: autoscaling/v1
+  - apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
     metadata:
       annotations: {}
@@ -358,11 +358,22 @@ objects:
       labels: {}
       name: ${NAME}${SUFFIX}
     spec:
-      maxReplicas: '${{REPLICA_MAX}}'
-      minReplicas: '${{REPLICAS}}'
       scaleTargetRef:
-        apiVersion: v1
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
-      cpuUtilization:
-        targetPercentage: 95
+        apiVersion: apps.openshift.io/v1
+      minReplicas: '${{REPLICAS}}'
+      maxReplicas: '${{REPLICA_MAX}}'
+      metrics:
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 90
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 95

--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -363,10 +363,10 @@ objects:
             name: memory
             target:
               type: Utilization
-              averageUtilization: 90
+              averageUtilization: 200
         - type: Resource
           resource:
             name: cpu
             target:
               type: Utilization
-              averageUtilization: 95
+              averageUtilization: 200

--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -362,8 +362,8 @@ objects:
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
         apiVersion: apps.openshift.io/v1
-      minReplicas: '${{REPLICAS}}'
-      maxReplicas: '${{REPLICA_MAX}}'
+      minReplicas: '${REPLICAS}'
+      maxReplicas: '${REPLICA_MAX}'
       metrics:
         - type: Resource
           resource:

--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -291,13 +291,6 @@ objects:
               name: ${NAME}:${VERSION}
           type: ImageChange
         - type: ConfigChange
-    status:
-      availableReplicas: 0
-      latestVersion: 0
-      observedGeneration: 0
-      replicas: 0
-      unavailableReplicas: 0
-      updatedReplicas: 0
   - apiVersion: v1
     stringData:
       database-name: ''
@@ -362,8 +355,8 @@ objects:
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
         apiVersion: apps.openshift.io/v1
-      minReplicas: '${REPLICAS}'
-      maxReplicas: '${REPLICA_MAX}'
+      minReplicas: '${{REPLICAS}}'
+      maxReplicas: '${{REPLICA_MAX}}'
       metrics:
         - type: Resource
           resource:

--- a/app/.pipeline/config.js
+++ b/app/.pipeline/config.js
@@ -89,7 +89,7 @@ const phases = {
     env: 'dev',
     sso: sso.dev,
     replicas: 1,
-    maxReplicas: 2
+    maxReplicas: 1
   },
   test: {
     namespace: 'af2668-test',

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -90,7 +90,7 @@ objects:
         role: app
       name: ${NAME}${SUFFIX}
     spec:
-      replicas: '${REPLICAS}'
+      replicas: '${{REPLICAS}}'
       revisionHistoryLimit: 10
       selector:
         deploymentConfig: ${NAME}${SUFFIX}
@@ -194,13 +194,6 @@ objects:
               name: ${NAME}:${VERSION}
           type: ImageChange
         - type: ConfigChange
-    status:
-      availableReplicas: 0
-      latestVersion: 0
-      observedGeneration: 0
-      replicas: 0
-      unavailableReplicas: 0
-      updatedReplicas: 0
   - apiVersion: v1
     kind: Service
     metadata:
@@ -253,8 +246,8 @@ objects:
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
         apiVersion: apps.openshift.io/v1
-      minReplicas: '${REPLICAS}'
-      maxReplicas: '${REPLICA_MAX}'
+      minReplicas: '${{REPLICAS}}'
+      maxReplicas: '${{REPLICA_MAX}}'
       metrics:
         - type: Resource
           resource:

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -241,7 +241,7 @@ objects:
       wildcardPolicy: None
     status:
       ingress: null
-  - apiVersion: autoscaling/v1
+  - apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
     metadata:
       annotations: {}
@@ -249,11 +249,22 @@ objects:
       labels: {}
       name: ${NAME}${SUFFIX}
     spec:
-      maxReplicas: '${{REPLICA_MAX}}'
-      minReplicas: '${{REPLICAS}}'
       scaleTargetRef:
-        apiVersion: v1
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
-      cpuUtilization:
-        targetPercentage: 95
+        apiVersion: apps.openshift.io/v1
+      minReplicas: '${{REPLICAS}}'
+      maxReplicas: '${{REPLICA_MAX}}'
+      metrics:
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 90
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 95

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -90,7 +90,7 @@ objects:
         role: app
       name: ${NAME}${SUFFIX}
     spec:
-      replicas: '${{REPLICAS}}'
+      replicas: '${REPLICAS}'
       revisionHistoryLimit: 10
       selector:
         deploymentConfig: ${NAME}${SUFFIX}
@@ -253,8 +253,8 @@ objects:
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
         apiVersion: apps.openshift.io/v1
-      minReplicas: '${{REPLICAS}}'
-      maxReplicas: '${{REPLICA_MAX}}'
+      minReplicas: '${REPLICAS}'
+      maxReplicas: '${REPLICA_MAX}'
       metrics:
         - type: Resource
           resource:

--- a/containers/backup/templates/backup-cronjob/backup-cronjob.yaml
+++ b/containers/backup/templates/backup-cronjob/backup-cronjob.yaml
@@ -146,7 +146,7 @@ objects:
     RETENTION.WEEKLY_BACKUPS: "${WEEKLY_BACKUPS}"
     RETENTION.MONTHLY_BACKUPS: "${MONTHLY_BACKUPS}"
 - kind: "CronJob"
-  apiVersion: "batch/v1beta1"
+  apiVersion: "batch/v1"
   metadata:
     name: "${JOB_NAME}"
     labels:

--- a/containers/n8n/Dockerfile
+++ b/containers/n8n/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest
+ARG N8N_VERSION
+ENV HOME=/opt/app-root/src \
+    TZ=America/Vancouver
+
+RUN yum -y update \
+  && yum -y install yum-utils \
+  && rpm --import http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 \
+  && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN yum install -y imagemagick
+RUN mkdir -p $HOME
+WORKDIR $HOME
+RUN npm install -g n8n
+RUN npm audit fix --force
+ENV PATH ${HOME}/node_modules/.bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+VOLUME ${HOME}
+VOLUME [ "/data" ]
+WORKDIR /data
+EXPOSE 5678/tcp
+CMD ["n8n"]

--- a/containers/n8n/n8n.bc.yaml
+++ b/containers/n8n/n8n.bc.yaml
@@ -1,12 +1,12 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 labels:
   app: n8n
   build: "${NAME}"
   template: "${NAME}-bc-template"
 metadata:
-  name: "${NAME}"
+  name: n8n
 objects:
   - kind: ImageStream
     apiVersion: v1
@@ -44,14 +44,18 @@ objects:
           ARG N8N_VERSION
           ENV HOME=/opt/app-root/src \
               TZ=America/Vancouver
+          USER root
+          RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+          RUN yum install -y GraphicsMagick
           RUN mkdir -p $HOME
           WORKDIR $HOME
-          RUN npm install -g n8n@${N8N_VERSION}
+          RUN npm install -g n8n
           ENV PATH ${HOME}/node_modules/.bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
           VOLUME ${HOME}
           VOLUME [ "/data" ]
           WORKDIR /data
           EXPOSE 5678/tcp
+          USER 1001
           CMD ["n8n"]
         type: Dockerfile
       strategy:
@@ -61,7 +65,7 @@ objects:
               value: "${N8N_VERSION}"
           from:
             kind: DockerImage
-            name: registry.access.redhat.com/ubi8/nodejs-14:latest
+            name: artifacts.developer.gov.bc.ca/redhat-docker-remote/ubi8/nodejs-16:latest
         type: Docker
       triggers:
         - type: ConfigChange
@@ -75,7 +79,7 @@ parameters:
     displayName: N8N Version
     description: Version of N8N to use
     required: true
-    value: 0.131.0
+    value: latest
   - name: VERSION
     displayName: Image version tag
     description: The version tag of the built image

--- a/containers/n8n/n8n.dc.yaml
+++ b/containers/n8n/n8n.dc.yaml
@@ -1,11 +1,11 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 labels:
   app: "${NAME}"
   template: "${NAME}-dc-template"
 metadata:
-  name: "${NAME}"
+  name: n8n-deploy
 objects:
   - kind: Secret
     apiVersion: v1
@@ -144,7 +144,7 @@ objects:
       - ReadWriteMany
       resources:
         requests:
-          storage: 2Gi
+          storage: 1Gi
       storageClassName: netapp-file-standard
       volumeMode: Filesystem
   - kind: PersistentVolumeClaim
@@ -322,7 +322,7 @@ objects:
                   key: database-name
                   name: "postgresql-${NAME}"
             imagePullPolicy: IfNotPresent
-            image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql:latest
+            image: artifacts.developer.gov.bc.ca/docker-remote/postgres:13.6
             livenessProbe:
               exec:
                 command:
@@ -473,6 +473,15 @@ objects:
                   name: "${NAME}"
             - name: WEBHOOK_TUNNEL_URL
               value: "https://${NAME}-${NAMESPACE}.apps.silver.devops.gov.bc.ca/"
+            - name: EXECUTIONS_MODE
+              value: queue
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: GENERIC_TIMEZONE
+              value: America/Vancouver
             image: "image-registry.openshift-image-registry.svc:5000/${N8N_IMAGE_NAMESPACE}/${NAME}:latest"
             imagePullPolicy: IfNotPresent
             name: n8n
@@ -540,7 +549,7 @@ parameters:
     description: Amount of disk space needed for persistence
     displayName: PVC Size
     required: true
-    value: 2Gi
+    value: 1Gi
   - name: N8N_USER
     displayName: N8N User name
     description: The name associated with the n8n basic user


### PR DESCRIPTION
# Overview

Fixing an issue with the horizontal autoscaler definition when deploying. The deploy code referenced an older version of the api for the scaler, therefore it was not deploying (pods were created all right). This would mean that we do not get that sweet auto-tuning that kubernetes can do for us.

Also consolidated some of the changes I made for N8N.