### PR TITLE
SIMSBIOHUB-336/337

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
@@ -557,7 +557,7 @@ describe('insertUpdateSurveyObservations', () => {
   });
 });
 
-describe('getSurveyObservations', () => {
+describe('getSurveyObservationsWithSupplementaryData', () => {
   afterEach(() => {
     sinon.restore();
   });
@@ -585,7 +585,8 @@ describe('getSurveyObservations', () => {
                   observation_date: '1970-01-01',
                   observation_time: '00:00:00'
                 }
-              ]
+              ],
+              supplementaryObservationData: { observationCount: 1 }
             }
           };
 
@@ -614,7 +615,8 @@ describe('getSurveyObservations', () => {
                   observation_date: '1970-01-01',
                   observation_time: '00:00:00'
                 }
-              ]
+              ],
+              supplementaryObservationData: { observationCount: 1 }
             }
           };
 
@@ -635,7 +637,8 @@ describe('getSurveyObservations', () => {
       describe('should succeed when', () => {
         it('returns an empty array', () => {
           const apiResponse = {
-            surveyObservations: []
+            surveyObservations: [],
+            supplementaryObservationData: { observationCount: 0 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -660,7 +663,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -687,7 +691,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -715,7 +720,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -743,7 +749,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -771,7 +778,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -799,7 +807,8 @@ describe('getSurveyObservations', () => {
                 update_date: '1970-01-01',
                 revision_count: 1
               }
-            ]
+            ],
+            supplementaryObservationData: { observationCount: 1 }
           };
 
           const response = responseValidator.validateResponse(200, apiResponse);
@@ -819,8 +828,14 @@ describe('getSurveyObservations', () => {
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
     const getSurveyObservationsStub = sinon
-      .stub(ObservationService.prototype, 'getSurveyObservations')
-      .resolves(([{ survey_observation_id: 1 }, { survey_observation_id: 2 }] as unknown) as ObservationRecord[]);
+      .stub(ObservationService.prototype, 'getSurveyObservationsWithSupplementaryData')
+      .resolves({
+        surveyObservations: ([
+          { survey_observation_id: 1 },
+          { survey_observation_id: 2 }
+        ] as unknown) as ObservationRecord[],
+        supplementaryObservationData: { observationCount: 2 }
+      });
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -835,7 +850,8 @@ describe('getSurveyObservations', () => {
     expect(getSurveyObservationsStub).to.have.been.calledOnceWith(2);
     expect(mockRes.statusValue).to.equal(200);
     expect(mockRes.jsonValue).to.eql({
-      surveyObservations: [{ survey_observation_id: 1 }, { survey_observation_id: 2 }]
+      surveyObservations: [{ survey_observation_id: 1 }, { survey_observation_id: 2 }],
+      supplementaryObservationData: { observationCount: 2 }
     });
   });
 
@@ -844,7 +860,9 @@ describe('getSurveyObservations', () => {
 
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
-    sinon.stub(ObservationService.prototype, 'getSurveyObservations').rejects(new Error('a test error'));
+    sinon
+      .stub(ObservationService.prototype, 'getSurveyObservationsWithSupplementaryData')
+      .rejects(new Error('a test error'));
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
@@ -296,8 +296,8 @@ export function getSurveyObservations(): RequestHandler {
 
       const observationService = new ObservationService(connection);
 
-      const surveyObservations = await observationService.getSurveyObservations(surveyId);
-      return res.status(200).json({ surveyObservations });
+      const observationData = await observationService.getSurveyObservationsWithSupplementaryData(surveyId);
+      return res.status(200).json(observationData);
     } catch (error) {
       defaultLog.error({ label: 'getSurveyObservations', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
@@ -160,6 +160,20 @@ GET.apiDoc = {
         'application/json': {
           schema: {
             ...surveyObservationsResponseSchema,
+            required: ['surveyObservations', 'supplementaryObservationData'],
+            properties: {
+              ...surveyObservationsResponseSchema.properties,
+              supplementaryObservationData: {
+                type: 'object',
+                required: ['rowCount'],
+                properties: {
+                  rowCount: {
+                    type: 'integer',
+                    minimum: 0
+                  }
+                }
+              }
+            },
             title: 'Survey get response object, for view purposes'
           }
         }

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
@@ -165,9 +165,9 @@ GET.apiDoc = {
               ...surveyObservationsResponseSchema.properties,
               supplementaryObservationData: {
                 type: 'object',
-                required: ['rowCount'],
+                required: ['observationCount'],
                 properties: {
-                  rowCount: {
+                  observationCount: {
                     type: 'integer',
                     minimum: 0
                   }

--- a/api/src/repositories/observation-repository.test.ts
+++ b/api/src/repositories/observation-repository.test.ts
@@ -136,6 +136,22 @@ describe('ObservationRepository', () => {
     });
   });
 
+  describe('getSurveyObservationCount', () => {
+    it('gets the count of survey observations for the given survey', async () => {
+      const mockQueryResponse = ({ rows: [{ rowCount: 1 }] } as unknown) as QueryResult<any>;
+
+      const mockDBConnection = getMockDBConnection({
+        knex: sinon.stub().resolves(mockQueryResponse)
+      });
+
+      const repo = new ObservationRepository(mockDBConnection);
+
+      const response = await repo.getSurveyObservationCount(1);
+
+      expect(response).to.eql({ observationCount: 1 });
+    });
+  });
+
   describe('insertSurveyObservationSubmission', () => {
     it('inserts a survey observation submission record', async () => {
       const mockQueryResponse = ({ rows: [1] } as unknown) as QueryResult<any>;

--- a/api/src/repositories/observation-repository.ts
+++ b/api/src/repositories/observation-repository.ts
@@ -227,7 +227,7 @@ export class ObservationRepository extends BaseRepository {
       .where('survey_id', surveyId);
 
     const response = await this.connection.knex(sqlStatement);
-    const observationCount = parseInt(response.rows[0].rowCount, 10);
+    const observationCount = Number(response.rows[0].rowCount);
     return { observationCount };
   }
 

--- a/api/src/repositories/observation-repository.ts
+++ b/api/src/repositories/observation-repository.ts
@@ -79,12 +79,6 @@ export const ObservationSubmissionRecord = z.object({
 
 export type ObservationSubmissionRecord = z.infer<typeof ObservationSubmissionRecord>;
 
-export const ObservationSupplementaryData = z.object({
-  rowCount: z.number()
-});
-
-export type ObservationSupplementaryData = z.infer<typeof ObservationSupplementaryData>;
-
 const defaultLog = getLogger('repositories/observation-repository');
 
 export class ObservationRepository extends BaseRepository {
@@ -218,13 +212,13 @@ export class ObservationRepository extends BaseRepository {
   }
 
   /**
-   * Retrieves the number of survey observation records for the given survey
+   * Retrieves the count of survey observations for the given survey
    *
    * @param {number} surveyId
-   * @return {*}  {Promise<ObservationSupplementaryData>}
+   * @return {*}  {Promise<{ observationCount: number }>}
    * @memberof ObservationRepository
    */
-  async getSurveyObservationRowCount(surveyId: number): Promise<ObservationSupplementaryData> {
+  async getSurveyObservationCount(surveyId: number): Promise<{ observationCount: number }> {
     const knex = getKnex();
     const sqlStatement = knex
       .queryBuilder()
@@ -233,8 +227,8 @@ export class ObservationRepository extends BaseRepository {
       .where('survey_id', surveyId);
 
     const response = await this.connection.knex(sqlStatement);
-    const rowCount = parseInt(response.rows[0].rowCount, 10);
-    return { rowCount };
+    const observationCount = parseInt(response.rows[0].rowCount, 10);
+    return { observationCount };
   }
 
   /**

--- a/api/src/repositories/observation-repository.ts
+++ b/api/src/repositories/observation-repository.ts
@@ -79,6 +79,12 @@ export const ObservationSubmissionRecord = z.object({
 
 export type ObservationSubmissionRecord = z.infer<typeof ObservationSubmissionRecord>;
 
+export const ObservationSupplementaryData = z.object({
+  rowCount: z.number()
+});
+
+export type ObservationSupplementaryData = z.infer<typeof ObservationSupplementaryData>;
+
 const defaultLog = getLogger('repositories/observation-repository');
 
 export class ObservationRepository extends BaseRepository {
@@ -209,6 +215,19 @@ export class ObservationRepository extends BaseRepository {
 
     const response = await this.connection.knex(sqlStatement, ObservationRecord);
     return response.rows;
+  }
+
+  async getSurveyObservationRowCount(surveyId: number): Promise<ObservationSupplementaryData> {
+    const knex = getKnex();
+    const sqlStatement = knex
+      .queryBuilder()
+      .count('survey_observation_id as rowCount')
+      .from('survey_observation')
+      .where('survey_id', surveyId);
+
+    const response = await this.connection.knex(sqlStatement);
+    const rowCount = parseInt(response.rows[0].rowCount, 10);
+    return { rowCount };
   }
 
   /**

--- a/api/src/repositories/observation-repository.ts
+++ b/api/src/repositories/observation-repository.ts
@@ -217,6 +217,13 @@ export class ObservationRepository extends BaseRepository {
     return response.rows;
   }
 
+  /**
+   * Retrieves the number of survey observation records for the given survey
+   *
+   * @param {number} surveyId
+   * @return {*}  {Promise<ObservationSupplementaryData>}
+   * @memberof ObservationRepository
+   */
   async getSurveyObservationRowCount(surveyId: number): Promise<ObservationSupplementaryData> {
     const knex = getKnex();
     const sqlStatement = knex

--- a/api/src/services/observation-service.test.ts
+++ b/api/src/services/observation-service.test.ts
@@ -108,11 +108,11 @@ describe('ObservationService', () => {
     });
   });
 
-  describe('getSurveyObservations', () => {
+  describe('getSurveyObservationsWithSupplementaryData', () => {
     it('Gets observations by survey id', async () => {
       const mockDBConnection = getMockDBConnection();
 
-      const mockGetResponse: ObservationRecord[] = [
+      const mockObservations: ObservationRecord[] = [
         {
           survey_observation_id: 11,
           survey_id: 1,
@@ -150,18 +150,31 @@ describe('ObservationService', () => {
           survey_sample_period_id: 1
         }
       ];
+
+      const mockSupplementaryData = {
+        observationCount: 1
+      };
+
       const getSurveyObservationsStub = sinon
         .stub(ObservationRepository.prototype, 'getSurveyObservations')
-        .resolves(mockGetResponse);
+        .resolves(mockObservations);
+
+      const getSurveyObservationSupplementaryDataStub = sinon
+        .stub(ObservationRepository.prototype, 'getSurveyObservationCount')
+        .resolves(mockSupplementaryData);
 
       const surveyId = 1;
 
       const observationService = new ObservationService(mockDBConnection);
 
-      const response = await observationService.getSurveyObservations(surveyId);
+      const response = await observationService.getSurveyObservationsWithSupplementaryData(surveyId);
 
       expect(getSurveyObservationsStub).to.be.calledOnceWith(surveyId);
-      expect(response).to.eql(mockGetResponse);
+      expect(getSurveyObservationSupplementaryDataStub).to.be.calledOnceWith(surveyId);
+      expect(response).to.eql({
+        surveyObservations: mockObservations,
+        supplementaryObservationData: mockSupplementaryData
+      });
     });
   });
 

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -1,11 +1,11 @@
 import xlsx from 'xlsx';
+import { z } from 'zod';
 import { IDBConnection } from '../database/db';
 import {
   InsertObservation,
   ObservationRecord,
   ObservationRepository,
   ObservationSubmissionRecord,
-  ObservationSupplementaryData,
   UpdateObservation
 } from '../repositories/observation-repository';
 import { generateS3FileKey, getFileFromS3 } from '../utils/file-utils';
@@ -31,6 +31,13 @@ const observationCSVColumnValidator = {
   columnNames: ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
   columnTypes: ['number', 'number', 'date', 'string', 'number', 'number']
 };
+
+export const ObservationSupplementaryData = z.object({
+  observationCount: z.number()
+});
+
+export type ObservationSupplementaryData = z.infer<typeof ObservationSupplementaryData>;
+
 export class ObservationService extends DBService {
   observationRepository: ObservationRepository;
 
@@ -96,7 +103,7 @@ export class ObservationService extends DBService {
     surveyId: number
   ): Promise<{ surveyObservations: ObservationRecord[]; supplementaryObservationData: ObservationSupplementaryData }> {
     const surveyObservations = await this.observationRepository.getSurveyObservations(surveyId);
-    const supplementaryObservationData = await this.observationRepository.getSurveyObservationRowCount(surveyId);
+    const supplementaryObservationData = await this.observationRepository.getSurveyObservationCount(surveyId);
     return { surveyObservations, supplementaryObservationData };
   }
 

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -5,6 +5,7 @@ import {
   ObservationRecord,
   ObservationRepository,
   ObservationSubmissionRecord,
+  ObservationSupplementaryData,
   UpdateObservation
 } from '../repositories/observation-repository';
 import { generateS3FileKey, getFileFromS3 } from '../utils/file-utils';
@@ -88,11 +89,15 @@ export class ObservationService extends DBService {
    * Retrieves all observation records for the given survey
    *
    * @param {number} surveyId
-   * @return {*}  {Promise<ObservationRecord[]>}
+   * @return {*}  {Promise<{ surveyObservations: ObservationRecord[]; supplementaryObservationData: ObservationSupplementaryData }>}
    * @memberof ObservationService
    */
-  async getSurveyObservations(surveyId: number): Promise<ObservationRecord[]> {
-    return this.observationRepository.getSurveyObservations(surveyId);
+  async getSurveyObservationsWithSupplementaryData(
+    surveyId: number
+  ): Promise<{ surveyObservations: ObservationRecord[]; supplementaryObservationData: ObservationSupplementaryData }> {
+    const surveyObservations = await this.observationRepository.getSurveyObservations(surveyId);
+    const supplementaryObservationData = await this.observationRepository.getSurveyObservationRowCount(surveyId);
+    return { surveyObservations, supplementaryObservationData };
   }
 
   /**

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -86,7 +86,7 @@ export class ObservationService extends DBService {
   }
 
   /**
-   * Retrieves all observation records for the given survey
+   * Retrieves all observation records for the given survey along with supplementary data
    *
    * @param {number} surveyId
    * @return {*}  {Promise<{ surveyObservations: ObservationRecord[]; supplementaryObservationData: ObservationSupplementaryData }>}

--- a/app/src/features/surveys/observations/ObservationComponent.tsx
+++ b/app/src/features/surveys/observations/ObservationComponent.tsx
@@ -46,7 +46,7 @@ const ObservationComponent = () => {
   const hasUnsavedChanges = observationsContext.hasUnsavedChanges();
   const [showConfirmRemoveAllDialog, setShowConfirmRemoveAllDialog] = useState<boolean>(false);
   const observationCount =
-    observationsContext.observationsDataLoader?.data?.supplementaryObservationData?.rowCount ?? 0;
+    observationsContext.observationsDataLoader?.data?.supplementaryObservationData?.observationCount ?? 0;
 
   return (
     <>

--- a/app/src/features/surveys/observations/ObservationComponent.tsx
+++ b/app/src/features/surveys/observations/ObservationComponent.tsx
@@ -45,6 +45,8 @@ const ObservationComponent = () => {
 
   const hasUnsavedChanges = observationsContext.hasUnsavedChanges();
   const [showConfirmRemoveAllDialog, setShowConfirmRemoveAllDialog] = useState<boolean>(false);
+  const observationCount =
+    observationsContext.observationsDataLoader?.data?.supplementaryObservationData?.rowCount ?? 0;
 
   return (
     <>
@@ -99,7 +101,7 @@ const ObservationComponent = () => {
               fontSize: '1.125rem',
               fontWeight: 700
             }}>
-            Observations
+            {`Observations (${observationCount})`}
           </Typography>
 
           <Box

--- a/app/src/features/surveys/observations/ObservationComponent.tsx
+++ b/app/src/features/surveys/observations/ObservationComponent.tsx
@@ -101,7 +101,10 @@ const ObservationComponent = () => {
               fontSize: '1.125rem',
               fontWeight: 700
             }}>
-            {`Observations (${observationCount})`}
+            Observations &zwnj;
+            <Typography sx={{ fontWeight: '400' }} component="span" variant="inherit" color="textSecondary">
+              ({observationCount})
+            </Typography>
           </Typography>
 
           <Box

--- a/app/src/features/surveys/observations/sampling-sites/SamplingSiteList.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/SamplingSiteList.tsx
@@ -64,6 +64,8 @@ const SamplingSiteList = () => {
     setSelectedSampleSiteId(sample_site_id);
   };
 
+  const samplingSiteCount = surveyContext.sampleSiteDataLoader.data?.sampleSites.length ?? 0;
+
   return (
     <>
       <Menu
@@ -118,7 +120,7 @@ const SamplingSiteList = () => {
               fontSize: '1.125rem',
               fontWeight: 700
             }}>
-            Sampling Sites
+            {`Sampling Sites (${samplingSiteCount})`}
           </Typography>
           <Button
             sx={{

--- a/app/src/features/surveys/observations/sampling-sites/SamplingSiteList.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/SamplingSiteList.tsx
@@ -120,7 +120,10 @@ const SamplingSiteList = () => {
               fontSize: '1.125rem',
               fontWeight: 700
             }}>
-            {`Sampling Sites (${samplingSiteCount})`}
+            Sampling Sites &zwnj;
+            <Typography sx={{ fontWeight: '400' }} component="span" variant="inherit" color="textSecondary">
+              ({samplingSiteCount})
+            </Typography>
           </Typography>
           <Button
             sx={{

--- a/app/src/features/surveys/view/SurveyPage.tsx
+++ b/app/src/features/surveys/view/SurveyPage.tsx
@@ -36,7 +36,7 @@ const SurveyPage: React.FC = () => {
   const observationsContext = useContext(ObservationsContext);
 
   const numObservations: number =
-    observationsContext.observationsDataLoader.data?.supplementaryObservationData?.rowCount || 0;
+    observationsContext.observationsDataLoader.data?.supplementaryObservationData?.observationCount || 0;
 
   useEffect(() => {
     codesContext.codesDataLoader.load();

--- a/app/src/features/surveys/view/SurveyPage.tsx
+++ b/app/src/features/surveys/view/SurveyPage.tsx
@@ -35,7 +35,8 @@ const SurveyPage: React.FC = () => {
   const surveyContext = useContext(SurveyContext);
   const observationsContext = useContext(ObservationsContext);
 
-  const numObservations: number = observationsContext.observationsDataLoader.data?.surveyObservations.length || 0;
+  const numObservations: number =
+    observationsContext.observationsDataLoader.data?.supplementaryObservationData?.rowCount || 0;
 
   useEffect(() => {
     codesContext.codesDataLoader.load();

--- a/app/src/interfaces/useObservationApi.interface.ts
+++ b/app/src/interfaces/useObservationApi.interface.ts
@@ -2,5 +2,5 @@ import { IObservationRecord } from 'contexts/observationsContext';
 
 export interface IGetSurveyObservationsResponse {
   surveyObservations: IObservationRecord[];
-  supplementaryObservationData: { rowCount: number };
+  supplementaryObservationData: { observationCount: number };
 }

--- a/app/src/interfaces/useObservationApi.interface.ts
+++ b/app/src/interfaces/useObservationApi.interface.ts
@@ -2,4 +2,5 @@ import { IObservationRecord } from 'contexts/observationsContext';
 
 export interface IGetSurveyObservationsResponse {
   surveyObservations: IObservationRecord[];
+  supplementaryObservationData: { rowCount: number };
 }


### PR DESCRIPTION
## Links to Jira Tickets
- [SIMSBIOHUB-336](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-336)
- [SIMSBIOHUB-337](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-337)

## Description of Changes

- Adds Sampling Site record count to title area, Example: Sampling Sites (10)
- Adds Observation record count to title area of observations map component and manage observations page, Example: Observations (10)
- Adds 'supplementaryObservationData' section to get survey observations endpoint
  - This allows observation record counts to be displayed, even if the get observations response becomes paginated or virtualized at a later date 