### PR TITLE
Bug fix: Wire up survey purpose in the surveys list

### DIFF
--- a/app/src/components/surveys/SurveysList.tsx
+++ b/app/src/components/surveys/SurveysList.tsx
@@ -8,6 +8,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
+import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
 import { SurveyViewObject } from 'interfaces/useSurveyApi.interface';
 import React, { useState } from 'react';
 
@@ -20,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export interface ISurveysListProps {
   surveysList: SurveyViewObject[];
   projectId: number;
+  codes: IGetAllCodeSetsResponse;
 }
 
 const SurveysList: React.FC<ISurveysListProps> = (props) => {
@@ -54,7 +56,12 @@ const SurveysList: React.FC<ISurveysListProps> = (props) => {
                   <TableCell>
                     {[...row.species?.focal_species_names, ...row.species?.ancillary_species_names].join(', ')}
                   </TableCell>
-                  <TableCell>Community Composition</TableCell>
+                  <TableCell>
+                    {row.purpose_and_methodology.intended_outcome_id &&
+                      props.codes?.intended_outcomes?.find(
+                        (item: any) => item.id === row.purpose_and_methodology.intended_outcome_id
+                      )?.name}
+                  </TableCell>
                 </TableRow>
               ))}
             {!props.surveysList.length && (

--- a/app/src/features/projects/view/ProjectPage.tsx
+++ b/app/src/features/projects/view/ProjectPage.tsx
@@ -85,7 +85,7 @@ const ProjectPage: React.FC = () => {
             <Grid item md={12} lg={8}>
               <Box mb={3}>
                 <Paper elevation={0}>
-                  <SurveysListPage projectForViewData={projectWithDetails} />
+                  <SurveysListPage projectForViewData={projectWithDetails} codes={codes}/>
                 </Paper>
               </Box>
               <Box mb={3}>

--- a/app/src/features/projects/view/ProjectPage.tsx
+++ b/app/src/features/projects/view/ProjectPage.tsx
@@ -85,7 +85,7 @@ const ProjectPage: React.FC = () => {
             <Grid item md={12} lg={8}>
               <Box mb={3}>
                 <Paper elevation={0}>
-                  <SurveysListPage projectForViewData={projectWithDetails} codes={codes}/>
+                  <SurveysListPage projectForViewData={projectWithDetails} codes={codes} />
                 </Paper>
               </Box>
               <Box mb={3}>

--- a/app/src/features/surveys/list/SurveysListPage.tsx
+++ b/app/src/features/surveys/list/SurveysListPage.tsx
@@ -5,6 +5,7 @@ import Icon from '@mdi/react';
 import SurveysList from 'components/surveys/SurveysList';
 import { H2ButtonToolbar } from 'components/toolbar/ActionToolbars';
 import { useBiohubApi } from 'hooks/useBioHubApi';
+import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
 import { IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
 import { SurveyViewObject } from 'interfaces/useSurveyApi.interface';
 import React, { useEffect, useState } from 'react';
@@ -12,6 +13,7 @@ import { useHistory } from 'react-router';
 
 export interface ISurveysListPageProps {
   projectForViewData: IGetProjectForViewResponse;
+  codes: IGetAllCodeSetsResponse;
 }
 
 /**
@@ -23,7 +25,7 @@ const SurveysListPage: React.FC<ISurveysListPageProps> = (props) => {
   const history = useHistory();
   const biohubApi = useBiohubApi();
 
-  const { projectForViewData } = props;
+  const { projectForViewData, codes } = props;
 
   const [surveys, setSurveys] = useState<SurveyViewObject[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -59,7 +61,7 @@ const SurveysListPage: React.FC<ISurveysListPageProps> = (props) => {
       />
       <Divider></Divider>
       <Box px={1}>
-        <SurveysList projectId={projectForViewData.id} surveysList={surveys} />
+        <SurveysList projectId={projectForViewData.id} surveysList={surveys} codes={codes} />
       </Box>
     </>
   );


### PR DESCRIPTION
In the surveysList the survey purpose was hardcoded to 'Community Composition'.

Fix:
* bring in the codes to map the intended outcome code to its name