### PR TITLE
SIMSBIOHUB - 241 + 242 + 253 - Critter / Observation / Deployment / Survey Stratum tables

### DIFF
--- a/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
@@ -71,7 +71,7 @@ export async function up(knex: Knex): Promise<void> {
   COMMENT ON COLUMN critter.revision_count           IS 'Revision count used for concurrency control.';
   COMMENT ON TABLE  critter                          IS 'Information about individual animals associated to specific observations.';
 
-  -- Add foreign key constraint from child table to parent table on <column_name_2>
+  -- Add foreign key constraint from child table to parent table on observation_id
   ALTER TABLE critter ADD CONSTRAINT critter_fk1
     FOREIGN KEY (observation_id)
     REFERENCES observation(observation_id);
@@ -82,6 +82,44 @@ export async function up(knex: Knex): Promise<void> {
   -- Create audit and journal triggers
   create trigger audit_critter before insert or update or delete on critter for each row execute procedure tr_audit_trigger();
   create trigger journal_critter after insert or update or delete on critter for each row execute procedure tr_journal_trigger();
+
+  ----------------------------------------------------------------------------------------
+  -- Create Deployment table
+  ----------------------------------------------------------------------------------------
+
+  CREATE TABLE deployment(
+    deployment_id            integer           GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+    critter_id               integer           NOT NULL,
+    bctw_deployment_id       uuid              NOT NULL,
+    create_date              timestamptz(6)    DEFAULT now() NOT NULL,
+    create_user              integer           NOT NULL,
+    update_date              timestamptz(6),
+    update_user              integer,
+    revision_count           integer           DEFAULT 0 NOT NULL,
+    CONSTRAINT deployment_pk PRIMARY KEY (deployment_id)
+  );
+
+  COMMENT ON COLUMN deployment.deployment_id            IS 'System generated surrogate primary key identifier.';
+  COMMENT ON COLUMN deployment.critter_id              IS 'The id of the critter. Internal Sims id.';
+  COMMENT ON COLUMN deployment.bctw_deployment_id       IS 'The external system id of a BCTW deployment / collar->animal assignment.';
+  COMMENT ON COLUMN deployment.create_date              IS 'The datetime the record was created.';
+  COMMENT ON COLUMN deployment.create_user              IS 'The id of the user who created the record as identified in the system user table.';
+  COMMENT ON COLUMN deployment.update_date              IS 'The datetime the record was updated.';
+  COMMENT ON COLUMN deployment.update_user              IS 'The id of the user who updated the record as identified in the system user table.';
+  COMMENT ON COLUMN deployment.revision_count          IS 'Revision count used for concurrency control.';
+  COMMENT ON TABLE  deployment                          IS 'Information about individual critters associated to specific bctw deployments.';
+
+  -- Add foreign key constraint from child table to parent table on critter_id
+  ALTER TABLE deployment ADD CONSTRAINT deployment_fk1
+    FOREIGN KEY (critter_id)
+    REFERENCES critter(critter_id);
+
+  -- Add unique constraint
+  CREATE UNIQUE INDEX deployment_uk1 ON deployment(critter_id, bctw_deployment_id);
+
+  -- Create audit and journal triggers
+  create trigger audit_critter before insert or update or delete on deployment for each row execute procedure tr_audit_trigger();
+  create trigger journal_critter after insert or update or delete on deployment for each row execute procedure tr_journal_trigger();
 
 
   ----------------------------------------------------------------------------------------
@@ -136,6 +174,7 @@ export async function up(knex: Knex): Promise<void> {
 
   create or replace view observation as select * from biohub.observation;
   create or replace view critter as select * from biohub.critter;
+  create or replace view deployment as select * from biohub.deployment;
   `);
 }
 

--- a/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
@@ -77,8 +77,11 @@ export async function up(knex: Knex): Promise<void> {
     FOREIGN KEY (observation_id)
     REFERENCES observation(observation_id);
 
+  -- Add foreign key index
+  CREATE INDEX critter_idx1 ON critter(observation_id);
+
   -- Add unique constraint
-  CREATE UNIQUE INDEX critter_uk1 ON critter(critterbase_critter_id);
+  CREATE UNIQUE INDEX critter_uk1 ON critter(observation_id, critterbase_critter_id);
 
   -- Create audit and journal triggers
   create trigger audit_critter before insert or update or delete on critter for each row execute procedure tr_audit_trigger();
@@ -114,6 +117,9 @@ export async function up(knex: Knex): Promise<void> {
   ALTER TABLE deployment ADD CONSTRAINT deployment_fk1
     FOREIGN KEY (critter_id)
     REFERENCES critter(critter_id);
+
+  -- Add foreign key index
+  CREATE INDEX deployment_idx1 ON deployment(critter_id);
 
   -- Add unique constraint
   CREATE UNIQUE INDEX deployment_uk1 ON deployment(critter_id, bctw_deployment_id);

--- a/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
@@ -6,6 +6,7 @@ import { Knex } from 'knex';
  * @export
  * @param {Knex} knex
  * @return {*}  {Promise<void>}
+ *
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`--sql

--- a/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
@@ -157,7 +157,7 @@ export async function up(knex: Knex): Promise<void> {
       IF (num_critters >= observation_total_count) THEN
 
 
-        RAISE EXCEPTION 'Can not add more critters than specified in observation';
+        RAISE EXCEPTION 'Can not add more individuals than specified in observation';
       END IF;
 
 
@@ -168,10 +168,10 @@ export async function up(knex: Knex): Promise<void> {
 
   ;
 
-  COMMENT ON FUNCTION biohub.tr_critter_observation_count() IS 'Validates amound of critters of an observation is less than or equal to observation count.';
+  COMMENT ON FUNCTION biohub.tr_critter_observation_count() IS 'Validates amount of individuals in an observation is less than or equal to observation total count.';
 
   -- Create observation count trigger
-  CREATE TRIGGER tr_critter_observation_count BEFORE INSERT OR UPDATE ON critter FOR EACH ROW EXECUTE PROCEDURE tr_critter_observation_count();
+  CREATE TRIGGER tr_critter_observation_count BEFORE INSERT ON critter FOR EACH ROW EXECUTE PROCEDURE tr_critter_observation_count();
 
   ----------------------------------------------------------------------------------------
   -- Create views

--- a/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_deployment_tables.ts
@@ -101,13 +101,13 @@ export async function up(knex: Knex): Promise<void> {
   );
 
   COMMENT ON COLUMN deployment.deployment_id            IS 'System generated surrogate primary key identifier.';
-  COMMENT ON COLUMN deployment.critter_id              IS 'The id of the critter. Internal Sims id.';
+  COMMENT ON COLUMN deployment.critter_id               IS 'The id of the critter. Internal Sims id.';
   COMMENT ON COLUMN deployment.bctw_deployment_id       IS 'The external system id of a BCTW deployment / collar->animal assignment.';
   COMMENT ON COLUMN deployment.create_date              IS 'The datetime the record was created.';
   COMMENT ON COLUMN deployment.create_user              IS 'The id of the user who created the record as identified in the system user table.';
   COMMENT ON COLUMN deployment.update_date              IS 'The datetime the record was updated.';
   COMMENT ON COLUMN deployment.update_user              IS 'The id of the user who updated the record as identified in the system user table.';
-  COMMENT ON COLUMN deployment.revision_count          IS 'Revision count used for concurrency control.';
+  COMMENT ON COLUMN deployment.revision_count           IS 'Revision count used for concurrency control.';
   COMMENT ON TABLE  deployment                          IS 'Information about individual critters associated to specific bctw deployments.';
 
   -- Add foreign key constraint from child table to parent table on critter_id

--- a/database/src/migrations/20230817000000_critter_observation_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_tables.ts
@@ -1,0 +1,145 @@
+
+import { Knex } from 'knex';
+
+/**
+ * Added critter and observation tables with trigger to check if critter instances is less than observation.total_count
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+
+  ----------------------------------------------------------------------------------------
+  -- Create Observation Table
+  ----------------------------------------------------------------------------------------
+
+  set search_path=biohub;
+
+  CREATE TABLE observation(
+    observation_id           integer           GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+    survey_id                integer           NOT NULL,
+    total_count   	         integer			     NOT NULL CHECK(total_count > 0),
+    observation_date         date,
+    create_date              timestamptz(6)    DEFAULT now() NOT NULL,
+    create_user              integer           NOT NULL,
+    update_date              timestamptz(6),
+    update_user              integer,
+    revision_count           integer           DEFAULT 0 NOT NULL,
+    CONSTRAINT observation_pk PRIMARY KEY (observation_id)
+
+  );
+
+  COMMENT ON COLUMN observation.observation_id           IS 'System generated surrogate primary key identifier.';
+  COMMENT ON COLUMN observation.survey_id                IS 'The id of the survey.';
+  COMMENT ON COLUMN observation.observation_date         IS 'Date the observation occured.';
+  COMMENT ON COLUMN observation.total_count              IS 'The number of individuals recorded in observation. Associated critters must be less than or equal.';
+  COMMENT ON COLUMN observation.create_date              IS 'The datetime the record was created.';
+  COMMENT ON COLUMN observation.create_user              IS 'The id of the user who created the record as identified in the system user table.';
+  COMMENT ON COLUMN observation.update_date              IS 'The datetime the record was updated.';
+  COMMENT ON COLUMN observation.update_user              IS 'The id of the user who updated the record as identified in the system user table.';
+  COMMENT ON COLUMN observation.revision_count           IS 'Revision count used for concurrency control.';
+  COMMENT ON TABLE  observation                          IS 'Information about taxon counts.';
+
+  -- Create audit and journal triggers
+  create trigger audit_observation before insert or update or delete on observation for each row execute procedure tr_audit_trigger();
+  create trigger journal_observation after insert or update or delete on observation for each row execute procedure tr_journal_trigger();
+
+  ----------------------------------------------------------------------------------------
+  -- Create Critter table
+  ----------------------------------------------------------------------------------------
+
+  CREATE TABLE critter(
+    critter_id               integer           GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+    observation_id           integer           NOT NULL,
+    critterbase_critter_id   uuid              NOT NULL,
+    create_date              timestamptz(6)    DEFAULT now() NOT NULL,
+    create_user              integer           NOT NULL,
+    update_date              timestamptz(6),
+    update_user              integer,
+    revision_count           integer           DEFAULT 0 NOT NULL,
+    CONSTRAINT critter_pk PRIMARY KEY (critter_id)
+  );
+
+  COMMENT ON COLUMN critter.critter_id               IS 'System generated surrogate primary key identifier.';
+  COMMENT ON COLUMN critter.observation_id           IS 'The id of the observation';
+  COMMENT ON COLUMN critter.critterbase_critter_id   IS 'The external system id of a Critterbase critter.';
+  COMMENT ON COLUMN critter.create_date              IS 'The datetime the record was created.';
+  COMMENT ON COLUMN critter.create_user              IS 'The id of the user who created the record as identified in the system user table.';
+  COMMENT ON COLUMN critter.update_date              IS 'The datetime the record was updated.';
+  COMMENT ON COLUMN critter.update_user              IS 'The id of the user who updated the record as identified in the system user table.';
+  COMMENT ON COLUMN critter.revision_count           IS 'Revision count used for concurrency control.';
+  COMMENT ON TABLE  critter                          IS 'Information about individual animals associated to specific observations.';
+
+  -- Add foreign key constraint from child table to parent table on <column_name_2>
+  ALTER TABLE critter ADD CONSTRAINT critter_fk1
+    FOREIGN KEY (observation_id)
+    REFERENCES observation(observation_id);
+
+  -- Add unique constraint
+  CREATE UNIQUE INDEX critter_uk1 ON critter(critterbase_critter_id);
+
+  -- Create audit and journal triggers
+  create trigger audit_critter before insert or update or delete on critter for each row execute procedure tr_audit_trigger();
+  create trigger journal_critter after insert or update or delete on critter for each row execute procedure tr_journal_trigger();
+
+
+  ----------------------------------------------------------------------------------------
+  -- Create Critter Observation count trigger
+  ----------------------------------------------------------------------------------------
+
+  CREATE OR REPLACE FUNCTION biohub.tr_critter_observation_count()
+
+   RETURNS trigger
+   LANGUAGE plpgsql
+  AS $function$
+    -- *******************************************************************
+
+    -- Procedure: tr_critter_observation_count
+    -- Purpose: Validates amount of critters of a observation is less than or equal to observation count.
+    --
+
+    -- MODIFICATION HISTORY
+    -- Person           Date        Comments
+    -- ---------------- ----------- --------------------------------------
+    -- mac.deluca@quartech.com
+    --                  2023-17-08  initial release
+    -- *******************************************************************
+    DECLARE
+      num_critters integer := (SELECT count(*) FROM critter WHERE critter.observation_id = NEW.observation_id);
+      observation_total_count integer := (SELECT total_count FROM observation WHERE observation.observation_id = NEW.observation_id);
+    BEGIN
+      IF (num_critters >= observation_total_count) THEN
+
+
+        RAISE EXCEPTION 'Can not add more critters than specified in observation';
+      END IF;
+
+
+      RETURN NEW;
+    end;
+
+    $function$
+
+  ;
+
+  COMMENT ON FUNCTION biohub.tr_critter_observation_count() IS 'Validates amound of critters of an observation is less than or equal to observation count.';
+
+  -- Create observation count trigger
+  CREATE TRIGGER tr_critter_observation_count BEFORE INSERT OR UPDATE ON critter FOR EACH ROW EXECUTE PROCEDURE tr_critter_observation_count();
+
+  ----------------------------------------------------------------------------------------
+  -- Create views
+  ----------------------------------------------------------------------------------------
+
+  set search_path=biohub_dapi_v1;
+
+  create or replace view observation as select * from biohub.observation;
+  create or replace view critter as select * from biohub.critter;
+  `)
+};
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}

--- a/database/src/migrations/20230817000000_critter_observation_tables.ts
+++ b/database/src/migrations/20230817000000_critter_observation_tables.ts
@@ -1,4 +1,3 @@
-
 import { Knex } from 'knex';
 
 /**
@@ -137,8 +136,8 @@ export async function up(knex: Knex): Promise<void> {
 
   create or replace view observation as select * from biohub.observation;
   create or replace view critter as select * from biohub.critter;
-  `)
-};
+  `);
+}
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(``);

--- a/database/src/migrations/20230818000000_survey_stratum.ts
+++ b/database/src/migrations/20230818000000_survey_stratum.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+/**
+ * Added new program and project_program for tracking programs (used to be project type)
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+
+`);

--- a/database/src/migrations/20230818000000_survey_stratum.ts
+++ b/database/src/migrations/20230818000000_survey_stratum.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 /**
- * Added new program and project_program for tracking programs (used to be project type)
+ * Added new survey stratum table
  *
  * @export
  * @param {Knex} knex
@@ -9,5 +9,61 @@ import { Knex } from 'knex';
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`--sql
+  ----------------------------------------------------------------------------------------
+  -- Create Survey Stratum Table
+  ----------------------------------------------------------------------------------------
+
+  set search_path=biohub;
+
+  CREATE TABLE survey_stratum(
+    survey_stratum_id        integer           GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+    survey_id                integer           NOT NULL,
+    name                     varchar(50)       NOT NULL,
+    description              varchar(250)      NOT NULL,
+    create_date              timestamptz(6)    DEFAULT now() NOT NULL,
+    create_user              integer           NOT NULL,
+    update_date              timestamptz(6),
+    update_user              integer,
+    revision_count           integer           DEFAULT 0 NOT NULL,
+    CONSTRAINT survey_stratum_pk PRIMARY KEY (survey_stratum_id)
+
+  );
+
+  COMMENT ON COLUMN survey_stratum.survey_stratum_id        IS 'System generated surrogate primary key identifier.';
+  COMMENT ON COLUMN survey_stratum.survey_id                IS 'The id of the survey.';
+  COMMENT ON COLUMN survey_stratum.name                     IS 'The name of the stratum.';
+  COMMENT ON COLUMN survey_stratum.description              IS 'Additional details of the stratum.';
+  COMMENT ON COLUMN survey_stratum.create_date              IS 'The datetime the record was created.';
+  COMMENT ON COLUMN survey_stratum.create_user              IS 'The id of the user who created the record as identified in the system user table.';
+  COMMENT ON COLUMN survey_stratum.update_date              IS 'The datetime the record was updated.';
+  COMMENT ON COLUMN survey_stratum.update_user              IS 'The id of the user who updated the record as identified in the system user table.';
+  COMMENT ON COLUMN survey_stratum.revision_count           IS 'Revision count used for concurrency control.';
+  COMMENT ON TABLE  survey_stratum                          IS 'Information about survey stratums';
+
+
+  -- Add foreign key constraint from child table to parent table on survey_id
+  ALTER TABLE survey_stratum ADD CONSTRAINT survey_stratum_fk1
+    FOREIGN KEY (survey_id)
+    REFERENCES survey(survey_id);
+
+  -- Add unique constraint
+  CREATE UNIQUE INDEX survey_stratum_uk1 ON survey_stratum(survey_id, name);
+
+  -- Create audit and journal triggers
+  create trigger audit_observation before insert or update or delete on survey_stratum for each row execute procedure tr_audit_trigger();
+  create trigger journal_observation after insert or update or delete on survey_stratum for each row execute procedure tr_journal_trigger();
+
+  ----------------------------------------------------------------------------------------
+  -- Create views
+  ----------------------------------------------------------------------------------------
+
+  set search_path=biohub_dapi_v1;
+
+  create or replace view survey_stratum as select * from biohub.survey_stratum;
 
 `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}

--- a/database/src/migrations/20230818000000_survey_stratum.ts
+++ b/database/src/migrations/20230818000000_survey_stratum.ts
@@ -46,6 +46,9 @@ export async function up(knex: Knex): Promise<void> {
     FOREIGN KEY (survey_id)
     REFERENCES survey(survey_id);
 
+  -- Add foreign key index
+  CREATE INDEX surve_stratum_idx1 ON survey_stratum(survey_id);
+
   -- Add unique constraint
   CREATE UNIQUE INDEX survey_stratum_uk1 ON survey_stratum(survey_id, name);
 


### PR DESCRIPTION
## Links to Jira Tickets

- [https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-241](url)

## Description of Changes

- New critter table
- New observation table
- New deployment table
- New survey_stratum table
- New trigger for monitoring total critter count to be less than observation total count

## Testing Notes 
- Included simple test sql script on ticket 241
[https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-241](url)
- Only allowed to add as many critters per observation_id as the total_count
- Unique index on critterbase_critter_id (this id is a external Critterbase critter_id)
- 
