### PR TITLE
BugFixes: Misc Fixes

### DIFF
--- a/api/src/models/survey-view.test.ts
+++ b/api/src/models/survey-view.test.ts
@@ -26,11 +26,11 @@ describe('GetSurveyData', () => {
     });
 
     it('sets end_date', () => {
-      expect(data.end_date).to.equal('undefined');
+      expect(data.end_date).to.equal(null);
     });
 
     it('sets start_date', () => {
-      expect(data.start_date).to.equal('undefined');
+      expect(data.start_date).to.equal(null);
     });
 
     it('sets geojson', () => {

--- a/api/src/models/survey-view.ts
+++ b/api/src/models/survey-view.ts
@@ -44,8 +44,6 @@ export class GetSurveyData {
     this.survey_name = obj?.name || '';
     this.start_date = obj?.start_date || null;
     this.end_date = obj?.end_date || null;
-    this.start_date = String(obj?.start_date) || '';
-    this.end_date = String(obj?.end_date) || '';
     this.geometry = (obj?.geojson?.length && obj.geojson) || [];
     this.survey_types = (obj?.survey_types?.length && obj.survey_types) || [];
     this.revision_count = obj?.revision_count || 0;


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

- Fix bug in survey view response dates being cast to strings (causing a null end_date to return as the string `'null'`)
  - Steps to reproduce (pre-fix):
    -  Create a project with no end date
    - Create a survey with no end date
    - See that the survey timeline on the view page is empty, because the response contains an end_date of `'null'` (as a string) rather than a proper `null` value.

## Testing Notes

n/a
