### PR TITLE
SIMSBIOHUB-363: Import Survey Area Name and Description from Shapefile

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.ts
@@ -233,14 +233,8 @@ POST.apiDoc = {
       'application/json': {
         schema: {
           type: 'object',
-          required: ['name', 'description', 'methods', 'survey_sample_sites'],
+          required: ['methods', 'survey_sample_sites'],
           properties: {
-            name: {
-              type: 'string'
-            },
-            description: {
-              type: 'string'
-            },
             methods: {
               type: 'array',
               minItems: 1,
@@ -277,7 +271,16 @@ POST.apiDoc = {
               type: 'array',
               minItems: 1,
               items: {
-                ...(GeoJSONFeature as object)
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string'
+                  },
+                  description: {
+                    type: 'string'
+                  },
+                  feature: { ...(GeoJSONFeature as object) }
+                }
               }
             }
           }

--- a/api/src/repositories/sample-location-repository.ts
+++ b/api/src/repositories/sample-location-repository.ts
@@ -154,10 +154,6 @@ export class SampleLocationRepository extends BaseRepository {
    * @memberof SampleLocationRepository
    */
   async insertSampleLocation(sample: InsertSampleLocationRecord): Promise<SampleLocationRecord> {
-    const shapeNameOrQuery = sample.name
-      ? SQL`${sample.name}`
-      : SQL`(SELECT concat('Sample Site ', (SELECT count(survey_sample_site_id) + 1 FROM survey_sample_site sss WHERE survey_id = ${sample.survey_id})))`;
-
     const sqlStatement = SQL`
     INSERT INTO survey_sample_site (
       survey_id,
@@ -166,10 +162,11 @@ export class SampleLocationRepository extends BaseRepository {
       geojson,
       geography
     ) VALUES (
-      ${sample.survey_id},`.append(shapeNameOrQuery).append(SQL`,
-        ${sample.description},
-        ${sample.geojson},
-        `);
+      ${sample.survey_id},
+      ${sample.name},
+      ${sample.description},
+      ${sample.geojson},
+        `;
     const geometryCollectionSQL = generateGeometryCollectionSQL(sample.geojson);
 
     sqlStatement.append(SQL`

--- a/api/src/services/sample-location-service.test.ts
+++ b/api/src/services/sample-location-service.test.ts
@@ -21,24 +21,26 @@ describe('SampleLocationService', () => {
       const mockData: PostSampleLocations = {
         survey_sample_site_id: null,
         survey_id: 1,
-        name: `Sample Site 1`,
-        description: ``,
         survey_sample_sites: [
           {
-            type: 'Feature',
-            geometry: {
-              type: 'Polygon',
-              coordinates: [
-                [
-                  [-121.904297, 50.930738],
-                  [-121.904297, 51.971346],
-                  [-120.19043, 51.971346],
-                  [-120.19043, 50.930738],
-                  [-121.904297, 50.930738]
+            name: `Sample Site 1`,
+            description: ``,
+            feature: {
+              type: 'Feature',
+              geometry: {
+                type: 'Polygon',
+                coordinates: [
+                  [
+                    [-121.904297, 50.930738],
+                    [-121.904297, 51.971346],
+                    [-120.19043, 51.971346],
+                    [-120.19043, 50.930738],
+                    [-121.904297, 50.930738]
+                  ]
                 ]
-              ]
-            },
-            properties: {}
+              },
+              properties: {}
+            }
           }
         ],
         methods: [

--- a/api/src/services/sample-location-service.ts
+++ b/api/src/services/sample-location-service.ts
@@ -1,4 +1,4 @@
-import { Feature, Geometry, GeometryCollection, Properties } from '@turf/helpers';
+import { Feature } from '@turf/helpers';
 import { IDBConnection } from '../database/db';
 import {
   SampleLocationRecord,
@@ -12,9 +12,11 @@ import { SampleMethodService } from './sample-method-service';
 export interface PostSampleLocations {
   survey_sample_site_id: number | null;
   survey_id: number;
-  name: string;
-  description: string;
-  survey_sample_sites: Feature[];
+  survey_sample_sites: {
+    name: string;
+    description: string;
+    feature: Feature;
+  }[];
   methods: InsertSampleMethodRecord[];
 }
 
@@ -79,25 +81,13 @@ export class SampleLocationService extends DBService {
    */
   async insertSampleLocations(sampleLocations: PostSampleLocations): Promise<SampleLocationRecord[]> {
     const methodService = new SampleMethodService(this.connection);
-    const shapeFileFeatureName = (geometry: Feature<Geometry | GeometryCollection, Properties>): string | undefined => {
-      const nameKey = Object.keys(geometry.properties ?? {}).find(
-        (key) => key.toLowerCase() === 'name' || key.toLowerCase() === 'label'
-      );
-      return nameKey && geometry.properties ? geometry.properties[nameKey].substring(0, 50) : undefined;
-    };
-    const shapeFileFeatureDesc = (geometry: Feature<Geometry | GeometryCollection, Properties>): string | undefined => {
-      const descKey = Object.keys(geometry.properties ?? {}).find(
-        (key) => key.toLowerCase() === 'desc' || key.toLowerCase() === 'descr' || key.toLowerCase() === 'des'
-      );
-      return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : undefined;
-    };
     // Create a sample location for each feature found
     const promises = sampleLocations.survey_sample_sites.map((item) => {
       const sampleLocation = {
         survey_id: sampleLocations.survey_id,
-        name: shapeFileFeatureName(item), // If this function returns undefined, insertSampleLocation will auto-generate a name instead.
-        description: shapeFileFeatureDesc(item) || sampleLocations.description,
-        geojson: item
+        name: item.name,
+        description: item.description,
+        geojson: item.feature
       };
 
       return this.sampleLocationRepository.insertSampleLocation(sampleLocation);

--- a/api/src/services/sample-location-service.ts
+++ b/api/src/services/sample-location-service.ts
@@ -9,14 +9,16 @@ import { InsertSampleMethodRecord } from '../repositories/sample-method-reposito
 import { DBService } from './db-service';
 import { SampleMethodService } from './sample-method-service';
 
+interface SampleSite {
+  name: string;
+  description: string;
+  feature: Feature;
+}
+
 export interface PostSampleLocations {
   survey_sample_site_id: number | null;
   survey_id: number;
-  survey_sample_sites: {
-    name: string;
-    description: string;
-    feature: Feature;
-  }[];
+  survey_sample_sites: SampleSite[];
   methods: InsertSampleMethodRecord[];
 }
 

--- a/app/src/features/surveys/components/locations/SurveyAreaMapControl.tsx
+++ b/app/src/features/surveys/components/locations/SurveyAreaMapControl.tsx
@@ -20,6 +20,7 @@ import L, { DrawEvents, LatLngBoundsExpression } from 'leaflet';
 import { useEffect, useState } from 'react';
 import { FeatureGroup, LayersControl, MapContainer as LeafletMapContainer } from 'react-leaflet';
 import { calculateUpdatedMapBounds } from 'utils/mapBoundaryUploadHelpers';
+import { shapeFileFeatureDesc, shapeFileFeatureName } from 'utils/Utils';
 import { ISurveyLocation, ISurveyLocationForm } from '../StudyAreaForm';
 
 export interface ISurveyAreMapControlProps {
@@ -49,8 +50,8 @@ export const SurveyAreaMapControl = (props: ISurveyAreMapControlProps) => {
           // Map features into form data
           const formData = features.map((item: Feature, index) => {
             return {
-              name: `Study Area ${index + 1}`,
-              description: '',
+              name: shapeFileFeatureName(item) ?? `Study Area ${index + 1}`,
+              description: shapeFileFeatureDesc(item) ?? '',
               geojson: [item],
               revision_count: 0
             };

--- a/app/src/features/surveys/observations/sampling-sites/SamplingSitePage.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/SamplingSitePage.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface ISurveySampleSite {
+export interface ISurveySampleSite {
   name: string;
   description: string;
   feature: Feature;
@@ -98,7 +98,7 @@ const SamplingSitePage = () => {
   const handleSubmit = async (values: ICreateSamplingSiteRequest) => {
     try {
       setIsSubmitting(true);
-      
+
       await biohubApi.samplingSite.createSamplingSites(surveyContext.projectId, surveyContext.surveyId, values);
 
       // Disable cancel prompt so we can navigate away from the page after saving

--- a/app/src/features/surveys/observations/sampling-sites/SamplingSitePage.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/SamplingSitePage.tsx
@@ -40,11 +40,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export interface ICreateSamplingSiteRequest {
+interface ISurveySampleSite {
   name: string;
   description: string;
+  feature: Feature;
+}
+
+export interface ICreateSamplingSiteRequest {
   survey_id: number;
-  survey_sample_sites: Feature[]; // extracted list from shape files
+  survey_sample_sites: ISurveySampleSite[]; // extracted list from shape files
   methods: ISurveySampleMethodData[];
 }
 
@@ -66,9 +70,11 @@ const SamplingSitePage = () => {
   }
 
   const samplingSiteYupSchema = yup.object({
-    name: yup.string().default(''),
-    description: yup.string().default(''),
-    survey_sample_sites: yup.array(yup.object()).min(1, 'At least one sampling site location is required'),
+    survey_sample_sites: yup
+      .array(
+        yup.object({ name: yup.string().default(''), description: yup.string().default(''), feature: yup.object({}) })
+      )
+      .min(1, 'At least one sampling site location is required'),
     methods: yup
       .array(yup.object().concat(SamplingSiteMethodYupSchema))
       .min(1, 'At least one sampling method is required')
@@ -92,7 +98,7 @@ const SamplingSitePage = () => {
   const handleSubmit = async (values: ICreateSamplingSiteRequest) => {
     try {
       setIsSubmitting(true);
-
+      
       await biohubApi.samplingSite.createSamplingSites(surveyContext.projectId, surveyContext.surveyId, values);
 
       // Disable cancel prompt so we can navigate away from the page after saving

--- a/app/src/features/surveys/observations/sampling-sites/components/SamplingSiteMapControl.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/components/SamplingSiteMapControl.tsx
@@ -31,6 +31,7 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { LayersControl, MapContainer as LeafletMapContainer } from 'react-leaflet';
 import { boundaryUploadHelper, calculateUpdatedMapBounds } from 'utils/mapBoundaryUploadHelpers';
 import { pluralize, shapeFileFeatureDesc, shapeFileFeatureName } from 'utils/Utils';
+import { ISurveySampleSite } from '../SamplingSitePage';
 
 const useStyles = makeStyles(() => ({
   zoomToBoundaryExtentBtn: {
@@ -76,7 +77,7 @@ const SamplingSiteMapControl = (props: ISamplingSiteMapControlProps) => {
 
   // Array of sampling site features
   const samplingSiteGeoJsonFeatures: Feature[] = useMemo(
-    () => get(values, name).map((a: any) => a.feature),
+    () => get(values, name).map((site: ISurveySampleSite) => site.feature),
     [name, values]
   );
 

--- a/app/src/features/surveys/observations/sampling-sites/components/SamplingSiteMapControl.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/components/SamplingSiteMapControl.tsx
@@ -16,6 +16,7 @@ import FullScreenScrollingEventHandler from 'components/map/components/FullScree
 import { MapBaseCss } from 'components/map/components/MapBaseCss';
 import StaticLayers from 'components/map/components/StaticLayers';
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM } from 'constants/spatial';
+import { SurveyContext } from 'contexts/surveyContext';
 import SampleSiteFileUploadItemActionButton from 'features/surveys/observations/sampling-sites/components/SampleSiteFileUploadItemActionButton';
 import SampleSiteFileUploadItemProgressBar from 'features/surveys/observations/sampling-sites/components/SampleSiteFileUploadItemProgressBar';
 import SampleSiteFileUploadItemSubtext from 'features/surveys/observations/sampling-sites/components/SampleSiteFileUploadItemSubtext';
@@ -26,10 +27,10 @@ import 'leaflet-fullscreen/dist/leaflet.fullscreen.css';
 import 'leaflet-fullscreen/dist/Leaflet.fullscreen.js';
 import 'leaflet/dist/leaflet.css';
 import get from 'lodash-es/get';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { LayersControl, MapContainer as LeafletMapContainer } from 'react-leaflet';
 import { boundaryUploadHelper, calculateUpdatedMapBounds } from 'utils/mapBoundaryUploadHelpers';
-import { pluralize } from 'utils/Utils';
+import { pluralize, shapeFileFeatureDesc, shapeFileFeatureName } from 'utils/Utils';
 
 const useStyles = makeStyles(() => ({
   zoomToBoundaryExtentBtn: {
@@ -61,6 +62,8 @@ export interface ISamplingSiteMapControlProps {
 const SamplingSiteMapControl = (props: ISamplingSiteMapControlProps) => {
   const classes = useStyles();
 
+  const surveyContext = useContext(SurveyContext);
+
   const { name, mapId, formikProps } = props;
 
   const { values, errors, setFieldValue, setFieldError } = formikProps;
@@ -72,7 +75,10 @@ const SamplingSiteMapControl = (props: ISamplingSiteMapControlProps) => {
   };
 
   // Array of sampling site features
-  const samplingSiteGeoJsonFeatures: Feature[] = get(values, name);
+  const samplingSiteGeoJsonFeatures: Feature[] = useMemo(
+    () => get(values, name).map((a: any) => a.feature),
+    [name, values]
+  );
 
   useEffect(() => {
     setUpdatedBounds(calculateUpdatedMapBounds(samplingSiteGeoJsonFeatures));
@@ -95,7 +101,15 @@ const SamplingSiteMapControl = (props: ISamplingSiteMapControlProps) => {
           <FileUpload
             uploadHandler={boundaryUploadHelper({
               onSuccess: (features: Feature[]) => {
-                setFieldValue(name, [...features]);
+                let numSites = surveyContext.sampleSiteDataLoader.data?.sampleSites.length ?? 0;
+                setFieldValue(
+                  name,
+                  features.map((feature) => ({
+                    name: shapeFileFeatureName(feature) ?? `Sample Site ${++numSites}`,
+                    description: shapeFileFeatureDesc(feature) ?? '',
+                    feature: feature
+                  }))
+                );
               },
               onFailure: (message: string) => {
                 setFieldError(name, message);

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -1,6 +1,6 @@
 import { SYSTEM_IDENTITY_SOURCE } from 'constants/auth';
 import { DATE_FORMAT, TIME_FORMAT } from 'constants/dateTimeFormats';
-import { Feature, Polygon } from 'geojson';
+import { Feature, GeoJsonProperties, Geometry, Polygon } from 'geojson';
 import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
 import { LatLngBounds } from 'leaflet';
 import _ from 'lodash';
@@ -450,4 +450,30 @@ export const uuidToColor = (id: string): { fillColor: string; outlineColor: stri
   const hexOutlineColor = RGBToHex(rgbOutlineColor);
 
   return { fillColor: `#${hexFillColor}`, outlineColor: `#${hexOutlineColor}` };
+};
+
+/**
+ * Used to extract a name from specific fields that can occur in the properties of a shapefile.
+ *
+ * @param {Feature<Geometry, GeoJsonProperties>} geometry
+ * @returns {string}
+ */
+export const shapeFileFeatureName = (geometry: Feature<Geometry, GeoJsonProperties>): string | undefined => {
+  const nameKey = Object.keys(geometry.properties ?? {}).find(
+    (key) => key.toLowerCase() === 'name' || key.toLowerCase() === 'label'
+  );
+  return nameKey && geometry.properties ? geometry.properties[nameKey].substring(0, 50) : undefined;
+};
+
+/**
+ * Used to extract a description from specific fields that can occur in the properties of a shapefile.
+ *
+ * @param {Feature<Geometry, GeoJsonProperties>} geometry
+ * @returns {string}
+ */
+export const shapeFileFeatureDesc = (geometry: Feature<Geometry, GeoJsonProperties>): string | undefined => {
+  const descKey = Object.keys(geometry.properties ?? {}).find(
+    (key) => key.toLowerCase() === 'desc' || key.toLowerCase() === 'descr' || key.toLowerCase() === 'des'
+  );
+  return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : undefined;
 };


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-363](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-363)

## Description of Changes

- Moved the shapefile name and description extraction to UI.
- Modified the sampling site POST api to accept custom names and desc from UI. 
- Implemented the same ability in study area submission, now both parts of the form can reference the same logic for extracting this info.

## Testing Notes

- Please make sure to test both sampling site and study area against shapefile submission.
