### PR TITLE
SIMSBIOHUB-30: SIMS Home Page

### DIFF
--- a/app/src/pages/landing/LandingPage.tsx
+++ b/app/src/pages/landing/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { AuthStateContext } from 'contexts/authStateContext';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 interface ILandingPageProps {
   originalPath: string;
 }
@@ -7,9 +7,14 @@ interface ILandingPageProps {
 export const LandingPage: React.FC<ILandingPageProps> = ({ originalPath }) => {
   const { keycloakWrapper } = useContext(AuthStateContext);
 
-  useEffect(() => {
+  const handleLogin = () => {
     keycloakWrapper?.keycloak?.login();
-  });
+  }
 
-  return null;
+  return (
+    <div>
+      <p>Temporary home page, pending <strong><a target="_blank" href='https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-30'>SIMSBIOHUB-30</a></strong>.</p>
+      <h2><a onClick={() => handleLogin()}>Click to Sign in</a></h2>
+    </div>
+  );
 };


### PR DESCRIPTION
# Overview

Creates a temporary, publicly-accessible home page in SIMS.

## Links to Jira tickets

 - https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-41

## Description of relevant changes

 - When unauthenticated access the SIMS application they land on a home page (currently they are redirected to the Keycloak instance)
 - Logged In users will be redirected to the 'Projects' page.