### PR TITLE
SIMSBIOHUB 343 - Incorrect date overlap error in sampling methods

### DIFF
--- a/app/src/features/surveys/components/EditSamplingMethod.tsx
+++ b/app/src/features/surveys/components/EditSamplingMethod.tsx
@@ -15,7 +15,7 @@ interface IEditSamplingMethodProps {
 
 export const SamplingSiteMethodYupSchema = yup.object({
   method_lookup_id: yup.number().required(),
-  description: yup.string().required(),
+  description: yup.string(),
   periods: yup
     .array(
       yup.object({
@@ -27,7 +27,7 @@ export const SamplingSiteMethodYupSchema = yup.object({
           .required('End date is required')
       })
     )
-    .hasUniqueDateRanges('Periods cannot overlap', 'start_date', 'end_state')
+    .hasUniqueDateRanges('Periods cannot overlap', 'start_date', 'end_date')
     .min(1, 'At least one time period is required')
 });
 

--- a/app/src/features/surveys/observations/sampling-sites/edit/SamplingSiteEditPage.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/edit/SamplingSiteEditPage.tsx
@@ -117,6 +117,7 @@ const SamplingSiteEditPage = () => {
       setEnableCancelCheck(false);
       // create complete, navigate back to observations page
       history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/observations`);
+      surveyContext.sampleSiteDataLoader.refresh(surveyContext.projectId, surveyContext.surveyId);
     } catch (error) {
       showCreateErrorDialog({
         dialogTitle: CreateSamplingSiteI18N.createErrorTitle,


### PR DESCRIPTION
Re-opening https://github.com/bcgov/biohubbc/pull/1144.
## Links to Jira Tickets

- [SIMSBIOHUB-343](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-343)

## Description of Changes

- Fixed an issue where the yup schema used for editing sampling methods used the wrong field for a date overlap check. 
- Removed an unintended required(). 
- Added a refresh call when submitting sampling method changes so they are reflected in the UI. Otherwise you will still see the previous value if you go back to the sampling methods view even though the new value did save to the db.

