### PR TITLE
BHBC-2301: Limit Map tab view to data and system admins only

### DIFF
--- a/app/src/AppRouter.tsx
+++ b/app/src/AppRouter.tsx
@@ -66,7 +66,9 @@ const AppRouter: React.FC = () => {
 
       <AppRoute path="/admin/search" title={getTitle('Search')} layout={BaseLayout}>
         <AuthenticatedRouteGuard>
-          <SearchPage />
+          <SystemRoleRouteGuard validRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+            <SearchPage />
+          </SystemRoleRouteGuard>
         </AuthenticatedRouteGuard>
       </AppRoute>
 

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -224,9 +224,11 @@ const Header: React.FC = () => {
                 <RouterLink to="/admin/projects" id="menu_projects">
                   Projects
                 </RouterLink>
-                <RouterLink to="/admin/search" id="menu_search">
-                  Map
-                </RouterLink>
+                <SystemRoleGuard validSystemRoles={[SYSTEM_ROLE.DATA_ADMINISTRATOR, SYSTEM_ROLE.SYSTEM_ADMIN]}>
+                  <RouterLink to="/admin/search" id="menu_search">
+                    Map
+                  </RouterLink>
+                </SystemRoleGuard>
                 <RouterLink to="/admin/resources" id="menu_resources">
                   Resources
                 </RouterLink>


### PR DESCRIPTION
# Overview
The Map page is now only visible to Data Admin and System Admin

## Links to Jira tickets

 - https://quartech.atlassian.net/browse/BHBC-2301

## Testing Procedure
1. Sign into SIMS as a Data Administrator. You should:

 - [ ] See the Map tab in the header.

2. Right-click on the **Map** link and click **Copy link address** (see Step 5)

3. Switch your role to System Admin and reload the app. You should:

 - [ ] See the Map tab in the header.

4. Switch your role to Creator and reload the app. You should:

 - [ ] NOT see the Map tab in the header.

5. Paste the link you copied from earlier. Alternatively, navigate to `/admin/search`. You should

 - [ ] See the Forbidden page 
