### PR TITLE
BHBC-2194: Data Submitter Sees Their Project That Has Unsubmitted Information

### DIFF
--- a/api/src/paths/project/{projectId}/surveys.test.ts
+++ b/api/src/paths/project/{projectId}/surveys.test.ts
@@ -70,8 +70,8 @@ describe('surveys', () => {
       .resolves([{ id: 1 }]);
 
     const getSurveysByIdsStub = sinon
-      .stub(SurveyService.prototype, 'getSurveysByIds')
-      .resolves([({ survey_details: { id: 1 } } as unknown) as SurveyObject]);
+      .stub(SurveyService.prototype, 'getSurveyById')
+      .resolves(({ survey_details: { id: 1 } } as unknown) as SurveyObject);
 
     const sampleReq = {
       keycloak_token: {},
@@ -81,7 +81,9 @@ describe('surveys', () => {
       }
     } as any;
 
-    const expectedResponse = [{ survey_details: { id: 1 } }];
+    const expectedResponse = [
+      { surveyData: { survey_details: { id: 1 } }, surveySupplementaryData: { survey_metadata_publish: null } }
+    ];
 
     let actualResult: any = null;
     const sampleRes = {

--- a/api/src/paths/project/{projectId}/surveys.ts
+++ b/api/src/paths/project/{projectId}/surveys.ts
@@ -3,8 +3,8 @@ import { Operation } from 'express-openapi';
 import { PROJECT_ROLE, SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { HTTP400 } from '../../../errors/http-error';
+import { SurveySupplementaryData } from '../../../models/survey-view';
 import { geoJsonFeature } from '../../../openapi/schemas/geoJson';
-import { SurveyMetadataPublish } from '../../../repositories/history-publish-repository';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { SurveyService } from '../../../services/survey-service';
 import { getLogger } from '../../../utils/logger';
@@ -54,307 +54,315 @@ GET.apiDoc = {
       content: {
         'application/json': {
           schema: {
-            title: 'Survey get response object, for view purposes',
-            type: 'object',
-            required: ['surveyData', 'surveySupplementaryData'],
-            properties: {
-              surveyData: {
-                type: 'object',
-                required: [
-                  'survey_details',
-                  'species',
-                  'permit',
-                  'funding',
-                  'proprietor',
-                  'purpose_and_methodology',
-                  'location'
-                ],
-                properties: {
-                  survey_details: {
-                    description: 'Survey Details',
-                    type: 'object',
-                    required: [
-                      'survey_name',
-                      'start_date',
-                      'biologist_first_name',
-                      'biologist_last_name',
-                      'revision_count'
-                    ],
-                    properties: {
-                      survey_name: {
-                        type: 'string'
-                      },
-                      start_date: {
-                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                        description: 'ISO 8601 date string for the funding end_date'
-                      },
-                      end_date: {
-                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                        nullable: true,
-                        description: 'ISO 8601 date string for the funding end_date'
-                      },
-                      biologist_first_name: {
-                        type: 'string'
-                      },
-                      biologist_last_name: {
-                        type: 'string'
-                      },
-                      revision_count: {
-                        type: 'number'
-                      }
-                    }
-                  },
-                  species: {
-                    description: 'Survey Species',
-                    type: 'object',
-                    required: ['focal_species', 'focal_species_names', 'ancillary_species', 'ancillary_species_names'],
-                    properties: {
-                      ancillary_species: {
-                        nullable: true,
-                        type: 'array',
-                        items: {
+            type: 'array',
+            items: {
+              title: 'Survey get response object, for view purposes',
+              type: 'object',
+              required: ['surveyData', 'surveySupplementaryData'],
+              properties: {
+                surveyData: {
+                  type: 'object',
+                  required: [
+                    'survey_details',
+                    'species',
+                    'permit',
+                    'funding',
+                    'proprietor',
+                    'purpose_and_methodology',
+                    'location'
+                  ],
+                  properties: {
+                    survey_details: {
+                      description: 'Survey Details',
+                      type: 'object',
+                      required: [
+                        'survey_name',
+                        'start_date',
+                        'biologist_first_name',
+                        'biologist_last_name',
+                        'revision_count'
+                      ],
+                      properties: {
+                        survey_name: {
+                          type: 'string'
+                        },
+                        start_date: {
+                          oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                          description: 'ISO 8601 date string for the funding end_date'
+                        },
+                        end_date: {
+                          oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                          nullable: true,
+                          description: 'ISO 8601 date string for the funding end_date'
+                        },
+                        biologist_first_name: {
+                          type: 'string'
+                        },
+                        biologist_last_name: {
+                          type: 'string'
+                        },
+                        revision_count: {
                           type: 'number'
                         }
-                      },
-                      ancillary_species_names: {
-                        nullable: true,
-                        type: 'array',
-                        items: {
-                          type: 'string'
-                        }
-                      },
-                      focal_species: {
-                        type: 'array',
-                        items: {
-                          type: 'number'
-                        }
-                      },
-                      focal_species_names: {
-                        type: 'array',
-                        items: {
-                          type: 'string'
+                      }
+                    },
+                    species: {
+                      description: 'Survey Species',
+                      type: 'object',
+                      required: [
+                        'focal_species',
+                        'focal_species_names',
+                        'ancillary_species',
+                        'ancillary_species_names'
+                      ],
+                      properties: {
+                        ancillary_species: {
+                          nullable: true,
+                          type: 'array',
+                          items: {
+                            type: 'number'
+                          }
+                        },
+                        ancillary_species_names: {
+                          nullable: true,
+                          type: 'array',
+                          items: {
+                            type: 'string'
+                          }
+                        },
+                        focal_species: {
+                          type: 'array',
+                          items: {
+                            type: 'number'
+                          }
+                        },
+                        focal_species_names: {
+                          type: 'array',
+                          items: {
+                            type: 'string'
+                          }
                         }
                       }
-                    }
-                  },
-                  permit: {
-                    description: 'Survey Permit',
-                    type: 'object',
-                    properties: {
-                      permits: {
-                        type: 'array',
-                        items: {
-                          type: 'object',
-                          required: ['permit_id', 'permit_number', 'permit_type'],
-                          properties: {
-                            permit_id: {
-                              type: 'number',
-                              minimum: 1
-                            },
-                            permit_number: {
-                              type: 'string'
-                            },
-                            permit_type: {
-                              type: 'string'
+                    },
+                    permit: {
+                      description: 'Survey Permit',
+                      type: 'object',
+                      properties: {
+                        permits: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            required: ['permit_id', 'permit_number', 'permit_type'],
+                            properties: {
+                              permit_id: {
+                                type: 'number',
+                                minimum: 1
+                              },
+                              permit_number: {
+                                type: 'string'
+                              },
+                              permit_type: {
+                                type: 'string'
+                              }
                             }
                           }
                         }
                       }
-                    }
-                  },
-                  funding: {
-                    description: 'Survey Funding Sources',
-                    type: 'object',
-                    properties: {
-                      funding_sources: {
-                        type: 'array',
-                        items: {
-                          type: 'object',
-                          required: [
-                            'pfs_id',
-                            'agency_name',
-                            'funding_amount',
-                            'funding_start_date',
-                            'funding_end_date'
-                          ],
-                          properties: {
-                            pfs_id: {
-                              type: 'number',
-                              nullable: true
-                            },
-                            agency_name: {
-                              type: 'string',
-                              nullable: true
-                            },
-                            funding_amount: {
-                              type: 'number',
-                              nullable: true
-                            },
-                            funding_start_date: {
-                              type: 'string',
-                              nullable: true,
-                              description: 'ISO 8601 date string'
-                            },
-                            funding_end_date: {
-                              type: 'string',
-                              nullable: true,
-                              description: 'ISO 8601 date string'
+                    },
+                    funding: {
+                      description: 'Survey Funding Sources',
+                      type: 'object',
+                      properties: {
+                        funding_sources: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            required: [
+                              'pfs_id',
+                              'agency_name',
+                              'funding_amount',
+                              'funding_start_date',
+                              'funding_end_date'
+                            ],
+                            properties: {
+                              pfs_id: {
+                                type: 'number',
+                                nullable: true
+                              },
+                              agency_name: {
+                                type: 'string',
+                                nullable: true
+                              },
+                              funding_amount: {
+                                type: 'number',
+                                nullable: true
+                              },
+                              funding_start_date: {
+                                type: 'string',
+                                nullable: true,
+                                description: 'ISO 8601 date string'
+                              },
+                              funding_end_date: {
+                                type: 'string',
+                                nullable: true,
+                                description: 'ISO 8601 date string'
+                              }
                             }
                           }
                         }
                       }
-                    }
-                  },
-                  purpose_and_methodology: {
-                    description: 'Survey Details',
-                    type: 'object',
-                    required: [
-                      'field_method_id',
-                      'additional_details',
-                      'intended_outcome_id',
-                      'ecological_season_id',
-                      'vantage_code_ids',
-                      'revision_count'
-                    ],
-                    properties: {
-                      field_method_id: {
-                        type: 'number'
-                      },
-                      additional_details: {
-                        type: 'string',
-                        nullable: true
-                      },
-                      intended_outcome_id: {
-                        type: 'number',
-                        nullable: true
-                      },
-                      ecological_season_id: {
-                        type: 'number',
-                        nullable: true
-                      },
-                      vantage_code_ids: {
-                        type: 'array',
-                        items: {
+                    },
+                    purpose_and_methodology: {
+                      description: 'Survey Details',
+                      type: 'object',
+                      required: [
+                        'field_method_id',
+                        'additional_details',
+                        'intended_outcome_id',
+                        'ecological_season_id',
+                        'vantage_code_ids',
+                        'revision_count'
+                      ],
+                      properties: {
+                        field_method_id: {
                           type: 'number'
+                        },
+                        additional_details: {
+                          type: 'string',
+                          nullable: true
+                        },
+                        intended_outcome_id: {
+                          type: 'number',
+                          nullable: true
+                        },
+                        ecological_season_id: {
+                          type: 'number',
+                          nullable: true
+                        },
+                        vantage_code_ids: {
+                          type: 'array',
+                          items: {
+                            type: 'number'
+                          }
                         }
                       }
-                    }
-                  },
-                  proprietor: {
-                    description: 'Survey Proprietor Details',
-                    type: 'object',
-                    nullable: true,
-                    required: [
-                      'category_rationale',
-                      'disa_required',
-                      'first_nations_id',
-                      'first_nations_name',
-                      'proprietor_name',
-                      'proprietor_type_id',
-                      'proprietor_type_name'
-                    ],
-                    properties: {
-                      category_rationale: {
-                        type: 'string'
-                      },
-                      disa_required: {
-                        type: 'boolean'
-                      },
-                      first_nations_id: {
-                        type: 'number',
-                        nullable: true
-                      },
-                      first_nations_name: {
-                        type: 'string',
-                        nullable: true
-                      },
-                      proprietor_name: {
-                        type: 'string'
-                      },
-                      proprietor_type_id: {
-                        type: 'number'
-                      },
-                      proprietor_type_name: {
-                        type: 'string'
+                    },
+                    proprietor: {
+                      description: 'Survey Proprietor Details',
+                      type: 'object',
+                      nullable: true,
+                      required: [
+                        'category_rationale',
+                        'disa_required',
+                        'first_nations_id',
+                        'first_nations_name',
+                        'proprietor_name',
+                        'proprietor_type_id',
+                        'proprietor_type_name'
+                      ],
+                      properties: {
+                        category_rationale: {
+                          type: 'string'
+                        },
+                        disa_required: {
+                          type: 'boolean'
+                        },
+                        first_nations_id: {
+                          type: 'number',
+                          nullable: true
+                        },
+                        first_nations_name: {
+                          type: 'string',
+                          nullable: true
+                        },
+                        proprietor_name: {
+                          type: 'string'
+                        },
+                        proprietor_type_id: {
+                          type: 'number'
+                        },
+                        proprietor_type_name: {
+                          type: 'string'
+                        }
                       }
-                    }
-                  },
-                  location: {
-                    description: 'Survey location Details',
-                    type: 'object',
-                    required: ['survey_area_name', 'geometry'],
-                    properties: {
-                      survey_area_name: {
-                        type: 'string'
-                      },
-                      geometry: {
-                        type: 'array',
-                        items: {
-                          ...(geoJsonFeature as object)
+                    },
+                    location: {
+                      description: 'Survey location Details',
+                      type: 'object',
+                      required: ['survey_area_name', 'geometry'],
+                      properties: {
+                        survey_area_name: {
+                          type: 'string'
+                        },
+                        geometry: {
+                          type: 'array',
+                          items: {
+                            ...(geoJsonFeature as object)
+                          }
                         }
                       }
                     }
                   }
-                }
-              },
-              surveySupplementaryData: {
-                description: 'Survey supplementary data',
-                type: 'object',
-                required: ['survey_metadata_publish'],
-                properties: {
-                  survey_metadata_publish: {
-                    description: 'Survey metadata publish record',
-                    type: 'object',
-                    nullable: true,
-                    required: [
-                      'survey_metadata_publish_id',
-                      'survey_id',
-                      'event_timestamp',
-                      'queue_id',
-                      'create_date',
-                      'create_user',
-                      'update_date',
-                      'update_user',
-                      'revision_count'
-                    ],
-                    properties: {
-                      survey_metadata_publish_id: {
-                        type: 'integer',
-                        minimum: 1
-                      },
-                      survey_id: {
-                        type: 'integer',
-                        minimum: 1
-                      },
-                      event_timestamp: {
-                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                        description: 'ISO 8601 date string for the project start date'
-                      },
-                      queue_id: {
-                        type: 'integer',
-                        minimum: 1
-                      },
-                      create_date: {
-                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                        description: 'ISO 8601 date string for the project start date'
-                      },
-                      create_user: {
-                        type: 'integer',
-                        minimum: 1
-                      },
-                      update_date: {
-                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                        description: 'ISO 8601 date string for the project start date',
-                        nullable: true
-                      },
-                      update_user: {
-                        type: 'integer',
-                        minimum: 1,
-                        nullable: true
-                      },
-                      revision_count: {
-                        type: 'integer',
-                        minimum: 0
+                },
+                surveySupplementaryData: {
+                  description: 'Survey supplementary data',
+                  type: 'object',
+                  required: ['survey_metadata_publish'],
+                  properties: {
+                    survey_metadata_publish: {
+                      description: 'Survey metadata publish record',
+                      type: 'object',
+                      nullable: true,
+                      required: [
+                        'survey_metadata_publish_id',
+                        'survey_id',
+                        'event_timestamp',
+                        'queue_id',
+                        'create_date',
+                        'create_user',
+                        'update_date',
+                        'update_user',
+                        'revision_count'
+                      ],
+                      properties: {
+                        survey_metadata_publish_id: {
+                          type: 'integer',
+                          minimum: 1
+                        },
+                        survey_id: {
+                          type: 'integer',
+                          minimum: 1
+                        },
+                        event_timestamp: {
+                          oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                          description: 'ISO 8601 date string for the project start date'
+                        },
+                        queue_id: {
+                          type: 'integer',
+                          minimum: 1
+                        },
+                        create_date: {
+                          oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                          description: 'ISO 8601 date string for the project start date'
+                        },
+                        create_user: {
+                          type: 'integer',
+                          minimum: 1
+                        },
+                        update_date: {
+                          oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                          description: 'ISO 8601 date string for the project start date',
+                          nullable: true
+                        },
+                        update_user: {
+                          type: 'integer',
+                          minimum: 1,
+                          nullable: true
+                        },
+                        revision_count: {
+                          type: 'integer',
+                          minimum: 0
+                        }
                       }
                     }
                   }
@@ -404,12 +412,28 @@ export function getSurveyList(): RequestHandler {
 
       const surveyIds = surveyIdsResponse.map((item: { id: any }) => item.id);
 
-      const surveys = await surveyIds.map(async (surveyId) => {
-        const survey = await surveyService.getSurveyById(surveyId);
-        const supplementaryData = (null as unknown) as SurveyMetadataPublish;
+      const surveys = await Promise.all(
+        surveyIds.map(async (surveyId) => {
+          const survey = await surveyService.getSurveyById(surveyId);
+          const supplementaryData = ({ survey_metadata_publish: null } as unknown) as SurveySupplementaryData; //hard coded null for testing
 
-        return { SurveyObject: survey, SurveyMetadataPublish: supplementaryData };
-      });
+          // const supplementaryData = ({
+          //   survey_metadata_publish: {
+          //     survey_metadata_publish_id: 1,
+          //     survey_id: 1,
+          //     event_timestamp: '2021-01-01',
+          //     queue_id: 1,
+          //     create_date: '2021-01-01',
+          //     create_user: 1,
+          //     update_date: '2021-01-01',
+          //     update_user: 1,
+          //     revision_count: 1
+          //   }
+          // } as unknown) as SurveySupplementaryData; //Hard coded for now
+
+          return { surveyData: survey, surveySupplementaryData: supplementaryData };
+        })
+      );
 
       await connection.commit();
 

--- a/api/src/paths/project/{projectId}/surveys.ts
+++ b/api/src/paths/project/{projectId}/surveys.ts
@@ -4,6 +4,7 @@ import { PROJECT_ROLE, SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { HTTP400 } from '../../../errors/http-error';
 import { geoJsonFeature } from '../../../openapi/schemas/geoJson';
+import { SurveyMetadataPublish } from '../../../repositories/history-publish-repository';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { SurveyService } from '../../../services/survey-service';
 import { getLogger } from '../../../utils/logger';
@@ -53,242 +54,307 @@ GET.apiDoc = {
       content: {
         'application/json': {
           schema: {
-            type: 'array',
-            items: {
-              title: 'Survey get response object, for view purposes',
-              type: 'object',
-              required: ['survey_details', 'species', 'permit', 'funding', 'purpose_and_methodology', 'proprietor'],
-              properties: {
-                survey_details: {
-                  description: 'Survey Details',
-                  type: 'object',
-                  required: [
-                    'id',
-                    'biologist_first_name',
-                    'biologist_last_name',
-                    'start_date',
-                    'geometry',
-                    'survey_area_name',
-                    'survey_name',
-                    'revision_count'
-                  ],
-                  properties: {
-                    id: {
-                      description: 'Survey id',
-                      type: 'number'
-                    },
-                    biologist_first_name: {
-                      type: 'string'
-                    },
-                    biologist_last_name: {
-                      type: 'string'
-                    },
-                    start_date: {
-                      oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                      description: 'ISO 8601 date string for the funding end_date'
-                    },
-                    end_date: {
-                      oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
-                      nullable: true,
-                      description: 'ISO 8601 date string for the funding end_date'
-                    },
-                    geometry: {
-                      type: 'array',
-                      items: {
-                        ...(geoJsonFeature as object)
-                      }
-                    },
-                    survey_area_name: {
-                      type: 'string'
-                    },
-                    survey_name: {
-                      type: 'string'
-                    },
-                    revision_count: {
-                      type: 'number'
-                    }
-                  }
-                },
-                species: {
-                  description: 'Survey Species',
-                  type: 'object',
-                  required: ['focal_species', 'focal_species_names', 'ancillary_species', 'ancillary_species_names'],
-                  properties: {
-                    ancillary_species: {
-                      nullable: true,
-                      type: 'array',
-                      items: {
+            title: 'Survey get response object, for view purposes',
+            type: 'object',
+            required: ['surveyData', 'surveySupplementaryData'],
+            properties: {
+              surveyData: {
+                type: 'object',
+                required: [
+                  'survey_details',
+                  'species',
+                  'permit',
+                  'funding',
+                  'proprietor',
+                  'purpose_and_methodology',
+                  'location'
+                ],
+                properties: {
+                  survey_details: {
+                    description: 'Survey Details',
+                    type: 'object',
+                    required: [
+                      'survey_name',
+                      'start_date',
+                      'biologist_first_name',
+                      'biologist_last_name',
+                      'revision_count'
+                    ],
+                    properties: {
+                      survey_name: {
+                        type: 'string'
+                      },
+                      start_date: {
+                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                        description: 'ISO 8601 date string for the funding end_date'
+                      },
+                      end_date: {
+                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                        nullable: true,
+                        description: 'ISO 8601 date string for the funding end_date'
+                      },
+                      biologist_first_name: {
+                        type: 'string'
+                      },
+                      biologist_last_name: {
+                        type: 'string'
+                      },
+                      revision_count: {
                         type: 'number'
                       }
-                    },
-                    ancillary_species_names: {
-                      nullable: true,
-                      type: 'array',
-                      items: {
-                        type: 'string'
-                      }
-                    },
-                    focal_species: {
-                      type: 'array',
-                      items: {
-                        type: 'number'
-                      }
-                    },
-                    focal_species_names: {
-                      type: 'array',
-                      items: {
-                        type: 'string'
+                    }
+                  },
+                  species: {
+                    description: 'Survey Species',
+                    type: 'object',
+                    required: ['focal_species', 'focal_species_names', 'ancillary_species', 'ancillary_species_names'],
+                    properties: {
+                      ancillary_species: {
+                        nullable: true,
+                        type: 'array',
+                        items: {
+                          type: 'number'
+                        }
+                      },
+                      ancillary_species_names: {
+                        nullable: true,
+                        type: 'array',
+                        items: {
+                          type: 'string'
+                        }
+                      },
+                      focal_species: {
+                        type: 'array',
+                        items: {
+                          type: 'number'
+                        }
+                      },
+                      focal_species_names: {
+                        type: 'array',
+                        items: {
+                          type: 'string'
+                        }
                       }
                     }
-                  }
-                },
-                permit: {
-                  type: 'object',
-                  description: 'Survey Permit Information',
-                  properties: {
-                    permits: {
-                      description: 'Survey Permits',
-                      type: 'array',
-                      items: {
-                        required: ['permit_id', 'permit_number', 'permit_type'],
-                        properties: {
-                          permit_id: {
-                            type: 'number',
-                            minimum: 1
-                          },
-                          permit_number: {
-                            type: 'string'
-                          },
-                          permit_type: {
-                            type: 'string'
+                  },
+                  permit: {
+                    description: 'Survey Permit',
+                    type: 'object',
+                    properties: {
+                      permits: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          required: ['permit_id', 'permit_number', 'permit_type'],
+                          properties: {
+                            permit_id: {
+                              type: 'number',
+                              minimum: 1
+                            },
+                            permit_number: {
+                              type: 'string'
+                            },
+                            permit_type: {
+                              type: 'string'
+                            }
                           }
                         }
                       }
                     }
-                  }
-                },
-                funding: {
-                  description: 'Survey Funding Sources',
-                  type: 'object',
-                  properties: {
-                    funding_sources: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        required: ['pfs_id', 'agency_name', 'funding_amount', 'funding_start_date', 'funding_end_date'],
-                        properties: {
-                          pfs_id: {
-                            type: 'number',
-                            nullable: true
-                          },
-                          agency_name: {
-                            type: 'string',
-                            nullable: true
-                          },
-                          funding_amount: {
-                            type: 'number',
-                            nullable: true
-                          },
-                          funding_start_date: {
-                            type: 'string',
-                            nullable: true,
-                            description: 'ISO 8601 date string'
-                          },
-                          funding_end_date: {
-                            type: 'string',
-                            nullable: true,
-                            description: 'ISO 8601 date string'
+                  },
+                  funding: {
+                    description: 'Survey Funding Sources',
+                    type: 'object',
+                    properties: {
+                      funding_sources: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          required: [
+                            'pfs_id',
+                            'agency_name',
+                            'funding_amount',
+                            'funding_start_date',
+                            'funding_end_date'
+                          ],
+                          properties: {
+                            pfs_id: {
+                              type: 'number',
+                              nullable: true
+                            },
+                            agency_name: {
+                              type: 'string',
+                              nullable: true
+                            },
+                            funding_amount: {
+                              type: 'number',
+                              nullable: true
+                            },
+                            funding_start_date: {
+                              type: 'string',
+                              nullable: true,
+                              description: 'ISO 8601 date string'
+                            },
+                            funding_end_date: {
+                              type: 'string',
+                              nullable: true,
+                              description: 'ISO 8601 date string'
+                            }
                           }
                         }
                       }
                     }
-                  }
-                },
-                purpose_and_methodology: {
-                  description: 'Survey Details',
-                  type: 'object',
-                  required: [
-                    'field_method_id',
-                    'additional_details',
-                    'intended_outcome_id',
-                    'ecological_season_id',
-                    'vantage_code_ids'
-                  ],
-                  properties: {
-                    field_method_id: {
-                      type: 'number'
-                    },
-                    additional_details: {
-                      type: 'string',
-                      nullable: true
-                    },
-                    intended_outcome_id: {
-                      type: 'number',
-                      nullable: true
-                    },
-                    ecological_season_id: {
-                      type: 'number',
-                      nullable: true
-                    },
-                    vantage_code_ids: {
-                      type: 'array',
-                      items: {
+                  },
+                  purpose_and_methodology: {
+                    description: 'Survey Details',
+                    type: 'object',
+                    required: [
+                      'field_method_id',
+                      'additional_details',
+                      'intended_outcome_id',
+                      'ecological_season_id',
+                      'vantage_code_ids',
+                      'revision_count'
+                    ],
+                    properties: {
+                      field_method_id: {
                         type: 'number'
+                      },
+                      additional_details: {
+                        type: 'string',
+                        nullable: true
+                      },
+                      intended_outcome_id: {
+                        type: 'number',
+                        nullable: true
+                      },
+                      ecological_season_id: {
+                        type: 'number',
+                        nullable: true
+                      },
+                      vantage_code_ids: {
+                        type: 'array',
+                        items: {
+                          type: 'number'
+                        }
+                      }
+                    }
+                  },
+                  proprietor: {
+                    description: 'Survey Proprietor Details',
+                    type: 'object',
+                    nullable: true,
+                    required: [
+                      'category_rationale',
+                      'disa_required',
+                      'first_nations_id',
+                      'first_nations_name',
+                      'proprietor_name',
+                      'proprietor_type_id',
+                      'proprietor_type_name'
+                    ],
+                    properties: {
+                      category_rationale: {
+                        type: 'string'
+                      },
+                      disa_required: {
+                        type: 'boolean'
+                      },
+                      first_nations_id: {
+                        type: 'number',
+                        nullable: true
+                      },
+                      first_nations_name: {
+                        type: 'string',
+                        nullable: true
+                      },
+                      proprietor_name: {
+                        type: 'string'
+                      },
+                      proprietor_type_id: {
+                        type: 'number'
+                      },
+                      proprietor_type_name: {
+                        type: 'string'
+                      }
+                    }
+                  },
+                  location: {
+                    description: 'Survey location Details',
+                    type: 'object',
+                    required: ['survey_area_name', 'geometry'],
+                    properties: {
+                      survey_area_name: {
+                        type: 'string'
+                      },
+                      geometry: {
+                        type: 'array',
+                        items: {
+                          ...(geoJsonFeature as object)
+                        }
                       }
                     }
                   }
-                },
-                proprietor: {
-                  description: 'Survey Proprietor Details',
-                  type: 'object',
-                  nullable: true,
-                  required: [
-                    'category_rationale',
-                    'disa_required',
-                    'first_nations_id',
-                    'first_nations_name',
-                    'proprietor_name',
-                    'proprietor_type_id',
-                    'proprietor_type_name'
-                  ],
-                  properties: {
-                    category_rationale: {
-                      type: 'string'
-                    },
-                    disa_required: {
-                      type: 'boolean'
-                    },
-                    first_nations_id: {
-                      type: 'number',
-                      nullable: true
-                    },
-                    first_nations_name: {
-                      type: 'string',
-                      nullable: true
-                    },
-                    proprietor_name: {
-                      type: 'string'
-                    },
-                    proprietor_type_id: {
-                      type: 'number'
-                    },
-                    proprietor_type_name: {
-                      type: 'string'
-                    }
-                  }
-                },
-                location: {
-                  description: 'Survey location Details',
-                  type: 'object',
-                  required: ['survey_area_name', 'geometry'],
-                  properties: {
-                    survey_area_name: {
-                      type: 'string'
-                    },
-                    geometry: {
-                      type: 'array',
-                      items: {
-                        ...(geoJsonFeature as object)
+                }
+              },
+              surveySupplementaryData: {
+                description: 'Survey supplementary data',
+                type: 'object',
+                required: ['survey_metadata_publish'],
+                properties: {
+                  survey_metadata_publish: {
+                    description: 'Survey metadata publish record',
+                    type: 'object',
+                    nullable: true,
+                    required: [
+                      'survey_metadata_publish_id',
+                      'survey_id',
+                      'event_timestamp',
+                      'queue_id',
+                      'create_date',
+                      'create_user',
+                      'update_date',
+                      'update_user',
+                      'revision_count'
+                    ],
+                    properties: {
+                      survey_metadata_publish_id: {
+                        type: 'integer',
+                        minimum: 1
+                      },
+                      survey_id: {
+                        type: 'integer',
+                        minimum: 1
+                      },
+                      event_timestamp: {
+                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                        description: 'ISO 8601 date string for the project start date'
+                      },
+                      queue_id: {
+                        type: 'integer',
+                        minimum: 1
+                      },
+                      create_date: {
+                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                        description: 'ISO 8601 date string for the project start date'
+                      },
+                      create_user: {
+                        type: 'integer',
+                        minimum: 1
+                      },
+                      update_date: {
+                        oneOf: [{ type: 'object' }, { type: 'string', format: 'date' }],
+                        description: 'ISO 8601 date string for the project start date',
+                        nullable: true
+                      },
+                      update_user: {
+                        type: 'integer',
+                        minimum: 1,
+                        nullable: true
+                      },
+                      revision_count: {
+                        type: 'integer',
+                        minimum: 0
                       }
                     }
                   }
@@ -338,7 +404,12 @@ export function getSurveyList(): RequestHandler {
 
       const surveyIds = surveyIdsResponse.map((item: { id: any }) => item.id);
 
-      const surveys = await surveyService.getSurveysByIds(surveyIds);
+      const surveys = await surveyIds.map(async (surveyId) => {
+        const survey = await surveyService.getSurveyById(surveyId);
+        const supplementaryData = (null as unknown) as SurveyMetadataPublish;
+
+        return { SurveyObject: survey, SurveyMetadataPublish: supplementaryData };
+      });
 
       await connection.commit();
 

--- a/app/src/components/publish/SurveySubmissionAlertBar.tsx
+++ b/app/src/components/publish/SurveySubmissionAlertBar.tsx
@@ -7,7 +7,7 @@ import { IGetSummaryResultsResponse } from 'interfaces/useSummaryResultsApi.inte
 import { IGetSurveyAttachmentsResponse } from 'interfaces/useSurveyApi.interface';
 import React, { useContext, useState } from 'react';
 
-const SubmissionAlertBar = () => {
+const SurveySubmissionAlertBar = () => {
   const surveyContext = useContext(SurveyContext);
 
   const [forceAlertClose, setForceAlertClose] = useState(false);
@@ -94,4 +94,4 @@ function getAttachmentDataSubmissionStatus(surveyAttachmentsData?: IGetSurveyAtt
   return 'UNSUBMITTED';
 }
 
-export default SubmissionAlertBar;
+export default SurveySubmissionAlertBar;

--- a/app/src/components/surveys/SurveysList.test.tsx
+++ b/app/src/components/surveys/SurveysList.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { SurveyViewObject } from 'interfaces/useSurveyApi.interface';
+import { IGetSurveyForViewResponse, SurveySupplementaryData } from 'interfaces/useSurveyApi.interface';
 import React from 'react';
 import { Router } from 'react-router';
 import { codes } from 'test-helpers/code-helpers';
@@ -11,36 +11,46 @@ const history = createMemoryHistory();
 
 describe('SurveysList', () => {
   it('renders correctly with surveys', () => {
-    const surveysList: SurveyViewObject[] = [
+    const surveysList: IGetSurveyForViewResponse[] = [
       {
-        ...surveyObject,
-        survey_details: {
-          ...surveyObject.survey_details,
-          survey_name: 'Moose Survey 1',
-          start_date: '2021-04-09 11:53:53',
-          end_date: '2021-05-09 11:53:53'
+        surveyData: {
+          ...surveyObject,
+          survey_details: {
+            ...surveyObject.survey_details,
+            survey_name: 'Moose Survey 1',
+            start_date: '2021-04-09 11:53:53',
+            end_date: '2021-05-09 11:53:53'
+          },
+          species: {
+            focal_species: [1],
+            focal_species_names: ['species 1'],
+            ancillary_species: [2],
+            ancillary_species_names: ['species 2']
+          }
         },
-        species: {
-          focal_species: [1],
-          focal_species_names: ['species 1'],
-          ancillary_species: [2],
-          ancillary_species_names: ['species 2']
-        }
+        surveySupplementaryData: ({
+          survey_metadata_publish: null
+        } as unknown) as SurveySupplementaryData
       },
       {
-        ...surveyObject,
-        survey_details: {
-          ...surveyObject.survey_details,
-          survey_name: 'Moose Survey 2',
-          start_date: '2021-04-09 11:53:53',
-          end_date: '2021-06-10 11:53:53'
+        surveyData: {
+          ...surveyObject,
+          survey_details: {
+            ...surveyObject.survey_details,
+            survey_name: 'Moose Survey 2',
+            start_date: '2021-04-09 11:53:53',
+            end_date: '2021-06-10 11:53:53'
+          },
+          species: {
+            focal_species: [3],
+            focal_species_names: ['species 3'],
+            ancillary_species: [4],
+            ancillary_species_names: ['species 4']
+          }
         },
-        species: {
-          focal_species: [3],
-          focal_species_names: ['species 3'],
-          ancillary_species: [4],
-          ancillary_species_names: ['species 4']
-        }
+        surveySupplementaryData: ({
+          survey_metadata_publish: null
+        } as unknown) as SurveySupplementaryData
       }
     ];
 

--- a/app/src/components/surveys/SurveysList.tsx
+++ b/app/src/components/surveys/SurveysList.tsx
@@ -66,8 +66,8 @@ const SurveysList: React.FC<ISurveysListProps> = (props) => {
                   </TableCell>
                   <TableCell>
                     {[
-                      ...row.surveyData.species?.focal_species_names,
-                      ...row.surveyData.species?.ancillary_species_names
+                      ...row.surveyData.species.focal_species_names,
+                      ...row.surveyData.species.ancillary_species_names
                     ].join(', ')}
                   </TableCell>
                   <TableCell>

--- a/app/src/components/surveys/SurveysList.tsx
+++ b/app/src/components/surveys/SurveysList.tsx
@@ -1,5 +1,4 @@
 import Link from '@material-ui/core/Link';
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -8,19 +7,21 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
+import { SubmitStatusChip } from 'components/chips/SubmitStatusChip';
+import { BioHubSubmittedStatusType } from 'constants/misc';
 import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
-import { SurveyViewObject } from 'interfaces/useSurveyApi.interface';
+import { IGetSurveyForViewResponse } from 'interfaces/useSurveyApi.interface';
 import React, { useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   surveyTable: {
     tableLayout: 'fixed'
   }
 }));
 
 export interface ISurveysListProps {
-  surveysList: SurveyViewObject[];
+  surveysList: IGetSurveyForViewResponse[];
   projectId: number;
   codes: IGetAllCodeSetsResponse;
 }
@@ -31,6 +32,13 @@ const SurveysList: React.FC<ISurveysListProps> = (props) => {
   const [rowsPerPage] = useState(5);
   const [page] = useState(0);
 
+  function getSurveySubmissionStatus(survey: IGetSurveyForViewResponse): BioHubSubmittedStatusType {
+    if (survey.surveySupplementaryData.survey_metadata_publish?.survey_metadata_publish_id) {
+      return BioHubSubmittedStatusType.SUBMITTED;
+    }
+    return BioHubSubmittedStatusType.UNSUBMITTED;
+  }
+
   return (
     <>
       <TableContainer>
@@ -40,6 +48,7 @@ const SurveysList: React.FC<ISurveysListProps> = (props) => {
               <TableCell>Name</TableCell>
               <TableCell>Species</TableCell>
               <TableCell>Purpose</TableCell>
+              <TableCell width="140">Status</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -50,19 +59,25 @@ const SurveysList: React.FC<ISurveysListProps> = (props) => {
                     <Link
                       style={{ fontWeight: 'bold' }}
                       underline="always"
-                      to={`/admin/projects/${props.projectId}/surveys/${row.survey_details.id}/details`}
+                      to={`/admin/projects/${props.projectId}/surveys/${row.surveyData.survey_details.id}/details`}
                       component={RouterLink}>
-                      {row.survey_details.survey_name}
+                      {row.surveyData.survey_details.survey_name}
                     </Link>
                   </TableCell>
                   <TableCell>
-                    {[...row.species?.focal_species_names, ...row.species?.ancillary_species_names].join(', ')}
+                    {[
+                      ...row.surveyData.species?.focal_species_names,
+                      ...row.surveyData.species?.ancillary_species_names
+                    ].join(', ')}
                   </TableCell>
                   <TableCell>
-                    {row.purpose_and_methodology.intended_outcome_id &&
+                    {row.surveyData.purpose_and_methodology.intended_outcome_id &&
                       props.codes?.intended_outcomes?.find(
-                        (item: any) => item.id === row.purpose_and_methodology.intended_outcome_id
+                        (item: any) => item.id === row.surveyData.purpose_and_methodology.intended_outcome_id
                       )?.name}
+                  </TableCell>
+                  <TableCell>
+                    <SubmitStatusChip status={getSurveySubmissionStatus(row)} />
                   </TableCell>
                 </TableRow>
               ))}

--- a/app/src/contexts/projectContext.tsx
+++ b/app/src/contexts/projectContext.tsx
@@ -1,6 +1,7 @@
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader, { DataLoader } from 'hooks/useDataLoader';
 import { IGetProjectAttachmentsResponse, IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
+import { IGetSurveyForViewResponse } from 'interfaces/useSurveyApi.interface';
 import React, { createContext, PropsWithChildren, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router';
 
@@ -14,10 +15,18 @@ export interface IProjectContext {
   /**
    * The Data Loader used to load project data
    *
-   * @type {DataLoader<[project_id: number, project_id: number], IGetProjectForViewResponse, unknown>}
+   * @type {DataLoader<[project_id: number], IGetProjectForViewResponse, unknown>}
    * @memberof IProjectContext
    */
   projectDataLoader: DataLoader<[project_id: number], IGetProjectForViewResponse, unknown>;
+
+  /**
+   * The Data Loader used to load project data
+   *
+   * @type {DataLoader<[project_id: number], IGetSurveyForViewResponse[], unknown>}
+   * @memberof IProjectContext
+   */
+  surveysListDataLoader: DataLoader<[project_id: number], IGetSurveyForViewResponse[], unknown>;
 
   /**
    * The Data Loader used to load project data
@@ -38,6 +47,7 @@ export interface IProjectContext {
 
 export const ProjectContext = createContext<IProjectContext>({
   projectDataLoader: {} as DataLoader<[project_id: number], IGetProjectForViewResponse, unknown>,
+  surveysListDataLoader: {} as DataLoader<[project_id: number], IGetSurveyForViewResponse[], unknown>,
   artifactDataLoader: {} as DataLoader<[project_id: number], IGetProjectAttachmentsResponse, unknown>,
   projectId: -1
 });
@@ -45,6 +55,7 @@ export const ProjectContext = createContext<IProjectContext>({
 export const ProjectContextProvider = (props: PropsWithChildren<Record<never, any>>) => {
   const biohubApi = useBiohubApi();
   const projectDataLoader = useDataLoader(biohubApi.project.getProjectForView);
+  const surveysListDataLoader = useDataLoader(biohubApi.survey.getSurveysList);
   const artifactDataLoader = useDataLoader(biohubApi.project.getProjectAttachments);
   const urlParams = useParams();
 
@@ -62,6 +73,7 @@ export const ProjectContextProvider = (props: PropsWithChildren<Record<never, an
   useEffect(() => {
     if (projectId) {
       projectDataLoader.refresh(projectId);
+      surveysListDataLoader.refresh(projectId);
       artifactDataLoader.refresh(projectId);
     }
 
@@ -71,10 +83,11 @@ export const ProjectContextProvider = (props: PropsWithChildren<Record<never, an
   const projectContext: IProjectContext = useMemo(() => {
     return {
       projectDataLoader,
+      surveysListDataLoader,
       artifactDataLoader,
       projectId
     };
-  }, [projectDataLoader, artifactDataLoader, projectId]);
+  }, [projectDataLoader, surveysListDataLoader, artifactDataLoader, projectId]);
 
   return <ProjectContext.Provider value={projectContext}>{props.children}</ProjectContext.Provider>;
 };

--- a/app/src/features/projects/view/ProjectPage.tsx
+++ b/app/src/features/projects/view/ProjectPage.tsx
@@ -3,6 +3,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
+import ProjectSubmissionAlertBar from 'components/publish/ProjectSubmissionAlertBar';
 import { CodesContext } from 'contexts/codesContext';
 import { ProjectContext } from 'contexts/projectContext';
 import ProjectAttachments from 'features/projects/view/ProjectAttachments';
@@ -28,7 +29,11 @@ const ProjectPage = () => {
     projectContext.projectId
   ]);
 
-  if (!codesContext.codesDataLoader.data || !projectContext.projectDataLoader.data) {
+  if (
+    !codesContext.codesDataLoader.data ||
+    !projectContext.projectDataLoader.data ||
+    !projectContext.surveysListDataLoader.data
+  ) {
     return <CircularProgress className="pageProgress" size={40} />;
   }
 
@@ -38,6 +43,7 @@ const ProjectPage = () => {
 
       <Container maxWidth="xl">
         <Box py={3}>
+          <ProjectSubmissionAlertBar />
           <Grid container spacing={3}>
             <Grid item md={12} lg={4}>
               <Paper elevation={0}>

--- a/app/src/features/surveys/list/SurveysListPage.test.tsx
+++ b/app/src/features/surveys/list/SurveysListPage.test.tsx
@@ -4,7 +4,7 @@ import { IProjectContext, ProjectContext } from 'contexts/projectContext';
 import { createMemoryHistory } from 'history';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { DataLoader } from 'hooks/useDataLoader';
-import { SurveyViewObject } from 'interfaces/useSurveyApi.interface';
+import { IGetSurveyForViewResponse, SurveySupplementaryData } from 'interfaces/useSurveyApi.interface';
 import React from 'react';
 import { Router } from 'react-router';
 import { codes } from 'test-helpers/code-helpers';
@@ -44,6 +44,7 @@ describe('SurveysListPage', () => {
       projectDataLoader: {
         data: getProjectForViewResponse
       } as DataLoader<any, any, any>,
+      surveysListDataLoader: { data: [] } as DataLoader<any, any, any>,
       artifactDataLoader: { data: null } as DataLoader<any, any, any>,
       projectId: 1
     };
@@ -73,50 +74,58 @@ describe('SurveysListPage', () => {
         data: codes
       } as DataLoader<any, any, any>
     };
+
+    const surveysList: IGetSurveyForViewResponse[] = [
+      {
+        surveyData: {
+          ...surveyObject,
+          survey_details: {
+            ...surveyObject.survey_details,
+            survey_name: 'Moose Survey 1',
+            start_date: '2021-04-09 11:53:53',
+            end_date: '2021-05-09 11:53:53'
+          },
+          species: {
+            focal_species: [1],
+            focal_species_names: ['species 1'],
+            ancillary_species: [2],
+            ancillary_species_names: ['species 2']
+          }
+        },
+        surveySupplementaryData: ({
+          survey_metadata_publish: null
+        } as unknown) as SurveySupplementaryData
+      },
+      {
+        surveyData: {
+          ...surveyObject,
+          survey_details: {
+            ...surveyObject.survey_details,
+            survey_name: 'Moose Survey 2',
+            start_date: '2021-04-09 11:53:53',
+            end_date: '2021-06-10 11:53:53'
+          },
+          species: {
+            focal_species: [3],
+            focal_species_names: ['species 3'],
+            ancillary_species: [4],
+            ancillary_species_names: ['species 4']
+          }
+        },
+        surveySupplementaryData: ({
+          survey_metadata_publish: null
+        } as unknown) as SurveySupplementaryData
+      }
+    ];
+
     const mockProjectContext: IProjectContext = {
       projectDataLoader: {
         data: getProjectForViewResponse
       } as DataLoader<any, any, any>,
+      surveysListDataLoader: { data: surveysList } as DataLoader<any, any, any>,
       artifactDataLoader: { data: null } as DataLoader<any, any, any>,
       projectId: 1
     };
-
-    const surveysList: SurveyViewObject[] = [
-      {
-        ...surveyObject,
-        survey_details: {
-          ...surveyObject.survey_details,
-          id: 1,
-          survey_name: 'Moose Survey 1',
-          start_date: '2021-04-09 11:53:53',
-          end_date: '2021-05-09 11:53:53'
-        },
-        species: {
-          focal_species: [1],
-          focal_species_names: ['Moose'],
-          ancillary_species: [2],
-          ancillary_species_names: ['Elk']
-        }
-      },
-      {
-        ...surveyObject,
-        survey_details: {
-          ...surveyObject.survey_details,
-          id: 2,
-          survey_name: 'Moose Survey 2',
-          start_date: '2021-04-09 11:53:53',
-          end_date: '2021-06-10 11:53:53'
-        },
-        species: {
-          focal_species: [1],
-          focal_species_names: ['Moose'],
-          ancillary_species: [2],
-          ancillary_species_names: ['Elk']
-        }
-      }
-    ];
-
-    mockBiohubApi().survey.getSurveysList.mockResolvedValue(surveysList);
 
     const { getByText } = render(
       <Router history={history}>

--- a/app/src/features/surveys/list/SurveysListPage.tsx
+++ b/app/src/features/surveys/list/SurveysListPage.tsx
@@ -7,9 +7,7 @@ import SurveysList from 'components/surveys/SurveysList';
 import { H2ButtonToolbar } from 'components/toolbar/ActionToolbars';
 import { CodesContext } from 'contexts/codesContext';
 import { ProjectContext } from 'contexts/projectContext';
-import { useBiohubApi } from 'hooks/useBioHubApi';
-import useDataLoader from 'hooks/useDataLoader';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useHistory } from 'react-router';
 
 /**
@@ -19,20 +17,15 @@ import { useHistory } from 'react-router';
  */
 const SurveysListPage = () => {
   const history = useHistory();
-  const biohubApi = useBiohubApi();
 
   const codesContext = useContext(CodesContext);
   const projectContext = useContext(ProjectContext);
 
   assert(codesContext.codesDataLoader.data);
+  assert(projectContext.surveysListDataLoader.data);
 
   const codes = codesContext.codesDataLoader.data;
-
-  const surveysListDataLoader = useDataLoader((projectId: number) => biohubApi.survey.getSurveysList(projectId));
-
-  useEffect(() => {
-    surveysListDataLoader.load(projectContext.projectId);
-  }, [surveysListDataLoader, projectContext.projectId]);
+  const surveys = projectContext.surveysListDataLoader.data;
 
   const navigateToCreateSurveyPage = (projectId: number) => {
     history.push(`/admin/projects/${projectId}/survey/create`);
@@ -50,11 +43,7 @@ const SurveysListPage = () => {
       />
       <Divider></Divider>
       <Box px={1}>
-        <SurveysList
-          projectId={projectContext.projectId}
-          surveysList={surveysListDataLoader.data || []}
-          codes={codes}
-        />
+        <SurveysList projectId={projectContext.projectId} surveysList={surveys || []} codes={codes} />
       </Box>
     </>
   );

--- a/app/src/features/surveys/view/SurveyPage.tsx
+++ b/app/src/features/surveys/view/SurveyPage.tsx
@@ -3,7 +3,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
-import SubmissionAlertBar from 'components/publish/SubmissionAlertBar';
+import SurveySubmissionAlertBar from 'components/publish/SurveySubmissionAlertBar';
 import { CodesContext } from 'contexts/codesContext';
 import { SurveyContext } from 'contexts/surveyContext';
 import SurveyDetails from 'features/surveys/view/SurveyDetails';
@@ -39,7 +39,7 @@ const SurveyPage: React.FC = () => {
       <SurveyHeader />
       <Container maxWidth="xl">
         <Box my={3}>
-          <SubmissionAlertBar />
+          <SurveySubmissionAlertBar />
           <Grid container spacing={3}>
             <Grid item md={12} lg={4}>
               <Paper elevation={0}>

--- a/app/src/hooks/api/useSurveyApi.ts
+++ b/app/src/hooks/api/useSurveyApi.ts
@@ -14,8 +14,7 @@ import {
   IGetSurveyForUpdateResponse,
   IGetSurveyForViewResponse,
   ISurveyAvailableFundingSources,
-  SurveyUpdateObject,
-  SurveyViewObject
+  SurveyUpdateObject
 } from 'interfaces/useSurveyApi.interface';
 import qs from 'qs';
 
@@ -70,7 +69,7 @@ const useSurveyApi = (axios: AxiosInstance) => {
    * @param {number} projectId
    * @return {*}  {Promise<IGetSurveysListResponse[]>}
    */
-  const getSurveysList = async (projectId: number): Promise<SurveyViewObject[]> => {
+  const getSurveysList = async (projectId: number): Promise<IGetSurveyForViewResponse[]> => {
     const { data } = await axios.get(`/api/project/${projectId}/surveys`);
 
     return data;


### PR DESCRIPTION
# Overview

## Links to Jira tickets

- https://quartech.atlassian.net/browse/BHBC-2194

## Description of relevant changes

- Updated Project Context to load Survey List data
- Survey list has submitted tags
- Project Page has alert bar for submitted data

### NOTE: API for survey supplementary data is incomplete, using hard coded vlaues in surveys.ts endpoint 

## PR Checklist
A list of items that are good to consider when making any changes.

- [ ] Add file to survey to prompt an unsubmitted Survey tag, see Project page has unsubmitted data.
- [ ] Submit all data inside of Survey, see Project page, Survey is submitted and Project Alert has all data submitted.
- [ ] Add Attachment to Project, see Project alert bar update to unsubmitted.
