### PR TITLE
BHBC-2076: Display Templates from S3

### DIFF
--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -1,9 +1,8 @@
 import chai, { expect } from 'chai';
 import { describe } from 'mocha';
+import OpenAPIResponseValidator, { OpenAPIResponseValidatorArgs } from 'openapi-response-validator';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import OpenAPIResponseValidator, { OpenAPIResponseValidatorArgs } from 'openapi-response-validator';
-
 import { HTTPError } from '../../errors/http-error';
 import * as fileUtils from '../../utils/file-utils';
 import { getRequestHandlerMocks } from '../../__mocks__/db';
@@ -36,17 +35,17 @@ describe('listResources', () => {
       ['key1']: {
         'template-name': 'name1',
         'template-type': 'type1',
-        'species': 'species1',
+        species: 'species1'
       },
       ['key2']: {
         'template-name': 'name2',
         'template-type': 'type2',
-        'species': 'species2',
+        species: 'species2'
       },
       ['key3']: {
         'template-name': 'name3',
         'template-type': 'type3',
-        'species': 'species3',
+        species: 'species3'
       }
     };
 
@@ -143,7 +142,7 @@ describe('listResources', () => {
     expect(listFilesStub).to.have.been.calledWith('templates/Current');
     expect(mockRes.jsonValue).to.eql({ files: [] });
     expect(mockRes.statusValue).to.equal(200);
-  })
+  });
 
   it('catches error, and re-throws error', async () => {
     sinon.stub(fileUtils, 'listFilesFromS3').rejects(new Error('an error occurred'));
@@ -312,7 +311,7 @@ describe('listResources', () => {
           const response = responseValidator.validateResponse(200, apiResponse);
           expect(response.message).to.equal('The response was not valid.');
           expect(response.errors.length).to.equal(1);
-          expect(response.errors[0].message).to.equal("must be number");
+          expect(response.errors[0].message).to.equal('must be number');
           expect(response.errors[0].path).to.equal('files/0/fileSize');
         });
 

--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -11,6 +11,11 @@ import { GET, listResources } from './list';
 chai.use(sinonChai);
 
 describe('listResources', () => {
+  beforeEach(() => {
+    process.env.OBJECT_STORE_URL = 's3.host.example.com';
+    process.env.OBJECT_STORE_BUCKET_NAME = 'test-bucket';
+  });
+
   afterEach(() => {
     sinon.restore();
   });
@@ -49,7 +54,6 @@ describe('listResources', () => {
       }
     };
 
-    sinon.stub(fileUtils, 'getS3HostUrl').returns('s3.host.example.com/test-bucket');
     sinon.stub(fileUtils, 'getObjectMeta').callsFake((key: string) => {
       return Promise.resolve({
         Metadata: mockMetadata[key]
@@ -123,7 +127,6 @@ describe('listResources', () => {
   });
 
   it('should filter out directories from the s3 list respones', async () => {
-    sinon.stub(fileUtils, 'getS3HostUrl').returns('s3.host.example.com');
     sinon.stub(fileUtils, 'getObjectMeta').resolves({});
 
     const listFilesStub = sinon.stub(fileUtils, 'listFilesFromS3').resolves({

--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -1,0 +1,21 @@
+import chai from 'chai';
+import { describe } from 'mocha';
+
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+
+describe('listResources', () => {
+
+  it('returns an empty array if no resources are found', async () => {
+    //
+  });
+
+  it('returns an array of resources', async () => {
+    //
+  });
+
+  it('catches error, and re-throws error', async () => {
+   //
+  });
+});

--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -49,7 +49,7 @@ describe('listResources', () => {
       }
     };
 
-    sinon.stub(fileUtils, 'getS3PublicHostUrl').returns('s3.host.example.com');
+    sinon.stub(fileUtils, 'getS3HostUrl').returns('s3.host.example.com/test-bucket');
     sinon.stub(fileUtils, 'getObjectMeta').callsFake((key: string) => {
       return Promise.resolve({
         Metadata: mockMetadata[key]
@@ -86,8 +86,8 @@ describe('listResources', () => {
       files: [
         {
           fileName: 'key1',
-          url: 's3.host.example.com/key1',
-          lastModified: new Date('2023-01-01').toString(),
+          url: 's3.host.example.com/test-bucket/key1',
+          lastModified: new Date('2023-01-01').toISOString(),
           fileSize: 5,
           metadata: {
             templateName: 'name1',
@@ -97,8 +97,8 @@ describe('listResources', () => {
         },
         {
           fileName: 'key2',
-          url: 's3.host.example.com/key2',
-          lastModified: new Date('2023-01-02').toString(),
+          url: 's3.host.example.com/test-bucket/key2',
+          lastModified: new Date('2023-01-02').toISOString(),
           fileSize: 10,
           metadata: {
             templateName: 'name2',
@@ -108,8 +108,8 @@ describe('listResources', () => {
         },
         {
           fileName: 'key3',
-          url: 's3.host.example.com/key3',
-          lastModified: new Date('2023-01-03').toString(),
+          url: 's3.host.example.com/test-bucket/key3',
+          lastModified: new Date('2023-01-03').toISOString(),
           fileSize: 15,
           metadata: {
             templateName: 'name3',
@@ -123,7 +123,7 @@ describe('listResources', () => {
   });
 
   it('should filter out directories from the s3 list respones', async () => {
-    sinon.stub(fileUtils, 'getS3PublicHostUrl').returns('s3.host.example.com');
+    sinon.stub(fileUtils, 'getS3HostUrl').returns('s3.host.example.com');
     sinon.stub(fileUtils, 'getObjectMeta').resolves({});
 
     const listFilesStub = sinon.stub(fileUtils, 'listFilesFromS3').resolves({

--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -1,21 +1,340 @@
-import chai from 'chai';
+import chai, { expect } from 'chai';
 import { describe } from 'mocha';
-
+import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import OpenAPIResponseValidator, { OpenAPIResponseValidatorArgs } from 'openapi-response-validator';
+
+import { HTTPError } from '../../errors/http-error';
+import * as fileUtils from '../../utils/file-utils';
+import { getRequestHandlerMocks } from '../../__mocks__/db';
+import { GET, listResources } from './list';
 
 chai.use(sinonChai);
 
 describe('listResources', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it('returns an empty array if no resources are found', async () => {
-    //
+    const listFilesStub = sinon.stub(fileUtils, 'listFilesFromS3').resolves({
+      Contents: []
+    });
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    const requestHandler = listResources();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(listFilesStub).to.have.been.calledWith('templates/Current');
+    expect(mockRes.jsonValue).to.eql({ files: [] });
+    expect(mockRes.statusValue).to.equal(200);
   });
 
   it('returns an array of resources', async () => {
-    //
+    const mockMetadata = {
+      ['key1']: {
+        'template-name': 'name1',
+        'template-type': 'type1',
+        'species': 'species1',
+      },
+      ['key2']: {
+        'template-name': 'name2',
+        'template-type': 'type2',
+        'species': 'species2',
+      },
+      ['key3']: {
+        'template-name': 'name3',
+        'template-type': 'type3',
+        'species': 'species3',
+      }
+    };
+
+    sinon.stub(fileUtils, 'getS3PublicHostUrl').returns('s3.host.example.com');
+    sinon.stub(fileUtils, 'getObjectMeta').callsFake((key: string) => {
+      return Promise.resolve({
+        Metadata: mockMetadata[key]
+      });
+    });
+
+    const listFilesStub = sinon.stub(fileUtils, 'listFilesFromS3').resolves({
+      Contents: [
+        {
+          Key: 'key1',
+          LastModified: new Date('2023-01-01'),
+          Size: 5
+        },
+        {
+          Key: 'key2',
+          LastModified: new Date('2023-01-02'),
+          Size: 10
+        },
+        {
+          Key: 'key3',
+          LastModified: new Date('2023-01-03'),
+          Size: 15
+        }
+      ]
+    });
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    const requestHandler = listResources();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(listFilesStub).to.have.been.calledWith('templates/Current');
+    expect(mockRes.jsonValue).to.eql({
+      files: [
+        {
+          fileName: 'key1',
+          url: 's3.host.example.com/key1',
+          lastModified: new Date('2023-01-01').toString(),
+          fileSize: 5,
+          metadata: {
+            templateName: 'name1',
+            templateType: 'type1',
+            species: 'species1'
+          }
+        },
+        {
+          fileName: 'key2',
+          url: 's3.host.example.com/key2',
+          lastModified: new Date('2023-01-02').toString(),
+          fileSize: 10,
+          metadata: {
+            templateName: 'name2',
+            templateType: 'type2',
+            species: 'species2'
+          }
+        },
+        {
+          fileName: 'key3',
+          url: 's3.host.example.com/key3',
+          lastModified: new Date('2023-01-03').toString(),
+          fileSize: 15,
+          metadata: {
+            templateName: 'name3',
+            templateType: 'type3',
+            species: 'species3'
+          }
+        }
+      ]
+    });
+    expect(mockRes.statusValue).to.equal(200);
   });
 
+  it('should filter out directories from the s3 list respones', async () => {
+    sinon.stub(fileUtils, 'getS3PublicHostUrl').returns('s3.host.example.com');
+    sinon.stub(fileUtils, 'getObjectMeta').resolves({});
+
+    const listFilesStub = sinon.stub(fileUtils, 'listFilesFromS3').resolves({
+      Contents: [
+        {
+          Key: 'templates/Current/'
+        }
+      ]
+    });
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    const requestHandler = listResources();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(listFilesStub).to.have.been.calledWith('templates/Current');
+    expect(mockRes.jsonValue).to.eql({ files: [] });
+    expect(mockRes.statusValue).to.equal(200);
+  })
+
   it('catches error, and re-throws error', async () => {
-   //
+    sinon.stub(fileUtils, 'listFilesFromS3').rejects(new Error('an error occurred'));
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    try {
+      const requestHandler = listResources();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as HTTPError).message).to.equal('an error occurred');
+    }
+  });
+
+  describe('openApiSchema', () => {
+    describe('response validation', () => {
+      const responseValidator = new OpenAPIResponseValidator((GET.apiDoc as unknown) as OpenAPIResponseValidatorArgs);
+
+      describe('should succeed when', () => {
+        it('returns an empty response', async () => {
+          const apiResponse = { files: [] };
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response).to.equal(undefined);
+        });
+
+        it('optional values are not included', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                fileName: 'string1',
+                lastModified: 'string1',
+                fileSize: 0,
+                metadata: {}
+              }
+            ]
+          };
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response).to.equal(undefined);
+        });
+
+        it('optional values are valid', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                fileName: 'string1',
+                lastModified: 'string1',
+                fileSize: 0,
+                metadata: {
+                  templateName: 'string1',
+                  templateType: 'string1',
+                  species: 'string1'
+                }
+              }
+            ]
+          };
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response).to.equal(undefined);
+        });
+      });
+
+      describe('should fail when', () => {
+        it('returns a null response', async () => {
+          const apiResponse = null;
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors[0].message).to.equal('must be object');
+        });
+
+        it('file has no fileName', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                lastModified: 'string1',
+                fileSize: 0,
+                metadata: {}
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must have required property 'fileName'");
+          expect(response.errors[0].path).to.equal('files/0');
+        });
+
+        it('file has no url', async () => {
+          const apiResponse = {
+            files: [
+              {
+                fileName: 'string1',
+                lastModified: 'string1',
+                fileSize: 0,
+                metadata: {}
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must have required property 'url'");
+          expect(response.errors[0].path).to.equal('files/0');
+        });
+
+        it('file has no lastModified', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                fileName: 'string1',
+                fileSize: 0,
+                metadata: {}
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must have required property 'lastModified'");
+          expect(response.errors[0].path).to.equal('files/0');
+        });
+
+        it('file has no fileSize', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                fileName: 'string1',
+                lastModified: 'string1',
+                metadata: {}
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must have required property 'fileSize'");
+          expect(response.errors[0].path).to.equal('files/0');
+        });
+
+        it('fileSize is not a number', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                fileName: 'string1',
+                lastModified: 'string1',
+                fileSize: '100 kB',
+                metadata: {}
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must be number");
+          expect(response.errors[0].path).to.equal('files/0/fileSize');
+        });
+
+        it('file has no metadata', async () => {
+          const apiResponse = {
+            files: [
+              {
+                url: 'string1',
+                lastModified: 'string1',
+                fileName: 'string1',
+                fileSize: 0
+              }
+            ]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal("must have required property 'metadata'");
+          expect(response.errors[0].path).to.equal('files/0');
+        });
+      });
+    });
   });
 });

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -110,7 +110,7 @@ export function listResources(): RequestHandler {
 
           return {
             fileName,
-            url: `${getS3HostUrl(file.Key)}`,
+            url: getS3HostUrl(file.Key),
             lastModified: file.LastModified?.toISOString() || null,
             fileSize: file.Size,
             metadata

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -113,7 +113,7 @@ export function listResources(): RequestHandler {
           return {
             fileName,
             url: `${getS3PublicHostUrl()}/${file.Key}`,
-            lastModified: file.LastModified,
+            lastModified: file.LastModified?.toString() || null,
             fileSize: file.Size,
             metadata
           }

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -99,7 +99,7 @@ export function listResources(): RequestHandler {
             const metaResponse = await getObjectMeta(file.Key);
 
             // Trim path name and/or leading '/' character(s)
-            fileName = file.Key.replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}\/*`), '');
+            fileName = file.Key.replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}/*`), '');
 
             metadata = {
               species: metaResponse?.Metadata?.['species'],

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -98,8 +98,8 @@ export function listResources(): RequestHandler {
           if (file.Key) {
             const metaResponse = await getObjectMeta(file.Key);
 
-            // Trim path name and leading '/' character(s)
-            fileName = file.Key.replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}`), '').replace(/^\/|\/$/g, '');
+            // Trim path name and/or leading '/' character(s)
+            fileName = file.Key.replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}\/*`), '');
 
             metadata = {
               species: metaResponse?.Metadata?.['species'],

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -1,4 +1,4 @@
-import { Object } from 'aws-sdk/clients/s3';
+import { Object as S3Object } from 'aws-sdk/clients/s3';
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { getObjectMeta, getS3HostUrl, listFilesFromS3 } from '../../utils/file-utils';
@@ -90,8 +90,8 @@ export function listResources(): RequestHandler {
        * which fetch the metadata for each object in the list.
        */
       const filePromises = (response?.Contents || [])
-        .filter((file: Object) => !file.Key?.endsWith('/'))
-        .map(async (file: Object) => {
+        .filter((file: S3Object) => !file.Key?.endsWith('/'))
+        .map(async (file: S3Object) => {
           let metadata = {};
           let fileName = '';
 

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -1,0 +1,79 @@
+import { Object } from 'aws-sdk/clients/s3';
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { listFilesFromS3 } from '../../utils/file-utils';
+import { getLogger } from '../../utils/logger';
+
+const defaultLog = getLogger('paths/resources/list');
+
+export const GET: Operation = [listResources()];
+
+GET.apiDoc = {
+  description: 'Lists all resources.',
+  tags: ['resources'],
+  responses: {
+    200: {
+      description: 'Resources response object.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              files: {
+                type: 'array', 
+                items: {
+                  type: 'object',
+                  required: ['key', 'last_modified'],
+                  properties: {
+                    key: {
+                      type: 'string'
+                    },
+                    last_modified: {
+                      // type: 'string' // @TODO
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * List resources.
+ *
+ * @returns {RequestHandler}
+ */
+export function listResources(): RequestHandler {
+  return async (_req, res) => {
+    defaultLog.debug({ label: 'listResources' });
+
+    try {
+      const response = await listFilesFromS3('templates/Current');
+
+      const files = response?.Contents?.map((file: Object) => {
+        return {
+          key: file.Key,
+          last_modified: file.LastModified
+        }
+      }) || [];
+
+      res.status(200).json({ files });
+    } catch (error) {
+      defaultLog.error({ label: 'getSearchResults', message: 'error', error });
+      throw error;
+    }
+  };
+}

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -22,7 +22,7 @@ GET.apiDoc = {
             type: 'object',
             properties: {
               files: {
-                type: 'array', 
+                type: 'array',
                 items: {
                   type: 'object',
                   required: ['fileName', 'url', 'lastModified', 'fileSize', 'metadata'],
@@ -99,15 +99,13 @@ export function listResources(): RequestHandler {
             const metaResponse = await getObjectMeta(file.Key);
 
             // Trim path name and leading '/' character(s)
-            fileName = file.Key
-              .replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}`), '')
-              .replace(/^\/|\/$/g, '');
+            fileName = file.Key.replace(new RegExp(`^${CURRENT_TEMPLATES_PATH}`), '').replace(/^\/|\/$/g, '');
 
             metadata = {
               species: metaResponse?.Metadata?.['species'],
               templateName: metaResponse?.Metadata?.['template-name'],
               templateType: metaResponse?.Metadata?.['template-type']
-            }
+            };
           }
 
           return {
@@ -116,7 +114,7 @@ export function listResources(): RequestHandler {
             lastModified: file.LastModified?.toString() || null,
             fileSize: file.Size,
             metadata
-          }
+          };
         });
 
       // Resolve all promises before returning the result

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -1,7 +1,7 @@
 import { Object } from 'aws-sdk/clients/s3';
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getObjectMeta, getS3PublicHostUrl, listFilesFromS3 } from '../../utils/file-utils';
+import { getObjectMeta, getS3HostUrl, listFilesFromS3 } from '../../utils/file-utils';
 import { getLogger } from '../../utils/logger';
 
 const defaultLog = getLogger('paths/resources/list');
@@ -110,8 +110,8 @@ export function listResources(): RequestHandler {
 
           return {
             fileName,
-            url: `${getS3PublicHostUrl()}/${file.Key}`,
-            lastModified: file.LastModified?.toString() || null,
+            url: `${getS3HostUrl(file.Key)}`,
+            lastModified: file.LastModified?.toISOString() || null,
             fileSize: file.Size,
             metadata
           };

--- a/api/src/paths/resources/list.ts
+++ b/api/src/paths/resources/list.ts
@@ -34,7 +34,7 @@ GET.apiDoc = {
                       type: 'string'
                     },
                     lastModified: {
-                      type: 'string'
+                      oneOf: [{ type: 'string', format: 'date' }, { type: 'object' }]
                     },
                     fileSize: {
                       type: 'number'

--- a/api/src/utils/file-utils.test.ts
+++ b/api/src/utils/file-utils.test.ts
@@ -76,7 +76,7 @@ describe('getS3HostUrl', () => {
 
     const result = getS3HostUrl();
 
-    expect(result).to.equal('nrs.objectstore.gov.bc.ca/');
+    expect(result).to.equal('nrs.objectstore.gov.bc.ca');
   });
 
   it('should successfully produce an S3 host url', () => {

--- a/api/src/utils/file-utils.test.ts
+++ b/api/src/utils/file-utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { deleteFileFromS3, generateS3FileKey, getS3SignedURL } from './file-utils';
+
+import { deleteFileFromS3, generateS3FileKey, getS3HostUrl, getS3SignedURL } from './file-utils';
 
 describe('deleteFileFromS3', () => {
   it('returns null when no key specified', async () => {
@@ -62,4 +63,42 @@ describe('generateS3FileKey', () => {
 
     expect(result).to.equal('projects/1/surveys/2/summaryresults/3/testFileName');
   });
+});
+
+describe.only('getS3PublicHostUrl', () => {
+  beforeEach(() => {
+    process.env.OBJECT_STORE_URL = 's3.host.example.com';
+    process.env.OBJECT_STORE_BUCKET_NAME = 'test-bucket-name';
+  });
+
+  it('should yield a default S3 host url', () => {
+    delete process.env.OBJECT_STORE_URL;
+    delete process.env.OBJECT_STORE_BUCKET_NAME;
+
+    const result = getS3HostUrl();
+
+    expect(result).to.equal('nrs.objectstore.gov.bc.ca/')
+  });
+
+  it('should successfully produce an S3 host url', () => {
+    const result = getS3HostUrl();
+
+    expect(result).to.equal('s3.host.example.com/test-bucket-name')
+  });
+
+  it('should successfully append a key to an S3 host url', () => {
+    const result = getS3HostUrl('my-test-file.txt');
+
+    expect(result).to.equal('s3.host.example.com/test-bucket-name/my-test-file.txt')
+  })
+});
+
+
+
+describe('listFilesFromS3', () => {
+  //const result = listFilesFromS3('path/to/files');
+});
+
+describe('getObjectMeta', () => {
+  //const result = getObjectMeta('test-key');
 });

--- a/api/src/utils/file-utils.test.ts
+++ b/api/src/utils/file-utils.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-
 import { deleteFileFromS3, generateS3FileKey, getS3HostUrl, getS3SignedURL } from './file-utils';
 
 describe('deleteFileFromS3', () => {
@@ -65,7 +64,7 @@ describe('generateS3FileKey', () => {
   });
 });
 
-describe.only('getS3PublicHostUrl', () => {
+describe('getS3PublicHostUrl', () => {
   beforeEach(() => {
     process.env.OBJECT_STORE_URL = 's3.host.example.com';
     process.env.OBJECT_STORE_BUCKET_NAME = 'test-bucket-name';
@@ -77,28 +76,18 @@ describe.only('getS3PublicHostUrl', () => {
 
     const result = getS3HostUrl();
 
-    expect(result).to.equal('nrs.objectstore.gov.bc.ca/')
+    expect(result).to.equal('nrs.objectstore.gov.bc.ca/');
   });
 
   it('should successfully produce an S3 host url', () => {
     const result = getS3HostUrl();
 
-    expect(result).to.equal('s3.host.example.com/test-bucket-name')
+    expect(result).to.equal('s3.host.example.com/test-bucket-name');
   });
 
   it('should successfully append a key to an S3 host url', () => {
     const result = getS3HostUrl('my-test-file.txt');
 
-    expect(result).to.equal('s3.host.example.com/test-bucket-name/my-test-file.txt')
-  })
-});
-
-
-
-describe('listFilesFromS3', () => {
-  //const result = listFilesFromS3('path/to/files');
-});
-
-describe('getObjectMeta', () => {
-  //const result = getObjectMeta('test-key');
+    expect(result).to.equal('s3.host.example.com/test-bucket-name/my-test-file.txt');
+  });
 });

--- a/api/src/utils/file-utils.test.ts
+++ b/api/src/utils/file-utils.test.ts
@@ -64,7 +64,7 @@ describe('generateS3FileKey', () => {
   });
 });
 
-describe('getS3PublicHostUrl', () => {
+describe('getS3HostUrl', () => {
   beforeEach(() => {
     process.env.OBJECT_STORE_URL = 's3.host.example.com';
     process.env.OBJECT_STORE_BUCKET_NAME = 'test-bucket-name';

--- a/api/src/utils/file-utils.test.ts
+++ b/api/src/utils/file-utils.test.ts
@@ -1,6 +1,16 @@
+import AWS from 'aws-sdk';
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { deleteFileFromS3, generateS3FileKey, getS3HostUrl, getS3SignedURL } from './file-utils';
+import {
+  deleteFileFromS3,
+  generateS3FileKey,
+  getS3HostUrl,
+  getS3SignedURL,
+  _getClamAvScanner,
+  _getObjectStoreBucketName,
+  _getObjectStoreUrl,
+  _getS3Client
+} from './file-utils';
 
 describe('deleteFileFromS3', () => {
   it('returns null when no key specified', async () => {
@@ -89,5 +99,85 @@ describe('getS3HostUrl', () => {
     const result = getS3HostUrl('my-test-file.txt');
 
     expect(result).to.equal('s3.host.example.com/test-bucket-name/my-test-file.txt');
+  });
+});
+
+describe('_getS3Client', () => {
+  it('should return an S3 client', () => {
+    process.env.OBJECT_STORE_ACCESS_KEY_ID = 'aaaa';
+    process.env.OBJECT_STORE_SECRET_KEY_ID = 'bbbb';
+
+    const result = _getS3Client();
+    expect(result).to.be.instanceOf(AWS.S3);
+  });
+});
+
+describe('_getClamAvScanner', () => {
+  it('should return a clamAv scanner client', () => {
+    process.env.ENABLE_FILE_VIRUS_SCAN = 'true';
+    process.env.CLAMAV_HOST = 'host';
+    process.env.CLAMAV_PORT = '1111';
+
+    const result = _getClamAvScanner();
+    expect(result).to.not.be.null;
+  });
+
+  it('should return null if enable file virus scan is not set to true', () => {
+    process.env.ENABLE_FILE_VIRUS_SCAN = 'false';
+    process.env.CLAMAV_HOST = 'host';
+    process.env.CLAMAV_PORT = '1111';
+
+    const result = _getClamAvScanner();
+    expect(result).to.be.null;
+  });
+
+  it('should return null if CLAMAV_HOST is not set', () => {
+    process.env.ENABLE_FILE_VIRUS_SCAN = 'true';
+    delete process.env.CLAMAV_HOST;
+    process.env.CLAMAV_PORT = '1111';
+
+    const result = _getClamAvScanner();
+    expect(result).to.be.null;
+  });
+
+  it('should return null if CLAMAV_PORT is not set', () => {
+    process.env.ENABLE_FILE_VIRUS_SCAN = 'true';
+    process.env.CLAMAV_HOST = 'host';
+    delete process.env.CLAMAV_PORT;
+
+    const result = _getClamAvScanner();
+    expect(result).to.be.null;
+  });
+});
+
+describe('_getObjectStoreBucketName', () => {
+  it('should return an object store bucket name', () => {
+    process.env.OBJECT_STORE_BUCKET_NAME = 'test-bucket1';
+
+    const result = _getObjectStoreBucketName();
+    expect(result).to.equal('test-bucket1');
+  });
+
+  it('should return its default value', () => {
+    delete process.env.OBJECT_STORE_BUCKET_NAME;
+
+    const result = _getObjectStoreBucketName();
+    expect(result).to.equal('');
+  });
+});
+
+describe('_getObjectStoreUrl', () => {
+  it('should return an object store bucket name', () => {
+    process.env.OBJECT_STORE_URL = 'test-url1';
+
+    const result = _getObjectStoreUrl();
+    expect(result).to.equal('test-url1');
+  });
+
+  it('should return its default value', () => {
+    delete process.env.OBJECT_STORE_URL;
+
+    const result = _getObjectStoreUrl();
+    expect(result).to.equal('nrs.objectstore.gov.bc.ca');
   });
 });

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -2,6 +2,7 @@ import AWS from 'aws-sdk';
 import {
   DeleteObjectOutput,
   GetObjectOutput,
+  HeadObjectOutput,
   ListObjectsOutput,
   ManagedUpload,
   Metadata
@@ -115,14 +116,27 @@ export async function getFileFromS3(key: string, versionId?: string): Promise<Ge
 }
 
 /**
- * Fetchs a list of files in S3 at the given path.
+ * Fetchs a list of files in S3 at the given path
  *
  * @export
- * @param {string} path the path in S3
- * @return {*}  {Promise<ListObjectsOutput>}
+ * @param {string} path the path (Prefix) of the directory in S3
+ * @return {*}  {Promise<ListObjectsOutput>} All objects at the given path, also including
+ * the directory itself.
  */
-export async function listFilesFromS3(path: string): Promise<ListObjectsOutput> {
+export const listFilesFromS3 = async (path: string): Promise<ListObjectsOutput> => {
   return S3.listObjects({ Bucket: OBJECT_STORE_BUCKET_NAME, Prefix: path })
+    .promise();
+}
+
+/**
+ * Retrieves all metadata for the given S3 object, including custom HTTP headers.
+ *
+ * @export
+ * @param {string} key the key of the object
+ * @returns {*} {Promise<HeadObjectOutput}
+ */
+export async function getObjectMeta(key: string): Promise<HeadObjectOutput> {
+  return S3.headObject({ Bucket: OBJECT_STORE_BUCKET_NAME, Key: key })
     .promise();
 }
 

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -33,13 +33,13 @@ const S3 = new AWS.S3({
 
 /**
  * Returns the S3 public host URL.
- * 
+ *
  * @export
  * @returns {*} {string}
  */
 export const getS3PublicHostUrl = () => {
-  return `${OBJECT_STORE_URL}/${OBJECT_STORE_BUCKET_NAME}`
-}
+  return `${OBJECT_STORE_URL}/${OBJECT_STORE_BUCKET_NAME}`;
+};
 
 /**
  * Delete a file from S3, based on its key.
@@ -134,9 +134,8 @@ export async function getFileFromS3(key: string, versionId?: string): Promise<Ge
  * the directory itself.
  */
 export const listFilesFromS3 = async (path: string): Promise<ListObjectsOutput> => {
-  return S3.listObjects({ Bucket: OBJECT_STORE_BUCKET_NAME, Prefix: path })
-    .promise();
-}
+  return S3.listObjects({ Bucket: OBJECT_STORE_BUCKET_NAME, Prefix: path }).promise();
+};
 
 /**
  * Retrieves all metadata for the given S3 object, including custom HTTP headers.
@@ -146,8 +145,7 @@ export const listFilesFromS3 = async (path: string): Promise<ListObjectsOutput> 
  * @returns {*} {Promise<HeadObjectOutput}
  */
 export async function getObjectMeta(key: string): Promise<HeadObjectOutput> {
-  return S3.headObject({ Bucket: OBJECT_STORE_BUCKET_NAME, Key: key })
-    .promise();
+  return S3.headObject({ Bucket: OBJECT_STORE_BUCKET_NAME, Key: key }).promise();
 }
 
 /**

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -32,6 +32,16 @@ const S3 = new AWS.S3({
 });
 
 /**
+ * Returns the S3 public host URL.
+ * 
+ * @export
+ * @returns {*} {string}
+ */
+export const getS3PublicHostUrl = () => {
+  return `${OBJECT_STORE_URL}/${OBJECT_STORE_BUCKET_NAME}`
+}
+
+/**
  * Delete a file from S3, based on its key.
  *
  * For potential future reference, for deleting the delete marker of a file in S3:

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -15,10 +15,10 @@ import { SubmissionErrorFromMessageType } from './submission-error';
 /**
  * Local getter for retrieving the ClamAV client.
  *
- * @returns {*} The ClamAV Scanner if `process.env.ENABLE_FILE_VIRUS_SCAN` is set to
+ * @returns {*} {clamd.ClamScanner | null} The ClamAV Scanner if `process.env.ENABLE_FILE_VIRUS_SCAN` is set to
  * 'true' and other appropriate environment variables are set; `null` otherwise.
  */
-const getClamAvScanner = () => {
+const getClamAvScanner = (): clamd.ClamScanner | null => {
   if (process.env.ENABLE_FILE_VIRUS_SCAN === 'true' && process.env.CLAMAV_HOST && process.env.CLAMAV_PORT) {
     return clamd.createScanner(process.env.CLAMAV_HOST, Number(process.env.CLAMAV_PORT));
   }
@@ -29,9 +29,9 @@ const getClamAvScanner = () => {
 /**
  * Local getter for retrieving the S3 client.
  *
- * @returns {*} The S3 client
+ * @returns {*} {AWS.S3} The S3 client
  */
-const getS3Client = () => {
+const getS3Client = (): AWS.S3 => {
   const awsEndpoint = new AWS.Endpoint(getObjectStoreUrl());
 
   return new AWS.S3({
@@ -47,18 +47,18 @@ const getS3Client = () => {
 /**
  * Local getter for retrieving the S3 object store URL.
  *
- * @returns {*} The object store URL
+ * @returns {*} {string} The object store URL
  */
-const getObjectStoreUrl = () => {
+const getObjectStoreUrl = (): string => {
   return process.env.OBJECT_STORE_URL || 'nrs.objectstore.gov.bc.ca';
 };
 
 /**
  * Local getter for retrieving the S3 object store bucket name.
  *
- * @returns {*} The object store bucket name
+ * @returns {*} {string} The object store bucket name
  */
-const getObjectStoreBucketName = () => {
+const getObjectStoreBucketName = (): string => {
   return process.env.OBJECT_STORE_BUCKET_NAME || '';
 };
 
@@ -68,9 +68,9 @@ const getObjectStoreBucketName = () => {
  *
  * @export
  * @param {string} [key] The key to an object in S3
- * @returns {*} {string}
+ * @returns {*} {string} The s3 host URL
  */
-export const getS3HostUrl = (key?: string) => {
+export const getS3HostUrl = (key?: string): string => {
   // Appends the given S3 object key, trimming any trailing '/' characters
   return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/*$/, '');
 };

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -72,7 +72,7 @@ const getObjectStoreBucketName = (): string => {
  */
 export const getS3HostUrl = (key?: string): string => {
   // Appends the given S3 object key, trimming any trailing '/' characters
-  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/*$/, '');
+  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/+?$/, '');
 };
 
 /**

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -72,8 +72,8 @@ const getObjectStoreBucketName = (): string => {
  */
 export const getS3HostUrl = (key?: string): string => {
   // Appends the given S3 object key, trimming any trailing '/' characters
-  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/+?$/, '');
-};
+  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/+$/, '');
+};3
 
 /**
  * Delete a file from S3, based on its key.

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -12,14 +12,25 @@ import { S3_ROLE } from '../constants/roles';
 import { SUBMISSION_MESSAGE_TYPE } from '../constants/status';
 import { SubmissionErrorFromMessageType } from './submission-error';
 
+/**
+ * Local getter for retrieving the ClamAV client.
+ *
+ * @returns {*} The ClamAV Scanner if `process.env.ENABLE_FILE_VIRUS_SCAN` is set to
+ * 'true' and other appropriate environment variables are set; `null` otherwise.
+ */
 const getClamAvScanner = () => {
   if (process.env.ENABLE_FILE_VIRUS_SCAN === 'true' && process.env.CLAMAV_HOST && process.env.CLAMAV_PORT) {
-    return clamd.createScanner(process.env.CLAMAV_HOST, Number(process.env.CLAMAV_PORT))
+    return clamd.createScanner(process.env.CLAMAV_HOST, Number(process.env.CLAMAV_PORT));
   }
 
   return null;
-}
+};
 
+/**
+ * Local getter for retrieving the S3 client.
+ *
+ * @returns {*} The S3 client
+ */
 const getS3Client = () => {
   const awsEndpoint = new AWS.Endpoint(getObjectStoreUrl());
 
@@ -31,15 +42,25 @@ const getS3Client = () => {
     s3ForcePathStyle: true,
     region: 'ca-central-1'
   });
-}
+};
 
+/**
+ * Local getter for retrieving the S3 object store URL.
+ *
+ * @returns {*} The object store URL
+ */
 const getObjectStoreUrl = () => {
   return process.env.OBJECT_STORE_URL || 'nrs.objectstore.gov.bc.ca';
-}
+};
 
+/**
+ * Local getter for retrieving the S3 object store bucket name.
+ *
+ * @returns {*} The object store bucket name
+ */
 const getObjectStoreBucketName = () => {
   return process.env.OBJECT_STORE_BUCKET_NAME || '';
-}
+};
 
 /**
  * Returns the S3 host URL. It optionally takes an S3 key as a parameter, which produces
@@ -90,14 +111,16 @@ export async function uploadFileToS3(
 ): Promise<ManagedUpload.SendData> {
   const s3Client = getS3Client();
 
-  return s3Client.upload({
-    Bucket: getObjectStoreBucketName(),
-    Body: file.buffer,
-    ContentType: file.mimetype,
-    Key: key,
-    ACL: S3_ROLE.AUTH_READ,
-    Metadata: metadata
-  }).promise();
+  return s3Client
+    .upload({
+      Bucket: getObjectStoreBucketName(),
+      Body: file.buffer,
+      ContentType: file.mimetype,
+      Key: key,
+      ACL: S3_ROLE.AUTH_READ,
+      Metadata: metadata
+    })
+    .promise();
 }
 
 export async function uploadBufferToS3(
@@ -108,14 +131,15 @@ export async function uploadBufferToS3(
 ): Promise<ManagedUpload.SendData> {
   const s3Client = getS3Client();
 
-  return s3Client.upload({
-    Bucket: getObjectStoreBucketName(),
-    Body: buffer,
-    ContentType: mimetype,
-    Key: key,
-    ACL: S3_ROLE.AUTH_READ,
-    Metadata: metadata
-  })
+  return s3Client
+    .upload({
+      Bucket: getObjectStoreBucketName(),
+      Body: buffer,
+      ContentType: mimetype,
+      Key: key,
+      ACL: S3_ROLE.AUTH_READ,
+      Metadata: metadata
+    })
     .promise()
     .catch(() => {
       throw SubmissionErrorFromMessageType(SUBMISSION_MESSAGE_TYPE.FAILED_UPLOAD_FILE_TO_S3);
@@ -133,11 +157,12 @@ export async function uploadBufferToS3(
 export async function getFileFromS3(key: string, versionId?: string): Promise<GetObjectOutput> {
   const s3Client = getS3Client();
 
-  return s3Client.getObject({
-    Bucket: getObjectStoreBucketName(),
-    Key: key,
-    VersionId: versionId
-  })
+  return s3Client
+    .getObject({
+      Bucket: getObjectStoreBucketName(),
+      Key: key,
+      VersionId: versionId
+    })
     .promise()
     .catch(() => {
       throw SubmissionErrorFromMessageType(SUBMISSION_MESSAGE_TYPE.FAILED_GET_FILE_FROM_S3);

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -71,9 +71,9 @@ const getObjectStoreBucketName = (): string => {
  * @returns {*} {string} The s3 host URL
  */
 export const getS3HostUrl = (key?: string): string => {
-  // Appends the given S3 object key, trimming any trailing '/' characters
-  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/+$/, '');
-};3
+  // Appends the given S3 object key, trimming between 0 and 2 trailing '/' characters
+  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/{0,2}$/, '');
+};
 
 /**
  * Delete a file from S3, based on its key.

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -71,7 +71,8 @@ const getObjectStoreBucketName = () => {
  * @returns {*} {string}
  */
 export const getS3HostUrl = (key?: string) => {
-  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}${key ? `/${key}` : ''}`;
+  // Appends the given S3 object key, trimming any trailing '/' characters
+  return `${getObjectStoreUrl()}/${getObjectStoreBucketName()}/${key || ''}`.replace(/\/*$/, '');
 };
 
 /**

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -1,5 +1,11 @@
 import AWS from 'aws-sdk';
-import { DeleteObjectOutput, GetObjectOutput, ManagedUpload, Metadata } from 'aws-sdk/clients/s3';
+import {
+  DeleteObjectOutput,
+  GetObjectOutput,
+  ListObjectsOutput,
+  ManagedUpload,
+  Metadata
+} from 'aws-sdk/clients/s3';
 import clamd from 'clamdjs';
 import { S3_ROLE } from '../constants/roles';
 import { SUBMISSION_MESSAGE_TYPE } from '../constants/status';
@@ -106,6 +112,18 @@ export async function getFileFromS3(key: string, versionId?: string): Promise<Ge
     .catch(() => {
       throw SubmissionErrorFromMessageType(SUBMISSION_MESSAGE_TYPE.FAILED_GET_FILE_FROM_S3);
     });
+}
+
+/**
+ * Fetchs a list of files in S3 at the given path.
+ *
+ * @export
+ * @param {string} path the path in S3
+ * @return {*}  {Promise<ListObjectsOutput>}
+ */
+export async function listFilesFromS3(path: string): Promise<ListObjectsOutput> {
+  return S3.listObjects({ Bucket: OBJECT_STORE_BUCKET_NAME, Prefix: path })
+    .promise();
 }
 
 /**

--- a/app/src/features/resources/ResourcesPage.test.tsx
+++ b/app/src/features/resources/ResourcesPage.test.tsx
@@ -16,12 +16,10 @@ const mockBiohubApi = ((useBiohubApi as unknown) as jest.Mock<typeof mockUseBioh
 );
 
 const renderContainer = () => {
-  return render(
-    <ResourcesPage />
-  );
+  return render(<ResourcesPage />);
 };
 
-describe('ResourcesPage', () => {  
+describe('ResourcesPage', () => {
   beforeEach(() => {
     // clear mocks before each test
     mockBiohubApi().resources.listResources.mockClear();

--- a/app/src/features/resources/ResourcesPage.test.tsx
+++ b/app/src/features/resources/ResourcesPage.test.tsx
@@ -1,11 +1,131 @@
-import { render } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import { IListResourcesResponse } from 'interfaces/useResourcesApi.interface';
 import React from 'react';
 import ResourcesPage from './ResourcesPage';
 
-describe('ResourcesPage', () => {
-  it('renders correctly', () => {
-    const { getByTestId } = render(<ResourcesPage />);
+jest.mock('../../hooks/useBioHubApi');
+const mockUseBiohubApi = {
+  resources: {
+    listResources: jest.fn<Promise<IListResourcesResponse>, []>()
+  }
+};
+
+const mockBiohubApi = ((useBiohubApi as unknown) as jest.Mock<typeof mockUseBiohubApi>).mockReturnValue(
+  mockUseBiohubApi
+);
+
+const renderContainer = () => {
+  return render(
+    <ResourcesPage />
+  );
+};
+
+describe('ResourcesPage', () => {  
+  beforeEach(() => {
+    // clear mocks before each test
+    mockBiohubApi().resources.listResources.mockClear();
+
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows 'No Resources Available' when there are no active users", async () => {
+    mockBiohubApi().resources.listResources.mockResolvedValue(({
+      files: []
+    } as unknown) as IListResourcesResponse);
+
+    const { getByText } = renderContainer();
+
+    await waitFor(() => {
+      expect(getByText('Resources')).toBeVisible();
+    });
+
+    expect(getByText('No Resources Available')).toBeVisible();
+  });
+
+  it('renders the initial default page correctly', async () => {
+    mockBiohubApi().resources.listResources.mockResolvedValue(({
+      files: [
+        {
+          fileName: 'key1',
+          url: 'host.example.com/key1',
+          lastModified: new Date().toISOString(),
+          fileSize: 10000,
+          metadata: {
+            templateName: 'template1',
+            templateType: 'template-type',
+            species: 'species'
+          }
+        },
+        {
+          fileName: 'key2',
+          url: 'host.example.com/key2',
+          lastModified: new Date().toISOString(),
+          fileSize: 10000,
+          metadata: {
+            templateName: 'template2',
+            templateType: 'template-type',
+            species: 'species'
+          }
+        }
+      ]
+    } as unknown) as IListResourcesResponse);
+
+    const { getByText, queryByText, getAllByText, getByTestId } = renderContainer();
+
+    await waitFor(() => {
+      expect(getByText('Resources')).toBeVisible();
+    });
 
     expect(getByTestId('resources-table')).toBeInTheDocument();
+    expect(getByText('template1')).toBeVisible();
+    expect(getByText('template2')).toBeVisible();
+    expect(getByText('template1').getAttribute('href')).toEqual('https://host.example.com/key1');
+    expect(getByText('template2').getAttribute('href')).toEqual('https://host.example.com/key2');
+    expect(queryByText('key1')).not.toBeInTheDocument();
+    expect(queryByText('key2')).not.toBeInTheDocument();
+    expect(getAllByText('template-type').length).toEqual(2);
+    expect(getAllByText('template-type')[0]).toBeVisible();
+    expect(getAllByText('template-type')[1]).toBeVisible();
+  });
+
+  it('renders templates with missing metadata', async () => {
+    mockBiohubApi().resources.listResources.mockResolvedValue(({
+      files: [
+        {
+          fileName: 'key1',
+          url: 'host.example.com/key1',
+          lastModified: new Date().toISOString(),
+          fileSize: 10000,
+          metadata: {}
+        },
+        {
+          fileName: 'key2',
+          url: 'host.example.com/key2',
+          lastModified: new Date().toISOString(),
+          fileSize: 10000,
+          metadata: {}
+        }
+      ]
+    } as unknown) as IListResourcesResponse);
+
+    const { getByText, getAllByText, getByTestId } = renderContainer();
+
+    await waitFor(() => {
+      expect(getByText('Resources')).toBeVisible();
+    });
+
+    expect(getByTestId('resources-table')).toBeInTheDocument();
+    expect(getByText('key1')).toBeVisible();
+    expect(getByText('key2')).toBeVisible();
+    expect(getByText('key1').getAttribute('href')).toEqual('https://host.example.com/key1');
+    expect(getByText('key2').getAttribute('href')).toEqual('https://host.example.com/key2');
+    expect(getAllByText('Other').length).toEqual(2);
+    expect(getAllByText('Other')[0]).toBeVisible();
+    expect(getAllByText('Other')[1]).toBeVisible();
   });
 });

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -79,17 +79,18 @@ const ResourcesPage: React.FC = () => {
               resources.map((row: IResourceFile) => {
                 const { templateType } = row.metadata;
                 const templateName = row.metadata.templateName || row.fileName;
+                const downloadUrl = ensureProtocol(row.url, 'https://')
 
                 return (
                   <TableRow key={row.url}>
                     <TableCell>
-                      <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }}>
+                      <Link href={downloadUrl} underline="always" style={{ fontWeight: 700 }}>
                         {templateName}
                       </Link>
                     </TableCell>
                     <TableCell>{templateType || 'Other'}</TableCell>
                     <TableCell align="center">
-                      <IconButton href={row.url} aria-label={`Download ${templateName}`}>
+                      <IconButton href={downloadUrl} aria-label={`Download ${templateName}`}>
                         <Icon path={mdiTrayArrowDown} size={0.8} />
                       </IconButton>
                     </TableCell>

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -49,7 +49,7 @@ const ResourcesPage: React.FC = () => {
 
   resourcesDataLoader.load();
 
-  const resources: IResourceFile[] = resourcesDataLoader.data?.files || []; 
+  const resources: IResourceFile[] = resourcesDataLoader.data?.files || [];
 
   if (!resourcesDataLoader.isReady || resourcesDataLoader.isLoading) {
     return <CircularProgress className="pageProgress" size={40} />;
@@ -77,13 +77,13 @@ const ResourcesPage: React.FC = () => {
               </TableRow>
             ) : (
               resources.map((row: IResourceFile) => {
-                const { templateType } = row.metadata
+                const { templateType } = row.metadata;
                 const templateName = row.metadata.templateName || row.fileName;
 
                 return (
                   <TableRow key={row.url}>
                     <TableCell>
-                      <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }} >
+                      <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }}>
                         {templateName}
                       </Link>
                     </TableCell>

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -69,12 +69,12 @@ const ResourcesPage: React.FC = () => {
             </TableRow>
           </TableHead>
           <TableBody data-testid="resources-table">
-            {resources?.map((row: IResourceFile, index: number) => {
+            {resources.map((row: IResourceFile) => {
               const { templateType } = row.metadata
               const templateName = row.metadata.templateName || row.fileName;
 
               return (
-                <TableRow key={`${templateName}-${index}`}>
+                <TableRow key={row.url}>
                   <TableCell>
                     <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }} >
                       {templateName}

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -15,6 +15,8 @@ import Typography from '@material-ui/core/Typography';
 import { mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
 import { ConfigContext } from 'contexts/configContext';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import useDataLoader from 'hooks/useDataLoader';
 import React, { useContext } from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -41,6 +43,15 @@ const useStyles = makeStyles((theme: Theme) => ({
 const ResourcesPage: React.FC = () => {
   const classes = useStyles();
   const config = useContext(ConfigContext);
+  
+  const biohubApi = useBiohubApi();
+  const resourcesDataLoader = useDataLoader(() => biohubApi.resources.listResources());
+
+  resourcesDataLoader.load();
+  
+  /**
+   * @deprecated
+   */
   const s3PublicHostURL = config?.S3_PUBLIC_HOST_URL;
 
   const resources = [

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -79,7 +79,7 @@ const ResourcesPage: React.FC = () => {
               resources.map((row: IResourceFile) => {
                 const { templateType } = row.metadata;
                 const templateName = row.metadata.templateName || row.fileName;
-                const downloadUrl = ensureProtocol(row.url, 'https://')
+                const downloadUrl = ensureProtocol(row.url, 'https://');
 
                 return (
                   <TableRow key={row.url}>

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -14,10 +14,11 @@ import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import { mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
-import { ConfigContext } from 'contexts/configContext';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
-import React, { useContext } from 'react';
+import { IResourceFile } from 'interfaces/useResourcesApi.interface';
+import React from 'react';
+import { ensureProtocol } from 'utils/Utils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   pageTitleContainer: {
@@ -42,132 +43,12 @@ const useStyles = makeStyles((theme: Theme) => ({
  */
 const ResourcesPage: React.FC = () => {
   const classes = useStyles();
-  const config = useContext(ConfigContext);
-  
   const biohubApi = useBiohubApi();
   const resourcesDataLoader = useDataLoader(() => biohubApi.resources.listResources());
 
   resourcesDataLoader.load();
-  
-  /**
-   * @deprecated
-   */
-  const s3PublicHostURL = config?.S3_PUBLIC_HOST_URL;
 
-  const resources = [
-    {
-      id: '13',
-      name: 'Deer Aerial Non Stratified Random Block Recruit Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Deer_Aerial_NonStratifiedRandomBlock_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Deer',
-      fileSize: '108 KB'
-    },
-    {
-      id: '14',
-      name: 'Deer Ground Transect Recruit Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Deer_Ground_Transect_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Deer',
-      fileSize: '114 KB'
-    },
-    {
-      id: '10',
-      name: 'Elk Aerial Stratified Random Block Recruit Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Elk_Aerial_StratifiedRandomBlock_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Elk',
-      fileSize: '122 KB'
-    },
-    {
-      id: '11',
-      name: 'Elk Aerial Non Stratified Random Block Recruit Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Elk_Aerial_NonStratifiedRandomBlock_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Elk',
-      fileSize: '120 KB'
-    },
-    {
-      id: '12',
-      name: 'Elk Aerial Transect Distance Sampling Recruit Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Elk_Aerial_Transect_DistanceSampling_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Elk',
-      fileSize: '114 KB'
-    },
-    {
-      id: '9',
-      name: 'Elk Summary Results Template 1.0',
-      url: `${s3PublicHostURL}/templates/Elk_Summary_Results_1.0.xlsx`,
-      type: 'Summary Results Template',
-      species: 'Elk',
-      fileSize: '24 KB'
-    },
-    {
-      id: '8',
-      name: 'Goat Summary Results Template 1.0',
-      url: `${s3PublicHostURL}/templates/Goat_Summary_Results_1.0.xlsx`,
-      type: 'Summary Results Template',
-      species: 'Mountain Goat',
-      fileSize: '27 KB'
-    },
-    {
-      id: '1',
-      name: 'Moose Aerial Non-SRB Recruitment Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Moose_Aerial_NonStratifiedRandomBlock_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Alces americanus, Moose',
-      fileSize: '145 KB'
-    },
-    {
-      id: '2',
-      name: 'Moose Aerial Stratified Random Block Recruitment Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Moose_Aerial_StratifiedRandomBlock_Recruit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Alces americanus, Moose',
-      fileSize: '143 KB'
-    },
-    {
-      id: '3',
-      name: 'Moose Aerial Transect Distance Sampling Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Moose_Aerial_Transect_Distance_Sampling_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Alces americanus, Moose',
-      fileSize: '143 KB'
-    },
-    {
-      id: '6',
-      name: 'Moose Summary Results Template 1.0',
-      url: `${s3PublicHostURL}/templates/Moose_Summary_Results_1.0.xlsx`,
-      type: 'Summary Results Template',
-      species: 'Alces americanus, Moose',
-      fileSize: '27 KB'
-    },
-    {
-      id: '5',
-      name: 'Mountain Goat Aerial Total Count Recruitment Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Goat_Aerial_Population_Total_Count_Recuit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Mountain Goat',
-      fileSize: '100 KB'
-    },
-    {
-      id: '4',
-      name: 'Sheep Aerial Total Count Recruitment Composition Survey 1.0',
-      url: `${s3PublicHostURL}/templates/Sheep_Aerial_Population_Total_Count_Recuit_Comp_Survey_1.0.xlsx`,
-      type: 'Field Data Template',
-      species: 'Sheep',
-      fileSize: '131 KB'
-    },
-    {
-      id: '7',
-      name: 'Sheep Summary Results Template 1.0',
-      url: `${s3PublicHostURL}/templates/Sheep_Summary_Results_1.0.xlsx`,
-      type: 'Summary Results Template',
-      species: 'Sheep',
-      fileSize: '24 KB'
-    }
-  ];
+  const resources: IResourceFile[] = resourcesDataLoader.data?.files || []; 
 
   const getResourcesList = () => {
     return (
@@ -183,21 +64,25 @@ const ResourcesPage: React.FC = () => {
             </TableRow>
           </TableHead>
           <TableBody data-testid="resources-table">
-            {resources?.map((row) => (
-              <TableRow key={row.id}>
-                <TableCell>
-                  <Link href={row.url} underline="always" style={{ fontWeight: 700 }}>
-                    {row.name}
-                  </Link>
-                </TableCell>
-                <TableCell>{row.type}</TableCell>
-                <TableCell align="center">
-                  <IconButton href={row.url} aria-label={'Download ' + row.name}>
-                    <Icon path={mdiTrayArrowDown} size={0.8} />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
+            {resources?.map((row: IResourceFile, index: number) => {
+              const { templateType } = row.metadata
+              const templateName = row.metadata.templateName || row.fileName;
+
+              return (
+                <TableRow key={`${templateName}-${index}`}>
+                  <TableCell>
+                    <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }} >
+                      {templateName}
+                    </Link>
+                  </TableCell>
+                  <TableCell>{templateType || 'Other'}</TableCell>
+                  <TableCell align="center">
+                    <IconButton href={row.url} aria-label={`Download ${templateName}`}>
+                      <Icon path={mdiTrayArrowDown} size={0.8} />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              )})}
           </TableBody>
         </Table>
       </TableContainer>

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -69,25 +69,34 @@ const ResourcesPage: React.FC = () => {
             </TableRow>
           </TableHead>
           <TableBody data-testid="resources-table">
-            {resources.map((row: IResourceFile) => {
-              const { templateType } = row.metadata
-              const templateName = row.metadata.templateName || row.fileName;
+            {resources.length === 0 ? (
+              <TableRow data-testid={'resources-row-0'}>
+                <TableCell colSpan={3} style={{ textAlign: 'center' }}>
+                  No Resources Available
+                </TableCell>
+              </TableRow>
+            ) : (
+              resources.map((row: IResourceFile) => {
+                const { templateType } = row.metadata
+                const templateName = row.metadata.templateName || row.fileName;
 
-              return (
-                <TableRow key={row.url}>
-                  <TableCell>
-                    <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }} >
-                      {templateName}
-                    </Link>
-                  </TableCell>
-                  <TableCell>{templateType || 'Other'}</TableCell>
-                  <TableCell align="center">
-                    <IconButton href={row.url} aria-label={`Download ${templateName}`}>
-                      <Icon path={mdiTrayArrowDown} size={0.8} />
-                    </IconButton>
-                  </TableCell>
-                </TableRow>
-              )})}
+                return (
+                  <TableRow key={row.url}>
+                    <TableCell>
+                      <Link href={ensureProtocol(row.url, 'https://')} underline="always" style={{ fontWeight: 700 }} >
+                        {templateName}
+                      </Link>
+                    </TableCell>
+                    <TableCell>{templateType || 'Other'}</TableCell>
+                    <TableCell align="center">
+                      <IconButton href={row.url} aria-label={`Download ${templateName}`}>
+                        <Icon path={mdiTrayArrowDown} size={0.8} />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/app/src/features/resources/ResourcesPage.tsx
+++ b/app/src/features/resources/ResourcesPage.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 import IconButton from '@material-ui/core/IconButton';
@@ -49,6 +50,10 @@ const ResourcesPage: React.FC = () => {
   resourcesDataLoader.load();
 
   const resources: IResourceFile[] = resourcesDataLoader.data?.files || []; 
+
+  if (!resourcesDataLoader.isReady || resourcesDataLoader.isLoading) {
+    return <CircularProgress className="pageProgress" size={40} />;
+  }
 
   const getResourcesList = () => {
     return (

--- a/app/src/hooks/api/useResourcesApi.test.ts
+++ b/app/src/hooks/api/useResourcesApi.test.ts
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import useResourcesApi from './useResourcesApi';
+
+describe('useResourcesApi', () => {
+  let mock: any;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('listResources works as expected for an empty list', async () => {
+    mock.onGet('/api/resources/list').reply(200, {
+      files: []
+    });
+
+    const result = await useResourcesApi(axios).listResources();
+
+    expect(result).toEqual({ files: [] });
+  });
+
+  it('listResources works as expected for a non-empty list', async () => {
+    mock.onGet('/api/resources/list').reply(200, {
+      files: [
+        {
+          fileName: 'filename',
+          url: 'url',
+          lastModified: 'lastmodified',
+          fileSize: 10,
+          metadata: {
+            templateName: 'templatename',
+            templateType: 'templatetype',
+            species: 'species'
+          }
+        }
+      ]
+    });
+
+    const result = await useResourcesApi(axios).listResources();
+
+    expect(result.files).toBeDefined();
+    expect(result.files.length).toEqual(1);
+    expect(result.files[0]).toEqual({
+      fileName: 'filename',
+      url: 'url',
+      lastModified: 'lastmodified',
+      fileSize: 10,
+      metadata: {
+        templateName: 'templatename',
+        templateType: 'templatetype',
+        species: 'species'
+      }
+    });
+  });
+});

--- a/app/src/hooks/api/useResourcesApi.ts
+++ b/app/src/hooks/api/useResourcesApi.ts
@@ -1,0 +1,27 @@
+import { AxiosInstance } from 'axios';
+import { IListResourcesResponse } from 'interfaces/useResourcesApi.interface';
+
+/**
+ * Returns a list of all resources
+ *
+ * @param {AxiosInstance} axios
+ * @return {*} object whose properties are supported api methods.
+ */
+const useResourcesApi = (axios: AxiosInstance) => {
+  /**
+   * Fetch all resources.
+   *
+   * @return {*}  {Promise<IListResourcesResponse>}
+   */
+  const listResources = async (): Promise<IListResourcesResponse> => {
+    const { data } = await axios.get('/api/resources/list');
+
+    return data;
+  };
+
+  return {
+    listResources
+  };
+};
+
+export default useResourcesApi;

--- a/app/src/hooks/useBioHubApi.ts
+++ b/app/src/hooks/useBioHubApi.ts
@@ -8,6 +8,7 @@ import useDraftApi from './api/useDraftApi';
 import useExternalApi from './api/useExternalApi';
 import useObservationApi from './api/useObservationApi';
 import useProjectApi from './api/useProjectApi';
+import useResourcesApi from './api/useResourcesApi';
 import useSearchApi from './api/useSearchApi';
 import useSurveyApi from './api/useSurveyApi';
 import useTaxonomyApi from './api/useTaxonomyApi';
@@ -40,6 +41,8 @@ export const useBiohubApi = () => {
 
   const observation = useObservationApi(apiAxios);
 
+  const resources = useResourcesApi(apiAxios);
+
   const external = useExternalApi(axios);
 
   return {
@@ -48,6 +51,7 @@ export const useBiohubApi = () => {
     taxonomy,
     survey,
     observation,
+    resources,
     codes,
     draft,
     user,

--- a/app/src/interfaces/useResourcesApi.interface.ts
+++ b/app/src/interfaces/useResourcesApi.interface.ts
@@ -1,0 +1,17 @@
+/**
+ * A single resource
+ *
+ * @TODO
+ * @export
+ * @interface IResource
+ */
+export interface IResource {
+  //
+}
+
+/**
+ * @TODO jsdoc
+ */
+export interface IListResourcesResponse {
+  files: any[]
+}

--- a/app/src/interfaces/useResourcesApi.interface.ts
+++ b/app/src/interfaces/useResourcesApi.interface.ts
@@ -19,40 +19,40 @@ export interface IResourceFile {
   url: string;
   /**
    * The size of the file (in bytes)
-   * 
+   *
    * @memberof IResourceFile
    */
   fileSize: number;
   /**
    * Resource metadata for the file
-   * 
+   *
    * @memberof IResourceFile
    */
-  metadata: IResourceMetadata
+  metadata: IResourceMetadata;
 }
 
 /**
  * Resource file metadata
- * 
+ *
  * @export
  * @interface IResourceMetadata
  */
 export interface IResourceMetadata {
   /**
    * The name of the template
-   * 
+   *
    * @memberof IResourceMetadata
    */
   templateName: string;
   /**
    * The type of resource template
-   * 
+   *
    * @memberof IResourceMetadata
    */
   templateType: string;
   /**
    * (Optional) The species pertaining to this particular resource
-   * 
+   *
    * @memberof IResourceMetadata
    */
   species?: string;
@@ -67,8 +67,8 @@ export interface IResourceMetadata {
 export interface IListResourcesResponse {
   /**
    * An array of resource files
-   * 
+   *
    * @memberof IListResourcesResponse
    */
-  files: IResourceFile[]
+  files: IResourceFile[];
 }

--- a/app/src/interfaces/useResourcesApi.interface.ts
+++ b/app/src/interfaces/useResourcesApi.interface.ts
@@ -6,6 +6,12 @@
  */
 export interface IResourceFile {
   /**
+   * The name of the file
+   *
+   * @memberof IResourceFile
+   */
+  fileName: string;
+  /**
    * The URL (key) of the file
    *
    * @memberof IResourceFile

--- a/app/src/interfaces/useResourcesApi.interface.ts
+++ b/app/src/interfaces/useResourcesApi.interface.ts
@@ -1,17 +1,68 @@
 /**
- * A single resource
+ * A single resource file.
  *
- * @TODO
  * @export
- * @interface IResource
+ * @interface IResourceFile
  */
-export interface IResource {
-  //
+export interface IResourceFile {
+  /**
+   * The URL (key) of the file
+   *
+   * @memberof IResourceFile
+   */
+  url: string;
+  /**
+   * The size of the file (in bytes)
+   * 
+   * @memberof IResourceFile
+   */
+  fileSize: number;
+  /**
+   * Resource metadata for the file
+   * 
+   * @memberof IResourceFile
+   */
+  metadata: IResourceMetadata
 }
 
 /**
- * @TODO jsdoc
+ * Resource file metadata
+ * 
+ * @export
+ * @interface IResourceMetadata
+ */
+export interface IResourceMetadata {
+  /**
+   * The name of the template
+   * 
+   * @memberof IResourceMetadata
+   */
+  templateName: string;
+  /**
+   * The type of resource template
+   * 
+   * @memberof IResourceMetadata
+   */
+  templateType: string;
+  /**
+   * (Optional) The species pertaining to this particular resource
+   * 
+   * @memberof IResourceMetadata
+   */
+  species?: string;
+}
+
+/**
+ * List resources endpoint response object.
+ *
+ * @export
+ * @interface IListResourcesResponse
  */
 export interface IListResourcesResponse {
-  files: any[]
+  /**
+   * An array of resource files
+   * 
+   * @memberof IListResourcesResponse
+   */
+  files: IResourceFile[]
 }

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -1,11 +1,13 @@
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { IConfig } from 'contexts/configContext';
+import { SYSTEM_IDENTITY_SOURCE } from 'hooks/useKeycloakWrapper';
 import {
   ensureProtocol,
   getFormattedAmount,
   getFormattedDate,
   getFormattedDateRangeString,
   getFormattedFileSize,
+  getFormattedIdentitySource,
   getLogOutUrl
 } from './Utils';
 
@@ -128,7 +130,7 @@ describe('getLogOutUrl', () => {
         clientId: ''
       },
       SITEMINDER_LOGOUT_URL: 'https://www.siteminderlogout.com'
-    };
+    } as IConfig;
 
     expect(getLogOutUrl(config)).toBeUndefined();
   });
@@ -145,7 +147,7 @@ describe('getLogOutUrl', () => {
         clientId: ''
       },
       SITEMINDER_LOGOUT_URL: 'https://www.siteminderlogout.com'
-    };
+    } as IConfig;
 
     expect(getLogOutUrl(config)).toBeUndefined();
   });
@@ -162,7 +164,7 @@ describe('getLogOutUrl', () => {
         clientId: ''
       },
       SITEMINDER_LOGOUT_URL: ''
-    };
+    } as IConfig;
 
     expect(getLogOutUrl(config)).toBeUndefined();
   });
@@ -187,7 +189,7 @@ describe('getLogOutUrl', () => {
         clientId: ''
       },
       SITEMINDER_LOGOUT_URL: 'https://www.siteminderlogout.com'
-    };
+    } as IConfig;
 
     expect(getLogOutUrl(config)).toEqual(
       'https://www.siteminderlogout.com?returl=https://www.keycloaklogout.com/auth/realms/myrealm/protocol/openid-connect/logout?redirect_uri=https://biohub.com/&retnow=1'
@@ -197,7 +199,7 @@ describe('getLogOutUrl', () => {
 
 describe('getFormattedFileSize', () => {
   it('returns `0 KB` if no file size exists', async () => {
-    const formattedFileSize = getFormattedFileSize(null as unknown);
+    const formattedFileSize = getFormattedFileSize((null as unknown) as number);
     expect(formattedFileSize).toEqual('0 KB');
   });
 
@@ -214,5 +216,37 @@ describe('getFormattedFileSize', () => {
   it('returns answer in GB if fileSize >= 1000000000', async () => {
     const formattedFileSize = getFormattedFileSize(1000000000);
     expect(formattedFileSize).toEqual('1.0 GB');
+  });
+});
+
+describe('getFormattedIdentitySource', () => {
+  it('returns BCeID Basic', () => {
+    const result = getFormattedIdentitySource(SYSTEM_IDENTITY_SOURCE.BCEID_BASIC);
+
+    expect(result).toEqual('BCeID Basic');
+  });
+
+  it('returns BCeID Business', () => {
+    const result = getFormattedIdentitySource(SYSTEM_IDENTITY_SOURCE.BCEID_BUSINESS);
+
+    expect(result).toEqual('BCeID Business');
+  });
+
+  it('returns IDIR', () => {
+    const result = getFormattedIdentitySource(SYSTEM_IDENTITY_SOURCE.IDIR);
+
+    expect(result).toEqual('IDIR');
+  });
+
+  it('returns null for unknown identity source', () => {
+    const result = getFormattedIdentitySource('__default_test_string' as SYSTEM_IDENTITY_SOURCE);
+
+    expect(result).toEqual(null);
+  });
+
+  it('returns null for null identity source', () => {
+    const result = getFormattedIdentitySource((null as unknown) as SYSTEM_IDENTITY_SOURCE);
+
+    expect(result).toEqual(null);
   });
 });


### PR DESCRIPTION
# Overview
Render live S3 bucket contents on the Resources page.

Guide for updating templates: https://apps.nrs.gov.bc.ca/int/confluence/display/TASHIS/Updating+Resource+Templates

## Links to Jira tickets

 - https://quartech.atlassian.net/browse/BHBC-2076

## Description of relevant changes

 - Adds a new endpoint and API hook for retreiving S3 files through the backend;
 - Removes hardcoded links to S3 from the Resources page;
 - Adds helper functions for retrieving lists of files for a given S3 folder
 - Replaces globally-scoped variables in the file utils module with appropriate getters

## PR Checklist

### Code

- [x] New files/classes/functions have appropriately descriptive names and comment blocks to describe their use/behaviour
- [x] I have avoided duplicating code when possible, moving re-usable pieces into functions
- [x] I have avoided hard-coding values where possible and moved any re-usable constants to a constants file
- [x] My code is as flat as possible (avoids deeply nested if/else blocks, promise chains, etc)
- [x] My code changes account for null/undefined values and handle errors appropriately
- [x] My code uses types/interfaces to help describe values/parameters/etc, help ensure type safety, and improve readability

### Style

- [x] My code follows the established style conventions
- [x] My code uses native material-ui components/icons/conventions when possible

### Documentation

- [x] I have commented my code sufficiently, such that an unfamiliar developer could understand my code
- [x] I have added/updated README's and related documentation, as needed

### Tests

- [x] I have added/updated unit tests for any code I've added/updated
- [x] I have added/updated the Postman requests/tests to account for any API endpoints I've added/updated

### Linting/Formatting

- [x] I have run the linter and fixed any issues, as needed  
       _See the `lint` commands in package.json_
- [x] I have run the formatter and fixed any issues, as needed  
       _See the `format` commands in package.json_

### SonarCloud

- [x] I have addressed all SonarCloud Bugs, Vulnerabilities, Security Hotspots, and Code Smells
