### PR TITLE
SIMSBIOHUB 347/341 - Names from shapefiles

### DIFF
--- a/api/src/repositories/sample-location-repository.ts
+++ b/api/src/repositories/sample-location-repository.ts
@@ -152,6 +152,10 @@ export class SampleLocationRepository extends BaseRepository {
    * @memberof SampleLocationRepository
    */
   async insertSampleLocation(sample: InsertSampleLocationRecord): Promise<SampleLocationRecord> {
+    const name = sample.name
+      ? SQL`${sample.name}`
+      : SQL`(SELECT concat('Sample Site ', (SELECT count(survey_sample_site_id) + 1 FROM survey_sample_site sss WHERE survey_id = ${sample.survey_id})))`;
+
     const sqlStatement = SQL`
     INSERT INTO survey_sample_site (
       survey_id,
@@ -160,11 +164,10 @@ export class SampleLocationRepository extends BaseRepository {
       geojson,
       geography
     ) VALUES (
-      ${sample.survey_id},
-      (SELECT concat('Sample Site ', (SELECT count(survey_sample_site_id) + 1 FROM survey_sample_site sss WHERE survey_id = ${sample.survey_id}))),
-      ${sample.description},
-      ${sample.geojson},
-      `;
+      ${sample.survey_id},`.append(name).append(SQL`,
+        ${sample.description},
+        ${sample.geojson},
+        `);
     const geometryCollectionSQL = generateGeometryCollectionSQL(sample.geojson);
 
     sqlStatement.append(SQL`

--- a/api/src/repositories/sample-location-repository.ts
+++ b/api/src/repositories/sample-location-repository.ts
@@ -25,7 +25,9 @@ export const SampleLocationRecord = z.object({
 export type SampleLocationRecord = z.infer<typeof SampleLocationRecord>;
 
 // Insert Object for Sample Locations
-export type InsertSampleLocationRecord = Pick<SampleLocationRecord, 'survey_id' | 'name' | 'description' | 'geojson'>;
+export type InsertSampleLocationRecord = Pick<SampleLocationRecord, 'survey_id' | 'description' | 'geojson'> & {
+  name: string | undefined;
+};
 
 // Update Object for Sample Locations
 export type UpdateSampleLocationRecord = Pick<
@@ -152,7 +154,7 @@ export class SampleLocationRepository extends BaseRepository {
    * @memberof SampleLocationRepository
    */
   async insertSampleLocation(sample: InsertSampleLocationRecord): Promise<SampleLocationRecord> {
-    const name = sample.name
+    const shapeNameOrQuery = sample.name
       ? SQL`${sample.name}`
       : SQL`(SELECT concat('Sample Site ', (SELECT count(survey_sample_site_id) + 1 FROM survey_sample_site sss WHERE survey_id = ${sample.survey_id})))`;
 
@@ -164,7 +166,7 @@ export class SampleLocationRepository extends BaseRepository {
       geojson,
       geography
     ) VALUES (
-      ${sample.survey_id},`.append(name).append(SQL`,
+      ${sample.survey_id},`.append(shapeNameOrQuery).append(SQL`,
         ${sample.description},
         ${sample.geojson},
         `);

--- a/api/src/services/sample-location-service.ts
+++ b/api/src/services/sample-location-service.ts
@@ -68,13 +68,13 @@ export class SampleLocationService extends DBService {
       const nameKey = Object.keys(geometry.properties ?? {}).find(
         (key) => key.toLowerCase() === 'name' || key.toLowerCase() === 'label'
       );
-      return nameKey && geometry.properties ? geometry.properties[nameKey] : '';
+      return nameKey && geometry.properties ? geometry.properties[nameKey].substring(0, 50) : '';
     };
     const determineDesc = (geometry: Feature<Geometry | GeometryCollection, Properties>) => {
       const descKey = Object.keys(geometry.properties ?? {}).find(
         (key) => key.toLowerCase() === 'desc' || key.toLowerCase() === 'description'
       );
-      return descKey && geometry.properties ? geometry.properties[descKey] : '';
+      return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : '';
     };
     // Create a sample location for each feature found
     const promises = sampleLocations.survey_sample_sites.map((item) => {

--- a/api/src/services/sample-location-service.ts
+++ b/api/src/services/sample-location-service.ts
@@ -58,30 +58,37 @@ export class SampleLocationService extends DBService {
   /**
    * Inserts survey Sample Locations.
    *
+   * It is a business requirement to use strings from the properties field of provided geometry
+   * to determine the name and description of sampling locations when possible.
+   *
+   * If there is no string contained in the fields 'name', 'label' to be used in our db,
+   * the system will auto-generate a name of 'Sampling Site #x', where x is taken from the greatest value
+   * integer id + 1 in the db.
+   *
    * @param {PostSampleLocations} sampleLocations
    * @return {*}  {Promise<SampleLocationRecord[]>}
    * @memberof SampleLocationService
    */
   async insertSampleLocations(sampleLocations: PostSampleLocations): Promise<SampleLocationRecord[]> {
     const methodService = new SampleMethodService(this.connection);
-    const determineName = (geometry: Feature<Geometry | GeometryCollection, Properties>) => {
+    const shapeFileFeatureName = (geometry: Feature<Geometry | GeometryCollection, Properties>): string | undefined => {
       const nameKey = Object.keys(geometry.properties ?? {}).find(
         (key) => key.toLowerCase() === 'name' || key.toLowerCase() === 'label'
       );
-      return nameKey && geometry.properties ? geometry.properties[nameKey].substring(0, 50) : '';
+      return nameKey && geometry.properties ? geometry.properties[nameKey].substring(0, 50) : undefined;
     };
-    const determineDesc = (geometry: Feature<Geometry | GeometryCollection, Properties>) => {
+    const shapeFileFeatureDesc = (geometry: Feature<Geometry | GeometryCollection, Properties>): string | undefined => {
       const descKey = Object.keys(geometry.properties ?? {}).find(
-        (key) => key.toLowerCase() === 'desc' || key.toLowerCase() === 'description'
+        (key) => key.toLowerCase() === 'desc' || key.toLowerCase() === 'descr' || key.toLowerCase() === 'des'
       );
-      return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : '';
+      return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : undefined;
     };
     // Create a sample location for each feature found
     const promises = sampleLocations.survey_sample_sites.map((item) => {
       const sampleLocation = {
         survey_id: sampleLocations.survey_id,
-        name: determineName(item), // Please note that additional logic for this also happens in insertSampleLocation below
-        description: determineDesc(item) || sampleLocations.description,
+        name: shapeFileFeatureName(item), // If this function returns undefined, insertSampleLocation will auto-generate a name instead.
+        description: shapeFileFeatureDesc(item) || sampleLocations.description,
         geojson: item
       };
 

--- a/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteEditForm.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteEditForm.tsx
@@ -33,7 +33,7 @@ export interface ISampleSiteEditFormProps {
 
 export const samplingSiteYupSchema = yup.object({
   sampleSite: yup.object({
-    name: yup.string().default('').max(50),
+    name: yup.string().default('').max(50, 'Maximum 50 characters.'),
     description: yup.string().default('').nullable(),
     survey_sample_sites: yup
       .array(yup.object())

--- a/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteEditForm.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteEditForm.tsx
@@ -33,7 +33,7 @@ export interface ISampleSiteEditFormProps {
 
 export const samplingSiteYupSchema = yup.object({
   sampleSite: yup.object({
-    name: yup.string().default(''),
+    name: yup.string().default('').max(50),
     description: yup.string().default('').nullable(),
     survey_sample_sites: yup
       .array(yup.object())

--- a/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteGeneralInformationForm.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/edit/components/SampleSiteGeneralInformationForm.tsx
@@ -15,9 +15,7 @@ const SampleSiteGeneralInformationForm: React.FC = (props) => {
           <CustomTextField
             name="sampleSite.name"
             label="Name"
-            other={{
-              required: true
-            }}
+            other={{ placeholder: 'Maximum 50 characters', required: true }}
           />
         </Grid>
         <Grid item xs={12}>


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-347](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-347)
- [SIMSBIOHUB-341](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-341)

## Description of Changes

- Added some additional logic to the API to extract a name and description from the provided shape file when creating sampling sites.
- It will search the keys of the geometry's properties for "name" or "label" and "desc" or "description" (exact match, should we allow substring?), then use the value for the sampling site name and description respectively. 
- Added a character limit to the sampling site name field in the edit form. 

## Testing Notes

- `OminecaShapefile.zip`'s properties are an example of something that won't be picked up by this approach.
- `62_Features_Shapefile.zip` properties will be used by this approach. 
