### PR TITLE
SIMSBIOHUB 370: Investigate backend caching for taxonomy endpoint

### DIFF
--- a/api/src/paths/taxonomy/species/list.ts
+++ b/api/src/paths/taxonomy/species/list.ts
@@ -77,7 +77,7 @@ export function getSpeciesFromIds(): RequestHandler {
     try {
       const taxonomyService = new TaxonomyService();
       const response = await taxonomyService.getSpeciesFromIds(ids as string[]);
-
+      res.setHeader('Cache-Control', 'max-age=604800')
       res.status(200).json({ searchResponse: response });
     } catch (error) {
       defaultLog.error({ label: 'getSearchResults', message: 'error', error });

--- a/api/src/paths/taxonomy/species/list.ts
+++ b/api/src/paths/taxonomy/species/list.ts
@@ -77,7 +77,10 @@ export function getSpeciesFromIds(): RequestHandler {
     try {
       const taxonomyService = new TaxonomyService();
       const response = await taxonomyService.getSpeciesFromIds(ids as string[]);
-      res.setHeader('Cache-Control', 'max-age=604800')
+
+      // Overwrite default cache-control header, allow caching up to 7 days
+      res.setHeader('Cache-Control', 'max-age=604800'); 
+
       res.status(200).json({ searchResponse: response });
     } catch (error) {
       defaultLog.error({ label: 'getSearchResults', message: 'error', error });

--- a/api/src/paths/taxonomy/species/search.ts
+++ b/api/src/paths/taxonomy/species/search.ts
@@ -75,7 +75,7 @@ export function searchSpecies(): RequestHandler {
     try {
       const taxonomyService = new TaxonomyService();
       const response = await taxonomyService.searchSpecies(term.toLowerCase());
-
+      res.removeHeader('Cache-Control');
       res.status(200).json({ searchResponse: response });
     } catch (error) {
       defaultLog.error({ label: 'getSearchResults', message: 'error', error });

--- a/api/src/paths/taxonomy/species/search.ts
+++ b/api/src/paths/taxonomy/species/search.ts
@@ -75,7 +75,7 @@ export function searchSpecies(): RequestHandler {
     try {
       const taxonomyService = new TaxonomyService();
       const response = await taxonomyService.searchSpecies(term.toLowerCase());
-      res.removeHeader('Cache-Control');
+      res.setHeader('Cache-Control', 'max-age=604800');
       res.status(200).json({ searchResponse: response });
     } catch (error) {
       defaultLog.error({ label: 'getSearchResults', message: 'error', error });

--- a/api/src/paths/taxonomy/species/search.ts
+++ b/api/src/paths/taxonomy/species/search.ts
@@ -72,10 +72,14 @@ export function searchSpecies(): RequestHandler {
     defaultLog.debug({ label: 'getSearchResults', message: 'request params', req_params: req.query.terms });
 
     const term = String(req.query.terms) || '';
+
     try {
       const taxonomyService = new TaxonomyService();
       const response = await taxonomyService.searchSpecies(term.toLowerCase());
-      res.setHeader('Cache-Control', 'max-age=604800');
+
+      // Overwrite default cache-control header, allow caching up to 7 days
+      res.setHeader('Cache-Control', 'max-age=604800'); 
+
       res.status(200).json({ searchResponse: response });
     } catch (error) {
       defaultLog.error({ label: 'getSearchResults', message: 'error', error });


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-370](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-370)

## Description of Changes

- Sets the Cache-Control header in the search and list taxonomy endpoints to have a max-age. This overrides the default no-cache behaviour elsewhere in the app. 

## Testing Notes

- Note that when listing many observations using the same species the network tab may display a request for each row, however the response will be fetched from cache. In Firefox, the request is greyed out a bit to indicate this.
