### PR TITLE
BHBC-2271: Create Project Context

### DIFF
--- a/app/src/contexts/projectContext.tsx
+++ b/app/src/contexts/projectContext.tsx
@@ -1,0 +1,81 @@
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import useDataLoader, { DataLoader } from 'hooks/useDataLoader';
+import { IGetProjectAttachmentsResponse, IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
+import React, { createContext, PropsWithChildren, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router';
+
+/**
+ * Context object that stores information about a project
+ *
+ * @export
+ * @interface IProjectContext
+ */
+export interface IProjectContext {
+  /**
+   * The Data Loader used to load project data
+   *
+   * @type {DataLoader<[project_id: number, project_id: number], IGetProjectForViewResponse, unknown>}
+   * @memberof IProjectContext
+   */
+  projectDataLoader: DataLoader<[project_id: number], IGetProjectForViewResponse, unknown>;
+
+  /**
+   * The Data Loader used to load project data
+   *
+   * @type {DataLoader<[project_id: number], IGetProjectAttachmentsResponse, unknown>}
+   * @memberof IProjectContext
+   */
+  artifactDataLoader: DataLoader<[project_id: number], IGetProjectAttachmentsResponse, unknown>;
+
+  /**
+   * The ID belonging to the current project
+   *
+   * @type {number}
+   * @memberof IProjectContext
+   */
+  projectId: number;
+}
+
+export const ProjectContext = createContext<IProjectContext>({
+  projectDataLoader: {} as DataLoader<[project_id: number], IGetProjectForViewResponse, unknown>,
+  artifactDataLoader: {} as DataLoader<[project_id: number], IGetProjectAttachmentsResponse, unknown>,
+  projectId: -1
+});
+
+export const ProjectContextProvider = (props: PropsWithChildren<Record<never, any>>) => {
+  const biohubApi = useBiohubApi();
+  const projectDataLoader = useDataLoader(biohubApi.project.getProjectForView);
+  const artifactDataLoader = useDataLoader(biohubApi.project.getProjectAttachments);
+  const urlParams = useParams();
+
+  if (!urlParams['id']) {
+    throw new Error(
+      "The project ID found in ProjectContextProvider was invalid. Does your current React route provide an 'id' parameter?"
+    );
+  }
+
+  const projectId = Number(urlParams['id']);
+
+  /**
+   * Refreshes the current project object whenever the current project ID changes
+   */
+  useEffect(() => {
+    if (projectId && projectId) {
+      projectDataLoader.refresh(projectId);
+      artifactDataLoader.refresh(projectId);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const projectContext: IProjectContext = useMemo(
+    () => ({
+      projectDataLoader,
+      artifactDataLoader,
+      projectId
+    }),
+    [projectDataLoader, artifactDataLoader, projectId]
+  );
+
+  return <ProjectContext.Provider value={projectContext}>{props.children}</ProjectContext.Provider>;
+};

--- a/app/src/contexts/projectContext.tsx
+++ b/app/src/contexts/projectContext.tsx
@@ -60,7 +60,7 @@ export const ProjectContextProvider = (props: PropsWithChildren<Record<never, an
    * Refreshes the current project object whenever the current project ID changes
    */
   useEffect(() => {
-    if (projectId && projectId) {
+    if (projectId) {
       projectDataLoader.refresh(projectId);
       artifactDataLoader.refresh(projectId);
     }

--- a/app/src/features/projects/view/ProjectPage.tsx
+++ b/app/src/features/projects/view/ProjectPage.tsx
@@ -3,13 +3,14 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
+import { ProjectContext } from 'contexts/projectContext';
 import LocationBoundary from 'features/projects/view/components/LocationBoundary';
 import ProjectAttachments from 'features/projects/view/ProjectAttachments';
 import SurveysListPage from 'features/surveys/list/SurveysListPage';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
 import { IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import ProjectDetails from './ProjectDetails';
 import ProjectHeader from './ProjectHeader';
@@ -29,6 +30,10 @@ const ProjectPage: React.FC = () => {
 
   const [isLoadingCodes, setIsLoadingCodes] = useState(false);
   const [codes, setCodes] = useState<IGetAllCodeSetsResponse>();
+
+  const projectContext = useContext(ProjectContext);
+
+  console.log({ projectContext });
 
   useEffect(() => {
     const getCodes = async () => {

--- a/app/src/routers/ProjectsRouter.tsx
+++ b/app/src/routers/ProjectsRouter.tsx
@@ -40,46 +40,48 @@ const ProjectsRouter: React.FC = () => {
         </ProjectsLayout>
       </AppRoute>
 
-      <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
+      <AppRoute path="/admin/projects/:id">
+        <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
 
-      <ProjectContextProvider>
-        <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>
-          <ProjectsLayout>
+        <ProjectContextProvider>
+          <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>
+            <ProjectsLayout>
+              <ProjectPage />
+            </ProjectsLayout>
+          </AppRoute>
+          
+
+          <AppRoute exact path="/admin/projects/:id/users" layout={ProjectsLayout}>
+            <ProjectsLayout>
+              <ProjectParticipantsPage />
+            </ProjectsLayout>
+          </AppRoute>
+
+          <AppRoute exact path="/admin/projects/:id/surveys" layout={ProjectsLayout}>
+            <ProjectsLayout>
+              <ProjectPage />
+            </ProjectsLayout>
+          </AppRoute>
+
+          <AppRoute path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')} layout={ProjectsLayout}>
+            <SurveyContextProvider>
+              <SurveyRouter />
+            </SurveyContextProvider>
+          </AppRoute>
+
+          <AppRoute exact path="/admin/projects/:id/survey/create" layout={ProjectsLayout}>
+            <CreateSurveyPage />
+          </AppRoute>
+
+          <AppRoute exact path="/admin/projects/:id/survey/edit" layout={ProjectsLayout}>
+            <EditSurveyPage />
+          </AppRoute>
+
+          <AppRoute exact path="/admin/projects/:id/attachments" layout={ProjectsLayout}>
             <ProjectPage />
-          </ProjectsLayout>
-        </AppRoute>
-        
-
-        <AppRoute exact path="/admin/projects/:id/users" layout={ProjectsLayout}>
-          <ProjectsLayout>
-            <ProjectParticipantsPage />
-          </ProjectsLayout>
-        </AppRoute>
-
-        <AppRoute exact path="/admin/projects/:id/surveys" layout={ProjectsLayout}>
-          <ProjectsLayout>
-            <ProjectPage />
-          </ProjectsLayout>
-        </AppRoute>
-
-        <AppRoute path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')} layout={ProjectsLayout}>
-          <SurveyContextProvider>
-            <SurveyRouter />
-          </SurveyContextProvider>
-        </AppRoute>
-
-        <AppRoute exact path="/admin/projects/:id/survey/create" layout={ProjectsLayout}>
-          <CreateSurveyPage />
-        </AppRoute>
-
-        <AppRoute exact path="/admin/projects/:id/survey/edit" layout={ProjectsLayout}>
-          <EditSurveyPage />
-        </AppRoute>
-
-        <AppRoute exact path="/admin/projects/:id/attachments" layout={ProjectsLayout}>
-          <ProjectPage />
-        </AppRoute>
-      </ProjectContextProvider>
+          </AppRoute>
+        </ProjectContextProvider>
+      </AppRoute>
 
       {/*  Catch any unknown routes, and re-direct to the not found page */}
       <AppRoute path="/admin/projects/*">

--- a/app/src/routers/ProjectsRouter.tsx
+++ b/app/src/routers/ProjectsRouter.tsx
@@ -1,3 +1,4 @@
+import { ProjectContextProvider } from 'contexts/projectContext';
 import { SurveyContextProvider } from 'contexts/surveyContext';
 import ProjectPage from 'features/projects/view/ProjectPage';
 import CreateSurveyPage from 'features/surveys/CreateSurveyPage';
@@ -41,41 +42,44 @@ const ProjectsRouter: React.FC = () => {
 
       <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
 
-      <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>
-        <ProjectsLayout>
+      <ProjectContextProvider>
+        <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>
+          <ProjectsLayout>
+            <ProjectPage />
+          </ProjectsLayout>
+        </AppRoute>
+        
+
+        <AppRoute exact path="/admin/projects/:id/users" layout={ProjectsLayout}>
+          <ProjectsLayout>
+            <ProjectParticipantsPage />
+          </ProjectsLayout>
+        </AppRoute>
+
+        <AppRoute exact path="/admin/projects/:id/surveys" layout={ProjectsLayout}>
+          <ProjectsLayout>
+            <ProjectPage />
+          </ProjectsLayout>
+        </AppRoute>
+
+        <AppRoute path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')} layout={ProjectsLayout}>
+          <SurveyContextProvider>
+            <SurveyRouter />
+          </SurveyContextProvider>
+        </AppRoute>
+
+        <AppRoute exact path="/admin/projects/:id/survey/create" layout={ProjectsLayout}>
+          <CreateSurveyPage />
+        </AppRoute>
+
+        <AppRoute exact path="/admin/projects/:id/survey/edit" layout={ProjectsLayout}>
+          <EditSurveyPage />
+        </AppRoute>
+
+        <AppRoute exact path="/admin/projects/:id/attachments" layout={ProjectsLayout}>
           <ProjectPage />
-        </ProjectsLayout>
-      </AppRoute>
-
-      <AppRoute exact path="/admin/projects/:id/users" layout={ProjectsLayout}>
-        <ProjectsLayout>
-          <ProjectParticipantsPage />
-        </ProjectsLayout>
-      </AppRoute>
-
-      <AppRoute exact path="/admin/projects/:id/surveys" layout={ProjectsLayout}>
-        <ProjectsLayout>
-          <ProjectPage />
-        </ProjectsLayout>
-      </AppRoute>
-
-      <AppRoute path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')} layout={ProjectsLayout}>
-        <SurveyContextProvider>
-          <SurveyRouter />
-        </SurveyContextProvider>
-      </AppRoute>
-
-      <AppRoute exact path="/admin/projects/:id/survey/create" layout={ProjectsLayout}>
-        <CreateSurveyPage />
-      </AppRoute>
-
-      <AppRoute exact path="/admin/projects/:id/survey/edit" layout={ProjectsLayout}>
-        <EditSurveyPage />
-      </AppRoute>
-
-      <AppRoute exact path="/admin/projects/:id/attachments" layout={ProjectsLayout}>
-        <ProjectPage />
-      </AppRoute>
+        </AppRoute>
+      </ProjectContextProvider>
 
       {/*  Catch any unknown routes, and re-direct to the not found page */}
       <AppRoute path="/admin/projects/*">

--- a/app/src/routers/ProjectsRouter.tsx
+++ b/app/src/routers/ProjectsRouter.tsx
@@ -40,8 +40,9 @@ const ProjectsRouter: React.FC = () => {
         </ProjectsLayout>
       </AppRoute>
 
+      <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
+
       <AppRoute path="/admin/projects/:id">
-        <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
 
         <ProjectContextProvider>
           <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>

--- a/app/src/routers/ProjectsRouter.tsx
+++ b/app/src/routers/ProjectsRouter.tsx
@@ -43,14 +43,12 @@ const ProjectsRouter: React.FC = () => {
       <Redirect exact from="/admin/projects/:id" to="/admin/projects/:id/details" />
 
       <AppRoute path="/admin/projects/:id">
-
         <ProjectContextProvider>
           <AppRoute exact path="/admin/projects/:id/details" layout={ProjectsLayout}>
             <ProjectsLayout>
               <ProjectPage />
             </ProjectsLayout>
           </AppRoute>
-          
 
           <AppRoute exact path="/admin/projects/:id/users" layout={ProjectsLayout}>
             <ProjectsLayout>


### PR DESCRIPTION
# Overview

Creates a ProjectContext, which wraps project-related app sections, providing a centralized location for fetching/refreshing project data. **As a first pass, components that currently consume project data through props will not consume the ProjectContext.**

## Links to Jira tickets

 - https://quartech.atlassian.net/browse/BHBC-2271

## Description of relevant changes
 - Creates the `useProjectContext` hook
 - Wraps project routes in the `ProjectRouter` with the `ProjectContextProvider`

## Testing
1. Create a Project
2. Enable the Developer Console (press **F12**)
3. Visit the project

You should:
 - [ ] See the project context printed in the console.
 - [ ] See that the project data in `projectContext.projectDataLoader.data` accurately reflects the project data.