### PR TITLE
BHBC-1955: Summary Messages Update

### DIFF
--- a/api/src/repositories/summary-repository.test.ts
+++ b/api/src/repositories/summary-repository.test.ts
@@ -352,10 +352,12 @@ describe('SummaryRepository', () => {
 
     it('should throw Submission error `Failed to find validation rules` when no species is found', async () => {
       const mockResponse = ({
-        rowCount: 1, 
-        rows: [{
-          wldtaxonomic_units_id: null
-        }]
+        rowCount: 1,
+        rows: [
+          {
+            wldtaxonomic_units_id: null
+          }
+        ]
       } as any) as Promise<QueryResult<any>>;
       const dbConnection = getMockDBConnection({ knex: () => mockResponse });
 

--- a/api/src/repositories/summary-repository.test.ts
+++ b/api/src/repositories/summary-repository.test.ts
@@ -375,6 +375,31 @@ describe('SummaryRepository', () => {
         );
       }
     });
+
+    it('should run without species specified', async () => {
+      const mockResponse = ({
+        rows: ([
+          {
+            summary_template_species_id: 1,
+            summary_template_id: 1,
+            wldtaxonomic_units_id: 1,
+            validation: 'validation_schema',
+            create_user: 1,
+            revision_count: 1
+          }
+        ] as unknown) as ISummarySubmissionMessagesResponse[]
+      } as any) as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      sinon
+        .stub(SummaryRepository.prototype, 'getSummaryTemplateIdFromNameVersion')
+        .resolves({ summary_template_id: 1 });
+
+      const repo = new SummaryRepository(dbConnection);
+      const response = await repo.getSummaryTemplateSpeciesRecords('templateName', 'templateVersion');
+
+      expect(response).to.be.eql((await mockResponse).rows);
+    });
   });
 
   describe('insertSummarySubmissionMessage', () => {

--- a/api/src/repositories/summary-repository.ts
+++ b/api/src/repositories/summary-repository.ts
@@ -428,6 +428,20 @@ export class SummaryRepository extends BaseRepository {
       throw failedToFindValidationRulesError;
     }
 
+    // check if the species in the survey and the species on the template match
+    if (species) {
+      if (!response.rows.some((row) => species.includes(Number(row.wldtaxonomic_units_id)))) {
+        throw new SummarySubmissionError({
+          messages: [
+            new MessageError(
+              SUMMARY_SUBMISSION_MESSAGE_TYPE.FAILED_GET_VALIDATION_RULES,
+              'The focal species imported from this template does not match the focal species selected for this survey.'
+            )
+          ]
+        });
+      }
+    }
+
     return response.rows;
   }
 

--- a/api/src/services/summary-service.test.ts
+++ b/api/src/services/summary-service.test.ts
@@ -801,14 +801,7 @@ describe('SummaryService', () => {
               col: 'Effort & Effects'
             }
           ],
-          rowErrors: [
-            {
-              errorCode: SUBMISSION_MESSAGE_TYPE.INVALID_VALUE,
-              message: 'Invalid Value',
-              col: 'Block SU',
-              row: 1
-            }
-          ]
+          rowErrors: []
         }
       ];
       const mediaState: IMediaState = {
@@ -821,7 +814,7 @@ describe('SummaryService', () => {
       } catch (error) {
         if (error instanceof SummarySubmissionError) {
           error.summarySubmissionMessages.forEach((e) => {
-            expect(e.type).to.be.eql(SUMMARY_SUBMISSION_MESSAGE_TYPE.INVALID_VALUE);
+            expect(e.type).to.be.eql(SUMMARY_SUBMISSION_MESSAGE_TYPE.MISSING_REQUIRED_HEADER);
           });
         }
       }

--- a/api/src/services/summary-service.ts
+++ b/api/src/services/summary-service.ts
@@ -338,7 +338,7 @@ export class SummaryService extends DBService {
       csvStateItem.headerErrors?.forEach((headerError) => {
         errors.push(
           new MessageError(
-            SUMMARY_SUBMISSION_MESSAGE_TYPE.INVALID_VALUE,
+            SUMMARY_SUBMISSION_MESSAGE_TYPE.MISSING_REQUIRED_HEADER,
             this.generateHeaderErrorMessage(csvStateItem.fileName, headerError),
             headerError.errorCode
           )

--- a/app/src/features/surveys/view/SurveySummaryResults.tsx
+++ b/app/src/features/surveys/view/SurveySummaryResults.tsx
@@ -199,8 +199,12 @@ const SurveySummaryResults = () => {
       label: 'Unexpected formats in the values provided'
     },
     miscellaneous: { type: ['Miscellaneous'], label: 'Miscellaneous errors exist in your file' },
+    user_error: {
+      type: ['Failed to Get Validation Rules'],
+      label: 'Failed to get validation rules'
+    },
     system_error: {
-      type: ['Missing Validation Schema', 'Failed to Get Validation Rules'],
+      type: ['Missing Validation Schema'],
       label: 'Contact your system administrator'
     }
   };


### PR DESCRIPTION
# Overview

## Description of relevant changes

- updated message type for missing header
- added check that survey species and template species line up properly

## Testing
### Scenario 1
- Get a summary template upsert script from [biohubbc-utils](https://github.com/bcgov/biohubbc-utils)
- Open DBeaver and run the summary template scripts
- Start SIMS 
- download a summary template from the resources 
- Create Project/ Survey
- Open summary template from resources page and remove an entire column
- Upload modified file and see `Mandatory fields have not been filled` error

### Scenario 2
- Get a summary template upsert script from [biohubbc-utils](https://github.com/bcgov/biohubbc-utils)
- Open DBeaver and run the summary template scripts
- Start SIMS 
- download a summary template from the resources 
- Create Project/ Survey
- Upload a summary template intended for a different species than the one in the survey and see `Failed to get validation rules` error



### Code

- [ ] New files/classes/functions have appropriately descriptive names and comment blocks to describe their use/behaviour
- [ ] I have avoided duplicating code when possible, moving re-usable pieces into functions
- [ ] I have avoided hard-coding values where possible and moved any re-usable constants to a constants file
- [ ] My code is as flat as possible (avoids deeply nested if/else blocks, promise chains, etc)
- [ ] My code changes account for null/undefined values and handle errors appropriately
- [ ] My code uses types/interfaces to help describe values/parameters/etc, help ensure type safety, and improve readability

### Style

- [ ] My code follows the established style conventions
- [ ] My code uses native material-ui components/icons/conventions when possible

### Documentation

- [ ] I have commented my code sufficiently, such that an unfamiliar developer could understand my code
- [ ] I have added/updated README's and related documentation, as needed

### Tests

- [ ] I have added/updated unit tests for any code I've added/updated
- [ ] I have added/updated the Postman requests/tests to account for any API endpoints I've added/updated

### Linting/Formatting

- [ ] I have run the linter and fixed any issues, as needed  
       _See the `lint` commands in package.json_
- [ ] I have run the formatter and fixed any issues, as needed  
       _See the `format` commands in package.json_

### SonarCloud

- [ ] I have addressed all SonarCloud Bugs, Vulnerabilities, Security Hotspots, and Code Smells
