### PR TITLE
BHBC-2226: Amend write path in S3 for survey attachments

### DIFF
--- a/api/src/services/attachment-service.test.ts
+++ b/api/src/services/attachment-service.test.ts
@@ -12,7 +12,6 @@ import {
   ISurveyAttachment,
   ISurveyReportAttachment
 } from '../repositories/attachment-repository';
-import * as file_utils from '../utils/file-utils';
 import { getMockDBConnection } from '../__mocks__/db';
 import { AttachmentService } from './attachment-service';
 chai.use(sinonChai);
@@ -125,14 +124,10 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe('upsertProjectAttachment', () => {
+      describe.only('upsertProjectAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getProjectAttachmentByFileName')
@@ -142,21 +137,24 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'updateProjectAttachment')
             .resolves({ id: 1, revision_count: 1 });
 
-          const response = await service.upsertProjectAttachment(({} as unknown) as Express.Multer.File, 1, 'string');
+          const response = await service.upsertProjectAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            'string'
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/file.test'
+          });
         });
 
         it('should insert and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getProjectAttachmentByFileName')
@@ -166,12 +164,19 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'insertProjectAttachment')
             .resolves({ id: 1, revision_count: 1 });
 
-          const response = await service.upsertProjectAttachment(({} as unknown) as Express.Multer.File, 1, 'string');
+          const response = await service.upsertProjectAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            'string'
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/file.test'
+          });
         });
       });
 
@@ -370,14 +375,10 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe('upsertProjectReportAttachment', () => {
+      describe.only('upsertProjectReportAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getProjectReportAttachmentByFileName')
@@ -395,26 +396,29 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'insertProjectReportAttachmentAuthor')
             .resolves();
 
-          const response = await service.upsertProjectReportAttachment(({} as unknown) as Express.Multer.File, 1, {
-            title: 'string',
-            authors: [{ first_name: 'first', last_name: 'last' }]
-          });
+          const response = await service.upsertProjectReportAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            {
+              title: 'string',
+              authors: [{ first_name: 'first', last_name: 'last' }]
+            }
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
           expect(serviceStub3).to.be.calledOnce;
           expect(serviceStub4).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/reports/file.test'
+          });
         });
 
         it('should insert and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getProjectReportAttachmentByFileName')
@@ -432,17 +436,24 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'insertProjectReportAttachmentAuthor')
             .resolves();
 
-          const response = await service.upsertProjectReportAttachment(({} as unknown) as Express.Multer.File, 1, {
-            title: 'string',
-            authors: [{ first_name: 'first', last_name: 'last' }]
-          });
+          const response = await service.upsertProjectReportAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            {
+              title: 'string',
+              authors: [{ first_name: 'first', last_name: 'last' }]
+            }
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
           expect(serviceStub3).to.be.calledOnce;
           expect(serviceStub4).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/reports/file.test'
+          });
         });
       });
 
@@ -612,14 +623,10 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe('upsertSurveyAttachment', () => {
+      describe.only('upsertSurveyAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getSurveyReportAttachmentByFileName')
@@ -629,21 +636,25 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'updateSurveyAttachment')
             .resolves({ id: 1, revision_count: 1 });
 
-          const response = await service.upsertSurveyAttachment(({} as unknown) as Express.Multer.File, 1, 1, 'string');
+          const response = await service.upsertSurveyAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            1,
+            'string'
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/surveys/1/file.test'
+          });
         });
 
         it('should insert and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getSurveyReportAttachmentByFileName')
@@ -653,12 +664,20 @@ describe('AttachmentService', () => {
             .stub(AttachmentService.prototype, 'insertSurveyAttachment')
             .resolves({ id: 1, revision_count: 1 });
 
-          const response = await service.upsertSurveyAttachment(({} as unknown) as Express.Multer.File, 1, 1, 'string');
+          const response = await service.upsertSurveyAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            1,
+            'string'
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/surveys/1/file.test'
+          });
         });
       });
     });
@@ -819,14 +838,10 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe('upsertSurveyReportAttachment', () => {
+      describe.only('upsertSurveyReportAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getSurveyReportAttachmentByFileName')
@@ -842,26 +857,30 @@ describe('AttachmentService', () => {
 
           const serviceStub4 = sinon.stub(AttachmentService.prototype, 'insertSurveyReportAttachmentAuthor').resolves();
 
-          const response = await service.upsertSurveyReportAttachment(({} as unknown) as Express.Multer.File, 1, 1, {
-            title: 'string',
-            authors: [{ first_name: 'first', last_name: 'last' }]
-          });
+          const response = await service.upsertSurveyReportAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            1,
+            {
+              title: 'string',
+              authors: [{ first_name: 'first', last_name: 'last' }]
+            }
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
           expect(serviceStub3).to.be.calledOnce;
           expect(serviceStub4).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/surveys/1/reports/file.test'
+          });
         });
 
         it('should insert and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
-
-          const data = { id: 1, revision_count: 1, key: 'key' };
-
-          const fileStub = sinon.stub(file_utils, 'generateS3FileKey').returns('key');
 
           const serviceStub1 = sinon
             .stub(AttachmentService.prototype, 'getSurveyReportAttachmentByFileName')
@@ -877,17 +896,25 @@ describe('AttachmentService', () => {
 
           const serviceStub4 = sinon.stub(AttachmentService.prototype, 'insertSurveyReportAttachmentAuthor').resolves();
 
-          const response = await service.upsertSurveyReportAttachment(({} as unknown) as Express.Multer.File, 1, 1, {
-            title: 'string',
-            authors: [{ first_name: 'first', last_name: 'last' }]
-          });
+          const response = await service.upsertSurveyReportAttachment(
+            ({ originalname: 'file.test' } as unknown) as Express.Multer.File,
+            1,
+            1,
+            {
+              title: 'string',
+              authors: [{ first_name: 'first', last_name: 'last' }]
+            }
+          );
 
           expect(serviceStub1).to.be.calledOnce;
           expect(serviceStub2).to.be.calledOnce;
           expect(serviceStub3).to.be.calledOnce;
           expect(serviceStub4).to.be.calledOnce;
-          expect(fileStub).to.be.calledOnce;
-          expect(response).to.eql(data);
+          expect(response).to.eql({
+            id: 1,
+            revision_count: 1,
+            key: 'projects/1/surveys/1/reports/file.test'
+          });
         });
       });
 

--- a/api/src/services/attachment-service.test.ts
+++ b/api/src/services/attachment-service.test.ts
@@ -124,7 +124,7 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe.only('upsertProjectAttachment', () => {
+      describe('upsertProjectAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
@@ -375,7 +375,7 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe.only('upsertProjectReportAttachment', () => {
+      describe('upsertProjectReportAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
@@ -623,7 +623,7 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe.only('upsertSurveyAttachment', () => {
+      describe('upsertSurveyAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);
@@ -838,7 +838,7 @@ describe('AttachmentService', () => {
         });
       });
 
-      describe.only('upsertSurveyReportAttachment', () => {
+      describe('upsertSurveyReportAttachment', () => {
         it('should update and return { id: number; revision_count: number; key: string }', async () => {
           const dbConnection = getMockDBConnection();
           const service = new AttachmentService(dbConnection);

--- a/api/src/services/attachment-service.ts
+++ b/api/src/services/attachment-service.ts
@@ -539,8 +539,7 @@ export class AttachmentService extends DBService {
     const key = generateS3FileKey({
       projectId: projectId,
       surveyId: surveyId,
-      fileName: file.originalname,
-      folder: 'reports'
+      fileName: file.originalname
     });
 
     const getResponse = await this.getSurveyReportAttachmentByFileName(surveyId, file.originalname);


### PR DESCRIPTION
# Overview
non-report survey attachments are being saved to a `.../reports directory` in S3.

## Links to Jira tickets

 - https://quartech.atlassian.net/browse/BHBC-2226

## Description of relevant changes

 - Changed where survey attachments get saved in S3
 - Increased test coverage to asset the correct save path in S3 for project and survey attachments and non-report attachments
