### PR TITLE
BugFix - Adjust Error Handling On Survey Participation Repo Function

### DIFF
--- a/api/src/repositories/survey-participation-repository.test.ts
+++ b/api/src/repositories/survey-participation-repository.test.ts
@@ -78,18 +78,15 @@ describe('SurveyParticipationRepository', () => {
       expect(response).to.eql([{ id: 1 }]);
     });
 
-    it('should throw an error when no rows returned', async () => {
+    it('should return no rows', async () => {
       const mockResponse = ({ rows: [], rowCount: 0 } as any) as Promise<QueryResult<any>>;
       const dbConnection = getMockDBConnection({ sql: () => mockResponse });
 
       const repository = new SurveyParticipationRepository(dbConnection);
 
-      try {
-        await repository.getSurveyParticipants(1);
-        expect.fail();
-      } catch (error) {
-        expect((error as Error).message).to.equal('Failed to get survey participants');
-      }
+      const response = await repository.getSurveyParticipants(1);
+
+      expect(response).to.eql([]);
     });
   });
 

--- a/api/src/repositories/survey-participation-repository.ts
+++ b/api/src/repositories/survey-participation-repository.ts
@@ -90,7 +90,7 @@ export class SurveyParticipationRepository extends BaseRepository {
   }
 
   /**
-   * Get a survey participant record with job name.
+   * Get a survey participant record.
    *
    * @param {number} surveyId
    * @param {number} systemUserId
@@ -155,7 +155,7 @@ export class SurveyParticipationRepository extends BaseRepository {
   }
 
   /**
-   * Get a survey participant record with job name.
+   * Get survey participant records.
    *
    * @param {number} surveyId
    * @return {*}  {Promise<SurveyUser[]>}
@@ -214,13 +214,6 @@ export class SurveyParticipationRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql(sqlStatement, SurveyUser.merge(SystemUser));
-
-    if (!response.rows.length) {
-      throw new ApiExecuteSQLError('Failed to get survey participants', [
-        'SurveyParticipationRepository->getSurveyParticipants',
-        'rows was null or undefined, expected rows != null'
-      ]);
-    }
 
     return response.rows;
   }


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Fix bad error handling on a repo function. Function was throwing on empty array, when empty array should be expected/allowed.

## Testing Notes

Projects/survey pages should load without error when the survey has not defined any survey level participant jobs
