### PR TITLE
Various Survey / Project UI Fixes

### DIFF
--- a/app/src/components/attachments/list/AttachmentsList.tsx
+++ b/app/src/components/attachments/list/AttachmentsList.tsx
@@ -46,35 +46,33 @@ const AttachmentsList = <T extends IGetProjectAttachment | IGetSurveyAttachment>
   const [page] = useState(0);
 
   return (
-    <Box>
-      <TableContainer>
-        <Table className={classes.attachmentsTable} aria-label="attachments-list-table">
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell width="150">Type</TableCell>
-              <TableCell></TableCell>
-              <TableCell width="80px"></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {(attachments.length &&
-              attachments.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
-                return (
-                  <AttachmentsTableRow
-                    key={`${row.fileType}-${row.id}`}
-                    attachment={row}
-                    handleDownload={handleDownload}
-                    handleDelete={handleDelete}
-                    handleViewDetails={handleViewDetails}
-                  />
-                );
-              })) || <></>}
-            {(!attachments.length && <NoAttachmentsTableRow />) || <></>}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Box>
+    <TableContainer>
+      <Table className={classes.attachmentsTable} aria-label="attachments-list-table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell width="140">Status</TableCell>
+            <TableCell width="80"></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {(attachments.length &&
+            attachments.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
+              return (
+                <AttachmentsTableRow
+                  key={`${row.fileType}-${row.id}`}
+                  attachment={row}
+                  handleDownload={handleDownload}
+                  handleDelete={handleDelete}
+                  handleViewDetails={handleViewDetails}
+                />
+              );
+            })) || <></>}
+          {(!attachments.length && <NoAttachmentsTableRow />) || <></>}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 };
 
@@ -102,7 +100,7 @@ function AttachmentsTableRow<T extends IGetProjectAttachment | IGetSurveyAttachm
         </Link>
       </TableCell>
       <TableCell>{attachment.fileType}</TableCell>
-      <TableCell align="right">
+      <TableCell>
         <SubmitStatusChip status={getArtifactSubmissionStatus(attachment)} />
       </TableCell>
       <TableCell align="right">
@@ -120,7 +118,7 @@ function AttachmentsTableRow<T extends IGetProjectAttachment | IGetSurveyAttachm
 function NoAttachmentsTableRow() {
   return (
     <TableRow>
-      <TableCell colSpan={3} align="center">
+      <TableCell colSpan={4} align="center">
         <Typography component="strong" color="textSecondary" variant="body2">
           No Documents
         </Typography>

--- a/app/src/components/attachments/list/AttachmentsList.tsx
+++ b/app/src/components/attachments/list/AttachmentsList.tsx
@@ -1,4 +1,3 @@
-import Box from '@material-ui/core/Box';
 import { grey } from '@material-ui/core/colors';
 import Link from '@material-ui/core/Link';
 import makeStyles from '@material-ui/core/styles/makeStyles';

--- a/app/src/components/attachments/list/AttachmentsListItemMenuButton.tsx
+++ b/app/src/components/attachments/list/AttachmentsListItemMenuButton.tsx
@@ -63,9 +63,9 @@ const AttachmentsListItemMenuButton = <T extends IGetProjectAttachment | IGetSur
               }}
               data-testid="attachment-action-menu-download">
               <ListItemIcon>
-                <Icon path={mdiTrayArrowDown} size={0.875} />
+                <Icon path={mdiTrayArrowDown} size={1} />
               </ListItemIcon>
-              Download Document
+              Download
             </MenuItem>
             {props.attachment.fileType === AttachmentType.REPORT && (
               <MenuItem
@@ -75,9 +75,9 @@ const AttachmentsListItemMenuButton = <T extends IGetProjectAttachment | IGetSur
                 }}
                 data-testid="attachment-action-menu-details">
                 <ListItemIcon>
-                  <Icon path={mdiInformationOutline} size={0.8} />
+                  <Icon path={mdiInformationOutline} size={1} />
                 </ListItemIcon>
-                View Document Details
+                View Details
               </MenuItem>
             )}
             <MenuItem
@@ -87,9 +87,9 @@ const AttachmentsListItemMenuButton = <T extends IGetProjectAttachment | IGetSur
               }}
               data-testid="attachment-action-menu-delete">
               <ListItemIcon>
-                <Icon path={mdiTrashCanOutline} size={0.8} />
+                <Icon path={mdiTrashCanOutline} size={1} />
               </ListItemIcon>
-              Delete Document
+              Delete
             </MenuItem>
           </Menu>
         </Box>

--- a/app/src/components/chips/SubmitStatusChip.tsx
+++ b/app/src/components/chips/SubmitStatusChip.tsx
@@ -6,12 +6,12 @@ import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
   chip: {
-    fontSize: '12px'
+    fontSize: '12px',
+    textTransform: 'uppercase'
   },
   chipUnSubmitted: {
     color: '#003366',
-    backgroundColor: '#DCEBFB',
-    textTransform: 'uppercase'
+    backgroundColor: '#DCEBFB'
   },
   chipSubmitted: {
     color: '#2D4821',
@@ -35,7 +35,7 @@ export const SubmitStatusChip: React.FC<{ status: BioHubSubmittedStatusType; chi
     chipStatusClass = classes.chipRejected;
   } else if (props.status === BioHubSubmittedStatusType.SUBMITTED) {
     chipLabel = 'Submitted';
-    chipStatusClass = 'colorSuccess';
+    chipStatusClass = classes.chipSubmitted;
   } else {
     chipLabel = 'Unsubmitted';
     chipStatusClass = classes.chipUnSubmitted;

--- a/app/src/features/projects/view/ProjectHeader.tsx
+++ b/app/src/features/projects/view/ProjectHeader.tsx
@@ -240,17 +240,20 @@ const ProjectHeader: React.FC<IProjectHeaderProps> = (props) => {
             </Box>
             <Box flex="0 0 auto" className={classes.titleActions}>
               <Button
+                id="project_settings-button"
                 variant="outlined"
-                startIcon={<Icon path={mdiCogOutline} size={0.8} />}
-                endIcon={<Icon path={mdiChevronDown} size={0.8} />}
-                aria-controls="simple-menu"
+                startIcon={<Icon path={mdiCogOutline} size={1} />}
+                endIcon={<Icon path={mdiChevronDown} size={1} />}
+                aria-label="Project Settings"
+                aria-controls="projectSettingsMenu"
                 aria-haspopup="true"
                 onClick={handleClick}>
-                Project Settings
+                Settings
               </Button>
               <Menu
-                style={{ marginTop: '8px' }}
                 id="projectSettingsMenu"
+                aria-labelledby="project_settings_button"
+                style={{ marginTop: '8px' }}
                 anchorEl={anchorEl}
                 getContentAnchorEl={null}
                 anchorOrigin={{
@@ -266,20 +269,20 @@ const ProjectHeader: React.FC<IProjectHeaderProps> = (props) => {
                 onClose={handleClose}>
                 <MenuItem onClick={() => history.push('users')}>
                   <ListItemIcon>
-                    <Icon path={mdiAccountMultipleOutline} size={0.8} />
+                    <Icon path={mdiAccountMultipleOutline} size={1} />
                   </ListItemIcon>
                   <Typography variant="inherit">Manage Project Team</Typography>
                 </MenuItem>
                 <MenuItem onClick={() => history.push(`/admin/projects/edit?projectId=${projectWithDetails.id}`)}>
                   <ListItemIcon>
-                    <Icon path={mdiPencilOutline} size={0.8} />
+                    <Icon path={mdiPencilOutline} size={1} />
                   </ListItemIcon>
                   <Typography variant="inherit">Edit Project Details</Typography>
                 </MenuItem>
                 {showDeleteProjectButton && (
                   <MenuItem onClick={showDeleteProjectDialog} data-testid={'delete-project-button'}>
                     <ListItemIcon>
-                      <Icon path={mdiTrashCanOutline} size={0.8} />
+                      <Icon path={mdiTrashCanOutline} size={1} />
                     </ListItemIcon>
                     <Typography variant="inherit">Delete Project</Typography>
                   </MenuItem>

--- a/app/src/features/surveys/view/SurveyAttachments.tsx
+++ b/app/src/features/surveys/view/SurveyAttachments.tsx
@@ -1,7 +1,7 @@
 import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 import Paper from '@material-ui/core/Paper';
-import { mdiTrayArrowUp } from '@mdi/js';
+import { mdiAttachment, mdiChevronDown, mdiFilePdfBox, mdiTrayArrowUp } from '@mdi/js';
 import Icon from '@mdi/react';
 import { IReportMetaForm } from 'components/attachments/ReportMetaForm';
 import FileUploadWithMetaDialog from 'components/dialog/attachments/FileUploadWithMetaDialog';
@@ -55,7 +55,7 @@ const SurveyAttachments: React.FC = () => {
     <>
       <FileUploadWithMetaDialog
         open={openUploadAttachments}
-        dialogTitle={attachmentType === 'Report' ? 'Upload Report' : 'Upload Attachment'}
+        dialogTitle={attachmentType === 'Report' ? 'Upload Report' : 'Upload Attachments'}
         attachmentType={attachmentType}
         onFinish={getFinishHandler()}
         onClose={() => {
@@ -71,14 +71,25 @@ const SurveyAttachments: React.FC = () => {
           buttonTitle="Upload Documents"
           buttonProps={{ variant: 'contained' }}
           buttonStartIcon={<Icon path={mdiTrayArrowUp} size={1} />}
+          buttonEndIcon={<Icon path={mdiChevronDown} size={1} />}
           menuItems={[
-            { menuLabel: 'Add Report', menuOnClick: handleUploadReportClick },
-            { menuLabel: 'Add Attachments', menuOnClick: handleUploadAttachmentClick }
+            {
+              menuLabel: 'Upload a Report',
+              menuIcon: <Icon path={mdiFilePdfBox} size={1} />,
+              menuOnClick: handleUploadReportClick
+            },
+            {
+              menuLabel: 'Upload Attachments',
+              menuIcon: <Icon path={mdiAttachment} size={1} />,
+              menuOnClick: handleUploadAttachmentClick
+            }
           ]}
         />
         <Divider></Divider>
-        <Box px={1}>
-          <SurveyAttachmentsList />
+        <Box p={3}>
+          <Paper variant="outlined">
+            <SurveyAttachmentsList />
+          </Paper>
         </Box>
       </Paper>
     </>

--- a/app/src/features/surveys/view/SurveyAttachmentsList.tsx
+++ b/app/src/features/surveys/view/SurveyAttachmentsList.tsx
@@ -57,8 +57,8 @@ const SurveyAttachmentsList: React.FC = () => {
   const handleDelete = (attachment: IGetSurveyAttachment) => {
     dialogContext.setYesNoDialog({
       open: true,
-      dialogTitle: 'Delete Document',
-      dialogText: 'Are you sure you want to delete the selected document? This action cannot be undone.',
+      dialogTitle: 'Delete Document?',
+      dialogText: 'Are you sure you want to delete this document? This action cannot be undone.',
       yesButtonProps: { color: 'secondary' },
       onYes: async () => {
         try {

--- a/app/src/features/surveys/view/SurveyHeader.test.tsx
+++ b/app/src/features/surveys/view/SurveyHeader.test.tsx
@@ -106,7 +106,7 @@ describe('SurveyHeader', () => {
 
     await waitFor(() => {
       expect(
-        getByText('Are you sure you want to delete this survey, its attachments and associated observations?')
+        getByText('Are you sure you want to delete this survey? This action cannot be undone.')
       ).toBeInTheDocument();
     });
 

--- a/app/src/features/surveys/view/SurveyHeader.tsx
+++ b/app/src/features/surveys/view/SurveyHeader.tsx
@@ -11,6 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import {
   mdiArrowLeft,
   mdiCalendarRangeOutline,
+  mdiChevronDown,
   mdiCogOutline,
   mdiPencilOutline,
   mdiShareAllOutline,
@@ -87,8 +88,8 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
   const [finishSubmission, setFinishSubmission] = useState(false);
 
   const defaultYesNoDialogProps = {
-    dialogTitle: 'Delete Survey',
-    dialogText: 'Are you sure you want to delete this survey, its attachments and associated observations?',
+    dialogTitle: 'Delete Survey?',
+    dialogText: 'Are you sure you want to delete this survey? This action cannot be undone.',
     open: false,
     onClose: () => dialogContext.setYesNoDialog({ open: false }),
     onNo: () => dialogContext.setYesNoDialog({ open: false }),
@@ -111,6 +112,10 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
     dialogContext.setYesNoDialog({
       ...defaultYesNoDialogProps,
       open: true,
+      yesButtonProps: { color: 'secondary' },
+      yesButtonLabel: 'Delete',
+      noButtonProps: { color: 'primary', variant: 'outlined' },
+      noButtonLabel: 'Cancel',
       onYes: () => {
         deleteSurvey();
         dialogContext.setYesNoDialog({ open: false });
@@ -172,7 +177,7 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
       <Paper square={true} elevation={0}>
         <Container maxWidth="xl">
           <Box py={4}>
-            <Box mt={-1} ml={-0.5} mb={1}>
+            <Box mt={-1} ml={-0.5} mb={0.5}>
               <Button
                 color="primary"
                 startIcon={<Icon path={mdiArrowLeft} size={0.9} />}
@@ -204,7 +209,7 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
               <Box display="flex" alignItems="flex-start" flex="0 0 auto" className={classes.pageTitleActions}>
                 <SystemRoleGuard validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
                   <Button
-                    title="Submit Survey Data and Documents"
+                    aria-label="Submit Survey Data and Documents"
                     color="primary"
                     variant="contained"
                     startIcon={<Icon path={mdiShareAllOutline} size={1} />}
@@ -214,18 +219,21 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
                   </Button>
                 </SystemRoleGuard>
                 <Button
-                  variant="outlined"
-                  color="primary"
-                  startIcon={<Icon path={mdiCogOutline} size={1} />}
-                  aria-controls="simple-menu"
+                  id="survey_settings_button"
+                  aria-label="Survey Settings"
+                  aria-controls="surveySettingsMenu"
                   aria-haspopup="true"
+                  variant="outlined"
+                  startIcon={<Icon path={mdiCogOutline} size={1} />}
+                  endIcon={<Icon path={mdiChevronDown} size={1} />}
                   onClick={openSurveyMenu}
                   style={{ marginLeft: '0.5rem' }}>
                   Settings
                 </Button>
                 <Menu
+                  id="surveySettingsMenu"
+                  aria-labelledby="survey_settings_button"
                   style={{ marginTop: '8px' }}
-                  id="projectSettingsMenu"
                   anchorEl={anchorEl}
                   getContentAnchorEl={null}
                   anchorOrigin={{
@@ -246,7 +254,7 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
                       )
                     }>
                     <ListItemIcon>
-                      <Icon path={mdiPencilOutline} size={0.8} />
+                      <Icon path={mdiPencilOutline} size={1} />
                     </ListItemIcon>
                     <Typography variant="inherit">Edit Survey Details</Typography>
                   </MenuItem>
@@ -256,7 +264,7 @@ const SurveyHeader: React.FC<ISurveyHeaderProps> = (props) => {
                       onClick={showDeleteSurveyDialog}
                       disabled={!enableDeleteSurveyButton}>
                       <ListItemIcon>
-                        <Icon path={mdiTrashCanOutline} size={0.8} />
+                        <Icon path={mdiTrashCanOutline} size={1} />
                       </ListItemIcon>
                       <Typography variant="inherit">Delete Survey</Typography>
                     </MenuItem>

--- a/app/src/features/surveys/view/SurveyObservations.tsx
+++ b/app/src/features/surveys/view/SurveyObservations.tsx
@@ -152,7 +152,7 @@ const SurveyObservations: React.FC = () => {
   const defaultDeleteYesNoDialogProps = {
     ...defaultUploadYesNoDialogProps,
     dialogTitle: 'Delete Observations?',
-    dialogText: 'Are you sure you want to delete this file? This action cannot be undone.'
+    dialogText: 'Are you sure you want to delete observation data from this survey? This action cannot be undone.'
   };
 
   const importObservations = (): IUploadHandler => {

--- a/app/src/features/surveys/view/SurveySummaryResults.tsx
+++ b/app/src/features/surveys/view/SurveySummaryResults.tsx
@@ -159,8 +159,9 @@ const SurveySummaryResults = () => {
 
   const defaultDeleteYesNoDialogProps = {
     ...defaultUploadYesNoDialogProps,
-    dialogTitle: 'Delete Summary Results Data',
-    dialogText: 'Are you sure you want to delete this file? This action cannot be undone.'
+    dialogTitle: 'Delete Summary Results Data?',
+    dialogText:
+      'Are you sure you want to delete the summary results data for this survey? This action cannot be undone.'
   };
 
   summaryDataLoader.load();

--- a/app/src/themes/appTheme.ts
+++ b/app/src/themes/appTheme.ts
@@ -119,8 +119,7 @@ const appTheme = createMuiTheme({
       },
       startIcon: {
         marginTop: '1px',
-        marginBottom: '1px',
-        marginRight: '12px'
+        marginBottom: '1px'
       },
       sizeLarge: {
         fontSize: '1rem'


### PR DESCRIPTION
# Overview

## Description of relevant changes

- Fixed issues with inconsistent display of the 'Attachments Menu' across project/survey views
- Updated aria tags, menu icons (chevron) and unique ID's for 'survey settings' and 'project settings' buttons 
- Fixed Attachments List table spacing/alignment issues
- Fixed inconsistent icon sizing in buttons
- Fixed an issue with the 'submitStatusChip' rendering incorrectly when in a submitted state
- Standardized dialog content when removing / deleting observations, summary results, and attachments

## PR Checklist

A list of items that are good to consider when making any changes.

_Note: this list is not exhaustive, and not all items are always applicable._

### Code

- [ ] New files/classes/functions have appropriately descriptive names and comment blocks to describe their use/behaviour
- [ ] I have avoided duplicating code when possible, moving re-usable pieces into functions
- [ ] I have avoided hard-coding values where possible and moved any re-usable constants to a constants file
- [ ] My code is as flat as possible (avoids deeply nested if/else blocks, promise chains, etc)
- [ ] My code changes account for null/undefined values and handle errors appropriately
- [ ] My code uses types/interfaces to help describe values/parameters/etc, help ensure type safety, and improve readability

### Style

- [ ] My code follows the established style conventions
- [ ] My code uses native material-ui components/icons/conventions when possible

### Documentation

- [ ] I have commented my code sufficiently, such that an unfamiliar developer could understand my code
- [ ] I have added/updated README's and related documentation, as needed

### Tests

- [ ] I have added/updated unit tests for any code I've added/updated
- [ ] I have added/updated the Postman requests/tests to account for any API endpoints I've added/updated

### Linting/Formatting

- [ ] I have run the linter and fixed any issues, as needed  
       _See the `lint` commands in package.json_
- [ ] I have run the formatter and fixed any issues, as needed  
       _See the `format` commands in package.json_

### SonarCloud

- [ ] I have addressed all SonarCloud Bugs, Vulnerabilities, Security Hotspots, and Code Smells
