### PR TITLE
BugFix: Fix Funding Source Migration

### DIFF
--- a/database/src/migrations/20230802000000_new_funding_table.ts
+++ b/database/src/migrations/20230802000000_new_funding_table.ts
@@ -35,7 +35,7 @@ export async function up(knex: Knex): Promise<void> {
   -------------------------------------------------------------------------
   CREATE TABLE funding_source(
     funding_source_id        integer           GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
-    name                     varchar(50)       NOT NULL,
+    name                     varchar(100)      NOT NULL,
     description              varchar(250)      NOT NULL,
     start_date               date,
     end_date                 date,


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

New funding source name field was shorter than old name field, causing migration to fail. 
Only caught in Test, where some funding sources had names longer than 50 characters.

## Testing Notes

Migration runs successfully.
