### PR TITLE
TechDebt: Add Support For Authorization By Survey ID

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/keyx/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/keyx/upload.ts
@@ -19,7 +19,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/list.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/list.ts
@@ -18,7 +18,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.ts
@@ -16,7 +16,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.ts
@@ -17,7 +17,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/delete.ts
@@ -17,7 +17,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/getSignedUrl.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/getSignedUrl.ts
@@ -20,7 +20,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/get.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/get.ts
@@ -18,7 +18,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/update.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/update.ts
@@ -16,7 +16,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/index.ts
@@ -15,7 +15,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -34,7 +34,7 @@ export const GET: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}.ts
@@ -16,7 +16,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -35,7 +35,7 @@ export const PATCH: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.ts
@@ -15,7 +15,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -133,7 +133,7 @@ export const PATCH: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/{bctwDeploymentId}.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/{bctwDeploymentId}.ts
@@ -18,7 +18,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/telemetry.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/telemetry.ts
@@ -160,7 +160,7 @@ export const GET: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/delete.ts
@@ -17,7 +17,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments.ts
@@ -15,7 +15,7 @@ export const GET: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/get.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/get.ts
@@ -20,7 +20,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/upload.ts
@@ -16,7 +16,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/{submissionId}/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/{submissionId}/delete.ts
@@ -16,7 +16,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/{submissionId}/getSignedUrl.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/dwca/observations/submission/{submissionId}/getSignedUrl.ts
@@ -23,7 +23,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/delete.ts
@@ -15,7 +15,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
@@ -20,7 +20,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -39,7 +39,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/process.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/process.ts
@@ -15,7 +15,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.body.project_id),
+          surveyId: Number(req.body.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.ts
@@ -16,7 +16,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/participants/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/participants/index.ts
@@ -16,7 +16,7 @@ export const GET: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -151,7 +151,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/participants/{surveyParticipationId}.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/participants/{surveyParticipationId}.ts
@@ -13,7 +13,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -133,7 +133,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.ts
@@ -15,8 +15,12 @@ export const GET: Operation = [
     return {
       or: [
         {
-          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -187,7 +191,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/index.ts
@@ -17,7 +17,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -203,7 +203,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/index.ts
@@ -17,8 +17,12 @@ export const GET: Operation = [
     return {
       or: [
         {
-          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -177,7 +181,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/index.ts
@@ -18,7 +18,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -157,7 +157,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/sample-period/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/sample-period/index.ts
@@ -17,8 +17,12 @@ export const GET: Operation = [
     return {
       or: [
         {
-          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -186,7 +190,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/sample-period/{surveySamplePeriodId}.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/sample-method/{surveySampleMethodId}/sample-period/{surveySamplePeriodId}.ts
@@ -18,7 +18,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {
@@ -176,7 +176,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/get.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/get.ts
@@ -21,7 +21,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/upload.ts
@@ -18,7 +18,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/delete.ts
@@ -15,7 +15,7 @@ export const DELETE: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/getSignedUrl.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/getSignedUrl.ts
@@ -21,7 +21,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/view.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/summary/submission/{summaryId}/view.ts
@@ -24,7 +24,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/upload.ts
@@ -16,7 +16,7 @@ export const POST: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/update.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/update.ts
@@ -16,7 +16,7 @@ export const PUT: Operation = [
       or: [
         {
           validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/update/get.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/update/get.ts
@@ -19,7 +19,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/view.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/view.ts
@@ -19,7 +19,7 @@ export const GET: Operation = [
             PROJECT_PERMISSION.COLLABORATOR,
             PROJECT_PERMISSION.OBSERVER
           ],
-          projectId: Number(req.params.projectId),
+          surveyId: Number(req.params.surveyId),
           discriminator: 'ProjectPermission'
         },
         {

--- a/api/src/repositories/project-participation-repository.test.ts
+++ b/api/src/repositories/project-participation-repository.test.ts
@@ -66,7 +66,7 @@ describe('ProjectParticipationRepository', () => {
     });
   });
 
-  describe('getProjectParticipantByUserGuid', () => {
+  describe('getProjectParticipantByProjectIdAndUserGuid', () => {
     it('should return result', async () => {
       const mockResponse = ({
         rows: [
@@ -83,7 +83,7 @@ describe('ProjectParticipationRepository', () => {
       const projectId = 1;
       const userGuid = '123-456-789';
 
-      const response = await repository.getProjectParticipantByUserGuid(projectId, userGuid);
+      const response = await repository.getProjectParticipantByProjectIdAndUserGuid(projectId, userGuid);
 
       expect(response).to.eql({ user_guid: '123-456-789' });
     });
@@ -97,7 +97,44 @@ describe('ProjectParticipationRepository', () => {
       const projectId = 1;
       const userGuid = '123-456-789';
 
-      const response = await repository.getProjectParticipantByUserGuid(projectId, userGuid);
+      const response = await repository.getProjectParticipantByProjectIdAndUserGuid(projectId, userGuid);
+
+      expect(response).to.eql(null);
+    });
+  });
+
+  describe('getProjectParticipantBySurveyIdAndUserGuid', () => {
+    it('should return result', async () => {
+      const mockResponse = ({
+        rows: [
+          {
+            user_guid: '123-456-789'
+          }
+        ],
+        rowCount: 1
+      } as any) as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new ProjectParticipationRepository(dbConnection);
+
+      const surveyId = 1;
+      const userGuid = '123-456-789';
+
+      const response = await repository.getProjectParticipantBySurveyIdAndUserGuid(surveyId, userGuid);
+
+      expect(response).to.eql({ user_guid: '123-456-789' });
+    });
+
+    it('should return null', async () => {
+      const mockResponse = ({ rows: [], rowCount: 0 } as any) as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new ProjectParticipationRepository(dbConnection);
+
+      const surveyId = 1;
+      const userGuid = '123-456-789';
+
+      const response = await repository.getProjectParticipantBySurveyIdAndUserGuid(surveyId, userGuid);
 
       expect(response).to.eql(null);
     });

--- a/api/src/repositories/project-participation-repository.ts
+++ b/api/src/repositories/project-participation-repository.ts
@@ -186,7 +186,7 @@ export class ProjectParticipationRepository extends BaseRepository {
   }
 
   /**
-   * Get a project user by project and system user guid. Returns null if the system user is not a participant of the
+   * Get a project user by project id and system user guid. Returns null if the system user is not a participant of the
    * project.
    *
    * @param {number} projectId
@@ -194,12 +194,12 @@ export class ProjectParticipationRepository extends BaseRepository {
    * @return {*}  {(Promise<(ProjectUser & SystemUser) | null>)}
    * @memberof ProjectParticipationRepository
    */
-  async getProjectParticipantByUserGuid(
+  async getProjectParticipantByProjectIdAndUserGuid(
     projectId: number,
     userGuid: string
   ): Promise<(ProjectUser & SystemUser) | null> {
     const knex = getKnex();
-    const queryBuilder = knex.queryBuilder().select().from('region_lookup');
+    const queryBuilder = knex.queryBuilder();
 
     queryBuilder
       .select(
@@ -233,7 +233,77 @@ export class ProjectParticipationRepository extends BaseRepository {
       .leftJoin('user_identity_source as uis', 'uis.user_identity_source_id', 'su.user_identity_source_id')
       .where('su.record_end_date', null)
       .where('pp.project_id', projectId)
-      .where('su.user_guid', userGuid)
+      .where(knex.raw(`LOWER(su.user_guid) = LOWER('${userGuid}')`))
+      .groupBy('su.system_user_id')
+      .groupBy('su.record_end_date')
+      .groupBy('su.user_identifier')
+      .groupBy('su.user_guid')
+      .groupBy('uis.name')
+      .groupBy('su.email')
+      .groupBy('su.display_name')
+      .groupBy('su.given_name')
+      .groupBy('su.family_name')
+      .groupBy('su.agency')
+      .groupBy('pp.project_participation_id')
+      .groupBy('pp.project_id')
+      .groupBy('pp.create_date')
+      .orderBy('pp.create_date', 'desc');
+
+    const response = await this.connection.knex(queryBuilder, ProjectUser.merge(SystemUser));
+
+    return response.rows?.[0] || null;
+  }
+
+  /**
+   * Get a project user by survey id and system user guid. Returns null if the system user is not a participant of the
+   * project.
+   *
+   * @param {number} surveyId
+   * @param {string} userGuid
+   * @return {*}  {(Promise<(ProjectUser & SystemUser) | null>)}
+   * @memberof ProjectParticipationRepository
+   */
+  async getProjectParticipantBySurveyIdAndUserGuid(
+    surveyId: number,
+    userGuid: string
+  ): Promise<(ProjectUser & SystemUser) | null> {
+    const knex = getKnex();
+    const queryBuilder = knex.queryBuilder();
+
+    queryBuilder
+      .select(
+        knex.raw(`
+          su.system_user_id,
+          su.user_identifier,
+          su.user_guid,
+          su.record_end_date,
+          uis.name AS identity_source,
+          array_remove(array_agg(sr.system_role_id), NULL) AS role_ids,
+          array_remove(array_agg(sr.name), NULL) AS role_names,
+          su.email,
+          su.display_name,
+          su.given_name,
+          su.family_name,
+          su.agency,
+          pp.project_participation_id,
+          pp.project_id,
+          array_remove(array_agg(pr.project_role_id), NULL) AS project_role_ids,
+          array_remove(array_agg(pr.name), NULL) AS project_role_names,
+          array_remove(array_agg(pp2.name), NULL) as project_role_permissions
+        `)
+      )
+      .from('project_participation as pp')
+      .leftJoin('project_role as pr', 'pp.project_role_id', 'pr.project_role_id')
+      .leftJoin('project_role_permission as prp', 'pp.project_role_id', 'prp.project_role_id')
+      .leftJoin('project_permission as pp2', 'pp2.project_permission_id', 'prp.project_permission_id')
+      .leftJoin('system_user as su', 'pp.system_user_id', 'su.system_user_id')
+      .leftJoin('system_user_role as sur', 'su.system_user_id', 'sur.system_user_id')
+      .leftJoin('system_role as sr', 'sur.system_role_id', 'sr.system_role_id')
+      .leftJoin('user_identity_source as uis', 'uis.user_identity_source_id', 'su.user_identity_source_id')
+      .leftJoin('survey as s', 's.project_id', 'pp.project_id')
+      .where('su.record_end_date', null)
+      .where('s.survey_id', surveyId)
+      .where(knex.raw(`LOWER(su.user_guid) = LOWER('${userGuid}')`))
       .groupBy('su.system_user_id')
       .groupBy('su.record_end_date')
       .groupBy('su.user_identifier')

--- a/api/src/services/authorization-service.test.ts
+++ b/api/src/services/authorization-service.test.ts
@@ -367,121 +367,252 @@ describe('AuthorizationService', () => {
   });
 
   describe('authorizeByProjectPermission', function () {
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('returns false if `authorizeProjectPermission` is null', async function () {
-      const mockAuthorizeProjectPermission = (null as unknown) as AuthorizeByProjectPermission;
-      const mockDBConnection = getMockDBConnection();
-
-      const authorizationService = new AuthorizationService(mockDBConnection);
-
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
-
-      expect(isAuthorizedByProjectPermission).to.equal(false);
-    });
-
-    it('returns false if `projectUserObject` is null', async function () {
-      const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
-        validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-        projectId: 1,
-        discriminator: 'ProjectPermission'
-      };
-      const mockDBConnection = getMockDBConnection();
-
-      const mockGetSystemUsersObjectResponse = (null as unknown) as ProjectUser & SystemUser;
-      sinon.stub(AuthorizationService.prototype, 'getProjectUserObject').resolves(mockGetSystemUsersObjectResponse);
-
-      const authorizationService = new AuthorizationService(mockDBConnection);
-
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
-
-      expect(isAuthorizedByProjectPermission).to.equal(false);
-    });
-
-    it('returns false if `record_end_date` is null', async function () {
-      const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
-        validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-        projectId: 1,
-        discriminator: 'ProjectPermission'
-      };
-      const mockDBConnection = getMockDBConnection();
-
-      const mockGetSystemUsersObjectResponse = ({ record_end_date: 'datetime' } as unknown) as ProjectUser & SystemUser;
-      sinon.stub(AuthorizationService.prototype, 'getProjectUserObject').resolves(mockGetSystemUsersObjectResponse);
-
-      const authorizationService = new AuthorizationService(mockDBConnection);
-
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
-
-      expect(isAuthorizedByProjectPermission).to.equal(false);
-    });
-
-    it('returns true if `authorizeProjectPermission` specifies no valid permissions', async function () {
-      const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
-        validProjectPermissions: [],
-        projectId: 1,
-        discriminator: 'ProjectPermission'
-      };
-      const mockDBConnection = getMockDBConnection();
-
-      const authorizationService = new AuthorizationService(mockDBConnection, {
-        projectUser: ({ project_id: 1 } as unknown) as ProjectUser & SystemUser
+    describe('by project id', function () {
+      afterEach(() => {
+        sinon.restore();
       });
 
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
+      it('returns false if `authorizeProjectPermission` is null', async function () {
+        const mockAuthorizeProjectPermission = (null as unknown) as AuthorizeByProjectPermission;
+        const mockDBConnection = getMockDBConnection();
 
-      expect(isAuthorizedByProjectPermission).to.equal(true);
-    });
+        const authorizationService = new AuthorizationService(mockDBConnection);
 
-    it('returns false if the user does not have any valid permissions', async function () {
-      const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
-        validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-        projectId: 1,
-        discriminator: 'ProjectPermission'
-      };
-      const mockDBConnection = getMockDBConnection();
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
 
-      const authorizationService = new AuthorizationService(mockDBConnection, {
-        projectUser: ({ project_id: 1, project_role_permissions: [] } as unknown) as ProjectUser & SystemUser
+        expect(isAuthorizedByProjectPermission).to.equal(false);
       });
 
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
+      it('returns false if `projectUserObject` is null', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          projectId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
 
-      expect(isAuthorizedByProjectPermission).to.equal(false);
-    });
+        const mockGetSystemUsersObjectResponse = (null as unknown) as ProjectUser & SystemUser;
+        sinon
+          .stub(AuthorizationService.prototype, 'getProjectUserObjectByProjectId')
+          .resolves(mockGetSystemUsersObjectResponse);
 
-    it('returns true if the user has at least one of the valid permissions', async function () {
-      const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
-        validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
-        projectId: 1,
-        discriminator: 'ProjectPermission'
-      };
-      const mockDBConnection = getMockDBConnection();
+        const authorizationService = new AuthorizationService(mockDBConnection);
 
-      const authorizationService = new AuthorizationService(mockDBConnection, {
-        projectUser: ({
-          project_id: 1,
-          project_role_permissions: [PROJECT_PERMISSION.COORDINATOR]
-        } as unknown) as ProjectUser & SystemUser
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
       });
 
-      const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
-        mockAuthorizeProjectPermission
-      );
+      it('returns false if `record_end_date` is null', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          projectId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
 
-      expect(isAuthorizedByProjectPermission).to.equal(true);
+        const mockGetSystemUsersObjectResponse = ({ record_end_date: 'datetime' } as unknown) as ProjectUser &
+          SystemUser;
+        sinon
+          .stub(AuthorizationService.prototype, 'getProjectUserObjectByProjectId')
+          .resolves(mockGetSystemUsersObjectResponse);
+
+        const authorizationService = new AuthorizationService(mockDBConnection);
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns true if `authorizeProjectPermission` specifies no valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [],
+          projectId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({ project_id: 1 } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(true);
+      });
+
+      it('returns false if the user does not have any valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          projectId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({ project_id: 1, project_role_permissions: [] } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns true if the user has at least one of the valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          projectId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({
+            project_id: 1,
+            project_role_permissions: [PROJECT_PERMISSION.COORDINATOR]
+          } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(true);
+      });
+    });
+
+    describe('by survey id', function () {
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('returns false if `authorizeProjectPermission` is null', async function () {
+        const mockAuthorizeProjectPermission = (null as unknown) as AuthorizeByProjectPermission;
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection);
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns false if `projectUserObject` is null', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          surveyId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const mockGetSystemUsersObjectResponse = (null as unknown) as ProjectUser & SystemUser;
+        sinon
+          .stub(AuthorizationService.prototype, 'getProjectUserObjectByProjectId')
+          .resolves(mockGetSystemUsersObjectResponse);
+
+        const authorizationService = new AuthorizationService(mockDBConnection);
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns false if `record_end_date` is null', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          surveyId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const mockGetSystemUsersObjectResponse = ({ record_end_date: 'datetime' } as unknown) as ProjectUser &
+          SystemUser;
+        sinon
+          .stub(AuthorizationService.prototype, 'getProjectUserObjectByProjectId')
+          .resolves(mockGetSystemUsersObjectResponse);
+
+        const authorizationService = new AuthorizationService(mockDBConnection);
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns true if `authorizeProjectPermission` specifies no valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [],
+          surveyId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({ project_id: 1 } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(true);
+      });
+
+      it('returns false if the user does not have any valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          surveyId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({ project_id: 1, project_role_permissions: [] } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(false);
+      });
+
+      it('returns true if the user has at least one of the valid permissions', async function () {
+        const mockAuthorizeProjectPermission: AuthorizeByProjectPermission = {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR],
+          surveyId: 1,
+          discriminator: 'ProjectPermission'
+        };
+        const mockDBConnection = getMockDBConnection();
+
+        const authorizationService = new AuthorizationService(mockDBConnection, {
+          projectUser: ({
+            project_id: 1,
+            project_role_permissions: [PROJECT_PERMISSION.COORDINATOR]
+          } as unknown) as ProjectUser & SystemUser
+        });
+
+        const isAuthorizedByProjectPermission = await authorizationService.authorizeByProjectPermission(
+          mockAuthorizeProjectPermission
+        );
+
+        expect(isAuthorizedByProjectPermission).to.equal(true);
+      });
     });
   });
 
@@ -714,7 +845,7 @@ describe('AuthorizationService', () => {
     });
   });
 
-  describe('getProjectUserObject', function () {
+  describe('getProjectUserObjectByProjectId', function () {
     afterEach(() => {
       sinon.restore();
     });
@@ -730,7 +861,7 @@ describe('AuthorizationService', () => {
 
       const projectId = 1;
 
-      const projectUser = await authorizationService.getProjectUserObject(projectId);
+      const projectUser = await authorizationService.getProjectUserObjectByProjectId(projectId);
 
       expect(projectUser).to.equal(null);
     });
@@ -739,13 +870,13 @@ describe('AuthorizationService', () => {
       const mockDBConnection = getMockDBConnection();
 
       const projectUserMock = null;
-      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRoles').resolves(projectUserMock);
+      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRolesByProjectId').resolves(projectUserMock);
 
       const authorizationService = new AuthorizationService(mockDBConnection);
 
       const projectId = 1;
 
-      const projectUser = await authorizationService.getProjectUserObject(projectId);
+      const projectUser = await authorizationService.getProjectUserObjectByProjectId(projectId);
 
       expect(projectUser).to.equal(null);
     });
@@ -773,7 +904,7 @@ describe('AuthorizationService', () => {
         project_role_permissions: [PROJECT_ROLE.COLLABORATOR]
       };
 
-      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRoles').resolves(projectUserMock);
+      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRolesByProjectId').resolves(projectUserMock);
 
       const authorizationService = new AuthorizationService(mockDBConnection, {
         keycloakToken: {
@@ -792,13 +923,13 @@ describe('AuthorizationService', () => {
 
       const projectId = 1;
 
-      const projectUser = await authorizationService.getProjectUserObject(projectId);
+      const projectUser = await authorizationService.getProjectUserObjectByProjectId(projectId);
 
       expect(projectUser).to.equal(projectUserMock);
     });
   });
 
-  describe('getProjectUserWithRoles', function () {
+  describe('getProjectUserWithRolesByProjectId', function () {
     afterEach(() => {
       sinon.restore();
     });
@@ -813,7 +944,7 @@ describe('AuthorizationService', () => {
 
       const projectId = 1;
 
-      const result = await authorizationService.getProjectUserWithRoles(projectId);
+      const result = await authorizationService.getProjectUserWithRolesByProjectId(projectId);
 
       expect(result).to.be.null;
     });
@@ -842,7 +973,7 @@ describe('AuthorizationService', () => {
         project_role_permissions: [PROJECT_ROLE.COLLABORATOR]
       };
       sinon
-        .stub(ProjectParticipationService.prototype, 'getProjectParticipantByUserGuid')
+        .stub(ProjectParticipationService.prototype, 'getProjectParticipantByProjectIdAndUserGuid')
         .resolves((projectUserMock as unknown) as any);
 
       const authorizationService = new AuthorizationService(mockDBConnection, {
@@ -862,7 +993,161 @@ describe('AuthorizationService', () => {
 
       const projectId = 1;
 
-      const result = await authorizationService.getProjectUserWithRoles(projectId);
+      const result = await authorizationService.getProjectUserWithRolesByProjectId(projectId);
+
+      expect(result).to.equal(projectUserMock);
+    });
+  });
+
+  describe('getProjectUserObjectBySurveyId', function () {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns null if fetching the project user throws an error', async function () {
+      const mockDBConnection = getMockDBConnection();
+
+      sinon.stub(AuthorizationService.prototype, 'getSystemUserWithRoles').callsFake(() => {
+        throw new Error('Test Error');
+      });
+
+      const authorizationService = new AuthorizationService(mockDBConnection);
+
+      const projectId = 1;
+
+      const projectUser = await authorizationService.getProjectUserObjectBySurveyId(projectId);
+
+      expect(projectUser).to.equal(null);
+    });
+
+    it('returns null if the project user is null or undefined', async function () {
+      const mockDBConnection = getMockDBConnection();
+
+      const projectUserMock = null;
+      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRolesByProjectId').resolves(projectUserMock);
+
+      const authorizationService = new AuthorizationService(mockDBConnection);
+
+      const projectId = 1;
+
+      const projectUser = await authorizationService.getProjectUserObjectBySurveyId(projectId);
+
+      expect(projectUser).to.equal(null);
+    });
+
+    it('returns a project user when keycloak token is valid', async function () {
+      const mockDBConnection = getMockDBConnection();
+
+      const projectUserMock: ProjectUser & SystemUser = {
+        system_user_id: 2,
+        user_identifier: 'username',
+        identity_source: SYSTEM_IDENTITY_SOURCE.IDIR,
+        user_guid: '123-456-789',
+        record_end_date: null,
+        role_ids: [1],
+        role_names: ['Collaborator'],
+        email: 'email@email.com',
+        family_name: 'lname',
+        given_name: 'fname',
+        display_name: 'test user',
+        agency: null,
+        project_participation_id: 3,
+        project_id: 1,
+        project_role_ids: [1],
+        project_role_names: [PROJECT_ROLE.COLLABORATOR],
+        project_role_permissions: [PROJECT_ROLE.COLLABORATOR]
+      };
+
+      sinon.stub(AuthorizationService.prototype, 'getProjectUserWithRolesBySurveyId').resolves(projectUserMock);
+
+      const authorizationService = new AuthorizationService(mockDBConnection, {
+        keycloakToken: {
+          idir_user_guid: '123-456-789',
+          identity_provider: 'idir',
+          idir_username: 'username',
+          email_verified: false,
+          name: 'test user',
+          preferred_username: '123-456-789@idir',
+          display_name: 'test user',
+          given_name: 'test',
+          family_name: 'user',
+          email: 'email@email.com'
+        }
+      });
+
+      const projectId = 1;
+
+      const projectUser = await authorizationService.getProjectUserObjectBySurveyId(projectId);
+
+      expect(projectUser).to.equal(projectUserMock);
+    });
+  });
+
+  describe('getProjectUserWithRolesBySurveyId', function () {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns null if the keycloak token is null', async function () {
+      const mockDBConnection = getMockDBConnection();
+      sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+      const authorizationService = new AuthorizationService(mockDBConnection, {
+        keycloakToken: undefined
+      });
+
+      const projectId = 1;
+
+      const result = await authorizationService.getProjectUserWithRolesBySurveyId(projectId);
+
+      expect(result).to.be.null;
+    });
+
+    it('returns a project user when keycloak token is valid', async function () {
+      const mockDBConnection = getMockDBConnection();
+      sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+      const projectUserMock: ProjectUser & SystemUser = {
+        system_user_id: 2,
+        user_identifier: 'username',
+        identity_source: SYSTEM_IDENTITY_SOURCE.IDIR,
+        user_guid: '123-456-789',
+        record_end_date: null,
+        role_ids: [1],
+        role_names: ['Collaborator'],
+        email: 'email@email.com',
+        family_name: 'lname',
+        given_name: 'fname',
+        display_name: 'test user',
+        agency: null,
+        project_participation_id: 3,
+        project_id: 1,
+        project_role_ids: [1],
+        project_role_names: [PROJECT_ROLE.COLLABORATOR],
+        project_role_permissions: [PROJECT_ROLE.COLLABORATOR]
+      };
+      sinon
+        .stub(ProjectParticipationService.prototype, 'getProjectParticipantBySurveyIdAndUserGuid')
+        .resolves((projectUserMock as unknown) as any);
+
+      const authorizationService = new AuthorizationService(mockDBConnection, {
+        keycloakToken: {
+          idir_user_guid: '123-456-789',
+          identity_provider: 'idir',
+          idir_username: 'username',
+          name: 'test user',
+          preferred_username: '123-456-789@idir',
+          display_name: 'test user',
+          email: 'email@email.com',
+          email_verified: false,
+          given_name: 'fname',
+          family_name: 'lname'
+        }
+      });
+
+      const projectId = 1;
+
+      const result = await authorizationService.getProjectUserWithRolesBySurveyId(projectId);
 
       expect(result).to.equal(projectUserMock);
     });

--- a/api/src/services/project-participation-service.ts
+++ b/api/src/services/project-participation-service.ts
@@ -101,7 +101,7 @@ export class ProjectParticipationService extends DBService {
   }
 
   /**
-   * Get the project participant for the given project and system user.
+   * Get the project participant for the given project id and system user.
    *
    * @param {number} projectId
    * @param {number} systemUserId
@@ -120,11 +120,26 @@ export class ProjectParticipationService extends DBService {
    * @return {*}  {(Promise<(ProjectUser & SystemUser) | null>)}
    * @memberof ProjectParticipationService
    */
-  async getProjectParticipantByUserGuid(
+  async getProjectParticipantByProjectIdAndUserGuid(
     projectId: number,
     userGuid: string
   ): Promise<(ProjectUser & SystemUser) | null> {
-    return this.projectParticipationRepository.getProjectParticipantByUserGuid(projectId, userGuid);
+    return this.projectParticipationRepository.getProjectParticipantByProjectIdAndUserGuid(projectId, userGuid);
+  }
+
+  /**
+   * Get the project participant for the given survey id and user guid.
+   *
+   * @param {number} surveyId
+   * @param {number} userGuid
+   * @return {*}  {(Promise<(ProjectUser & SystemUser) | null>)}
+   * @memberof ProjectParticipationService
+   */
+  async getProjectParticipantBySurveyIdAndUserGuid(
+    surveyId: number,
+    userGuid: string
+  ): Promise<(ProjectUser & SystemUser) | null> {
+    return this.projectParticipationRepository.getProjectParticipantBySurveyIdAndUserGuid(surveyId, userGuid);
   }
 
   /**


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

- Add support for authorization by for survey id.
- Update all paths under `../{surveyId}` to use survey id based authorization.
- Updated a few GET endpoints to include collaborator/observer project permissions (was testing as a collaborator and was getting endpoint failures when trying to load a survey page).

## Testing Notes

- The only 'real' changes/enhancements are in the service/repo files.
- All of the `../paths/..` changes are just to update to auth check to use survey id instead of project id.

Everything should work as before.
