### PR TITLE
SIMSBIOHUB-297: Keycloak Value Case Sensitivity

### DIFF
--- a/api/src/repositories/user-repository.ts
+++ b/api/src/repositories/user-repository.ts
@@ -219,7 +219,7 @@ export class UserRepository extends BaseRepository {
       ON
         uis.user_identity_source_id = su.user_identity_source_id
       WHERE
-        su.user_identifier = ${userIdentifier.toLowerCase()}
+        LOWER(su.user_identifier) = ${userIdentifier.toLowerCase()}
       AND
         uis.name = ${identitySource.toUpperCase()}
       GROUP BY
@@ -285,7 +285,7 @@ export class UserRepository extends BaseRepository {
         WHERE
           name = ${identitySource.toUpperCase()}
       ),
-      ${userIdentifier.toLowerCase()},
+      ${userIdentifier},
       ${displayName},
       ${givenName || null},
       ${familyName || null},

--- a/api/src/utils/keycloak-utils.ts
+++ b/api/src/utils/keycloak-utils.ts
@@ -7,7 +7,7 @@ import { SOURCE_SYSTEM, SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 export const IdirUserInformation = z.object({
   idir_user_guid: z.string().toLowerCase(),
   identity_provider: z.literal(SYSTEM_IDENTITY_SOURCE.IDIR.toLowerCase()),
-  idir_username: z.string().toLowerCase(),
+  idir_username: z.string(),
   email_verified: z.boolean(),
   name: z.string(),
   preferred_username: z.string(),
@@ -24,7 +24,7 @@ export type IdirUserInformation = z.infer<typeof IdirUserInformation>;
 export const BceidBasicUserInformation = z.object({
   bceid_user_guid: z.string().toLowerCase(),
   identity_provider: z.literal(SYSTEM_IDENTITY_SOURCE.BCEID_BASIC.toLowerCase()),
-  bceid_username: z.string().toLowerCase(),
+  bceid_username: z.string(),
   email_verified: z.boolean(),
   name: z.string(),
   preferred_username: z.string(),
@@ -43,7 +43,7 @@ export const BceidBusinessUserInformation = z.object({
   bceid_business_name: z.string(),
   bceid_user_guid: z.string().toLowerCase(),
   identity_provider: z.literal(SYSTEM_IDENTITY_SOURCE.BCEID_BUSINESS.toLowerCase()),
-  bceid_username: z.string().toLowerCase(),
+  bceid_username: z.string(),
   email_verified: z.boolean(),
   name: z.string(),
   preferred_username: z.string(),

--- a/app/src/hooks/useSimsUserWrapper.tsx
+++ b/app/src/hooks/useSimsUserWrapper.tsx
@@ -77,8 +77,8 @@ function useSimsUserWrapper(): ISimsUserWrapper {
 
   const userGuid =
     simsUserDataLoader.data?.user_guid ||
-    (auth.user?.profile?.idir_user_guid as string)?.toLowerCase() ||
-    (auth.user?.profile?.bceid_user_guid as string)?.toLowerCase();
+    (auth.user?.profile?.idir_user_guid as string) ||
+    (auth.user?.profile?.bceid_user_guid as string);
 
   const userIdentifier =
     simsUserDataLoader.data?.user_identifier ||

--- a/app/src/hooks/useSimsUserWrapper.tsx
+++ b/app/src/hooks/useSimsUserWrapper.tsx
@@ -77,8 +77,8 @@ function useSimsUserWrapper(): ISimsUserWrapper {
 
   const userGuid =
     simsUserDataLoader.data?.user_guid ||
-    (auth.user?.profile?.idir_user_guid as string) ||
-    (auth.user?.profile?.bceid_user_guid as string);
+    (auth.user?.profile?.idir_user_guid as string)?.toLowerCase() ||
+    (auth.user?.profile?.bceid_user_guid as string)?.toLowerCase();
 
   const userIdentifier =
     simsUserDataLoader.data?.user_identifier ||


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-297](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-297?)

## Description of Changes

- Removes toLowerCase casting on user_identifier fields from keycloak and stores raw string value in the database regardless of case
- Adds LOWER() sql statements on any relation to user_identifiers and user guids as to make them case-insensitive

## Testing Notes

- Test with IDIR and BCeID, as well as access request and approval workflows
- Any other functionality which relates to user_guids or user_identifiers

- Noticed that given_name and family_name do not get added to the database when a new user is added. Not sure if this is intentional or not.