### PR TITLE
SIMSBIOHUB-451: Recognize 'Species' column in uploaded observation CSV

### DIFF
--- a/api/.pipeline/config.js
+++ b/api/.pipeline/config.js
@@ -90,7 +90,7 @@ const phases = {
     s3KeyPrefix: (isStaticDeployment && 'sims') || `local/${deployChangeId}/sims`,
     tz: config.timezone.api,
     sso: config.sso.dev,
-    logLevel: 'silly',
+    logLevel: 'info',
     nodeOptions: '--max_old_space_size=2250', // 75% of memoryLimit (bytes)
     cpuRequest: '50m',
     cpuLimit: '600m',
@@ -156,7 +156,7 @@ const phases = {
     s3KeyPrefix: 'sims',
     tz: config.timezone.api,
     sso: config.sso.prod,
-    logLevel: 'error',
+    logLevel: 'warn',
     nodeOptions: '--max_old_space_size=2250', // 75% of memoryLimit (bytes)
     cpuRequest: '50m',
     cpuLimit: '1000m',

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -25,7 +25,7 @@ import { DBService } from './db-service';
 const defaultLog = getLogger('services/observation-service');
 
 const observationCSVColumnValidator: IXLSXCSVValidator = {
-  columnNames: ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
+  columnNames: ['SPECIES', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
   columnTypes: ['number', 'number', 'date', 'string', 'number', 'number'],
   columnAliases: {
     LATITUDE: ['LAT'],
@@ -278,7 +278,7 @@ export class ObservationService extends DBService {
     // Step 5. Merge all the table rows into an array of ObservationInsert[]
     const insertRows: InsertObservation[] = worksheetRowObjects.map((row) => ({
       survey_id: surveyId,
-      wldtaxonomic_units_id: row['SPECIES_TAXONOMIC_ID'],
+      wldtaxonomic_units_id: row['SPECIES'],
       survey_sample_site_id: null,
       survey_sample_method_id: null,
       survey_sample_period_id: null,

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -29,7 +29,8 @@ const observationCSVColumnValidator: IXLSXCSVValidator = {
   columnTypes: ['number', 'number', 'date', 'string', 'number', 'number'],
   columnAliases: {
     LATITUDE: ['LAT'],
-    LONGITUDE: ['LON', 'LONG', 'LNG']
+    LONGITUDE: ['LON', 'LONG', 'LNG'],
+    SPECIES: ['TAXON']
   }
 };
 

--- a/api/src/utils/xlsx-utils/worksheet-utils.test.ts
+++ b/api/src/utils/xlsx-utils/worksheet-utils.test.ts
@@ -16,7 +16,8 @@ describe('worksheet utils', () => {
         columnTypes: ['number', 'number', 'date', 'string', 'number', 'number'],
         columnAliases: {
           LATITUDE: ['LAT'],
-          LONGITUDE: ['LON', 'LONG', 'LNG']
+          LONGITUDE: ['LON', 'LONG', 'LNG'],
+          SPECIES: ['TAXON']
         }
       };
 
@@ -24,7 +25,7 @@ describe('worksheet utils', () => {
 
       const getWorksheetHeaderssStub = sinon
         .stub(worksheet_utils, 'getWorksheetHeaders')
-        .callsFake(() => ['SPECIES', 'COUNT', 'DATE', 'TIME', 'LAT', 'LON']);
+        .callsFake(() => ['TAXON', 'COUNT', 'DATE', 'TIME', 'LAT', 'LON']);
 
       const result = worksheet_utils.validateWorksheetHeaders(mockWorksheet, observationCSVColumnValidator);
 

--- a/api/src/utils/xlsx-utils/worksheet-utils.test.ts
+++ b/api/src/utils/xlsx-utils/worksheet-utils.test.ts
@@ -12,7 +12,7 @@ describe('worksheet utils', () => {
 
     it('should validate aliases', () => {
       const observationCSVColumnValidator: worksheet_utils.IXLSXCSVValidator = {
-        columnNames: ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
+        columnNames: ['SPECIES', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
         columnTypes: ['number', 'number', 'date', 'string', 'number', 'number'],
         columnAliases: {
           LATITUDE: ['LAT'],
@@ -24,7 +24,7 @@ describe('worksheet utils', () => {
 
       const getWorksheetHeaderssStub = sinon
         .stub(worksheet_utils, 'getWorksheetHeaders')
-        .callsFake(() => ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'LAT', 'LON']);
+        .callsFake(() => ['SPECIES', 'COUNT', 'DATE', 'TIME', 'LAT', 'LON']);
 
       const result = worksheet_utils.validateWorksheetHeaders(mockWorksheet, observationCSVColumnValidator);
 
@@ -34,7 +34,7 @@ describe('worksheet utils', () => {
 
     it('should fail for unknown aliases', () => {
       const observationCSVColumnValidator: worksheet_utils.IXLSXCSVValidator = {
-        columnNames: ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
+        columnNames: ['SPECIES', 'COUNT', 'DATE', 'TIME', 'LATITUDE', 'LONGITUDE'],
         columnTypes: ['number', 'number', 'date', 'string', 'number', 'number'],
         columnAliases: {
           LATITUDE: ['LAT'],
@@ -46,7 +46,7 @@ describe('worksheet utils', () => {
 
       const getWorksheetHeaderssStub = sinon
         .stub(worksheet_utils, 'getWorksheetHeaders')
-        .callsFake(() => ['SPECIES_TAXONOMIC_ID', 'COUNT', 'DATE', 'TIME', 'SOMETHING_LAT', 'LON']);
+        .callsFake(() => ['SPECIES', 'COUNT', 'DATE', 'TIME', 'SOMETHING_LAT', 'LON']);
 
       const result = worksheet_utils.validateWorksheetHeaders(mockWorksheet, observationCSVColumnValidator);
 


### PR DESCRIPTION
## Links to Jira Tickets

 - https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-451

## Description of Changes

Observation CSV uploads now expect the species column to be named `Species`, rather than `SPECIES_TAXONOMIC_ID`.

## Testing Notes

Upload an observations CSV, ensuring that the species column is titled `Species` (case insensitive). You should:
 - [ ] See that the upload was successful.