### PR TITLE
SIMSBIOHUB-536: Export observations table column headers to CSV

### DIFF
--- a/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
+++ b/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
@@ -17,6 +17,7 @@ import { GridColDef } from '@mui/x-data-grid';
 import { IObservationTableRow, MeasurementColumn } from 'contexts/observationsTableContext';
 import { MeasurementsButton } from 'features/surveys/observations/observations-table/configure-table/measurements/dialog/MeasurementsButton';
 import { CBMeasurementType } from 'interfaces/useCritterApi.interface';
+import ExportHeadersButton from '../export-button/ExportHeadersButton';
 
 export interface IConfigureColumnsPopoverContentProps {
   hideableColumns: GridColDef<IObservationTableRow>[];
@@ -55,6 +56,9 @@ export const ConfigureColumnsPopoverContent = (props: IConfigureColumnsPopoverCo
         <Typography component="div" variant="body2" fontWeight={700} textTransform={'uppercase'}>
           Configure Observations
         </Typography>
+        <ExportHeadersButton
+          // TODO
+        />
         <MeasurementsButton
           disabled={disabledAddMeasurements}
           selectedMeasurements={measurementColumns.map((item) => item.measurement)}

--- a/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
+++ b/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
@@ -56,7 +56,7 @@ export const ConfigureColumnsPopoverContent = (props: IConfigureColumnsPopoverCo
         <Typography component="div" variant="body2" fontWeight={700} textTransform={'uppercase'}>
           Configure Observations
         </Typography>
-        <Stack direction='row' alignItems='center' gap={2}>
+        <Stack direction="row" alignItems="center" gap={2}>
           <ExportHeadersButton />
           <MeasurementsButton
             disabled={disabledAddMeasurements}

--- a/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
+++ b/app/src/features/surveys/observations/observations-table/configure-table/ConfigureColumnsPopoverContent.tsx
@@ -56,14 +56,14 @@ export const ConfigureColumnsPopoverContent = (props: IConfigureColumnsPopoverCo
         <Typography component="div" variant="body2" fontWeight={700} textTransform={'uppercase'}>
           Configure Observations
         </Typography>
-        <ExportHeadersButton
-          // TODO
-        />
-        <MeasurementsButton
-          disabled={disabledAddMeasurements}
-          selectedMeasurements={measurementColumns.map((item) => item.measurement)}
-          onAddMeasurements={onAddMeasurements}
-        />
+        <Stack direction='row' alignItems='center' gap={2}>
+          <ExportHeadersButton />
+          <MeasurementsButton
+            disabled={disabledAddMeasurements}
+            selectedMeasurements={measurementColumns.map((item) => item.measurement)}
+            onAddMeasurements={onAddMeasurements}
+          />
+        </Stack>
       </Stack>
 
       <Divider flexItem />

--- a/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
+++ b/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
@@ -1,0 +1,33 @@
+import { mdiTable } from "@mdi/js";
+import Icon from "@mdi/react";
+import Button from "@mui/material/Button";
+import { useObservationsTableContext } from "hooks/useContext";
+import { useMemo } from "react";
+import { makeCsvObjectUrl } from "utils/Utils";
+
+type IExportHeadersButton = {
+  //
+}
+
+const ExportHeadersButton = (props: IExportHeadersButton) => {
+  const observationsTableContext = useObservationsTableContext();
+
+  const headerCsvDownloadHref = useMemo(() => {
+    const tableColumns = observationsTableContext._muiDataGridApiRef.current?.getAllColumns?.() ?? [];
+    const headerNames = tableColumns.map((column) => column.headerName);
+    const csvObject: Record<string, ''>[] = [Object.fromEntries(headerNames.map((headerName) => [headerName, '']))];
+
+    return makeCsvObjectUrl(csvObject);
+
+  // TODO double-check this useMemo dep
+  }, [observationsTableContext._muiDataGridApiRef.current?.getAllColumns]);
+
+  return (
+    <Button
+      startIcon={<Icon path={mdiTable} />}
+      href={headerCsvDownloadHref}
+    >Export Headers</Button>
+  )
+}
+
+export default ExportHeadersButton

--- a/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
+++ b/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
@@ -1,9 +1,9 @@
-import { mdiTable } from "@mdi/js";
-import Icon from "@mdi/react";
-import Button from "@mui/material/Button";
-import dayjs from "dayjs";
-import { useObservationsTableContext } from "hooks/useContext";
-import { makeCsvObjectUrl } from "utils/Utils";
+import { mdiTable } from '@mdi/js';
+import Icon from '@mdi/react';
+import Button from '@mui/material/Button';
+import dayjs from 'dayjs';
+import { useObservationsTableContext } from 'hooks/useContext';
+import { makeCsvObjectUrl } from 'utils/Utils';
 
 // Fields which will not be included in the downloaded CSV template
 const excludedFields = [
@@ -11,7 +11,7 @@ const excludedFields = [
   'survey_sample_site_id',
   'survey_sample_method_id',
   'survey_sample_period_id',
-  'actions',
+  'actions'
 ];
 
 const ExportHeadersButton = () => {
@@ -34,15 +34,13 @@ const ExportHeadersButton = () => {
     anchorElement.href = url;
     anchorElement.download = fileName;
     anchorElement.click();
-  }
+  };
 
   return (
-    <Button
-      startIcon={<Icon path={mdiTable} size={0.75} />}
-      variant='outlined'
-      onClick={handleDownload}
-    >Export Headers</Button>
-  )
-}
+    <Button startIcon={<Icon path={mdiTable} size={0.75} />} variant="outlined" onClick={handleDownload}>
+      Export Headers
+    </Button>
+  );
+};
 
-export default ExportHeadersButton
+export default ExportHeadersButton;

--- a/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
+++ b/app/src/features/surveys/observations/observations-table/export-button/ExportHeadersButton.tsx
@@ -1,31 +1,46 @@
 import { mdiTable } from "@mdi/js";
 import Icon from "@mdi/react";
 import Button from "@mui/material/Button";
+import dayjs from "dayjs";
 import { useObservationsTableContext } from "hooks/useContext";
-import { useMemo } from "react";
 import { makeCsvObjectUrl } from "utils/Utils";
 
-type IExportHeadersButton = {
-  //
-}
+// Fields which will not be included in the downloaded CSV template
+const excludedFields = [
+  '__check__',
+  'survey_sample_site_id',
+  'survey_sample_method_id',
+  'survey_sample_period_id',
+  'actions',
+];
 
-const ExportHeadersButton = (props: IExportHeadersButton) => {
+const ExportHeadersButton = () => {
   const observationsTableContext = useObservationsTableContext();
 
-  const headerCsvDownloadHref = useMemo(() => {
+  const handleDownload = () => {
     const tableColumns = observationsTableContext._muiDataGridApiRef.current?.getAllColumns?.() ?? [];
-    const headerNames = tableColumns.map((column) => column.headerName);
+
+    const headerNames = tableColumns
+      .filter((column) => !excludedFields.includes(column.field))
+      .map((column) => column.headerName);
+
     const csvObject: Record<string, ''>[] = [Object.fromEntries(headerNames.map((headerName) => [headerName, '']))];
 
-    return makeCsvObjectUrl(csvObject);
+    const url = makeCsvObjectUrl(csvObject);
+    const timestamp = dayjs().format('YYYY_MM_DD_HH_mm_ss');
+    const fileName = `SIMS_Observations_Template_${timestamp}.csv`;
 
-  // TODO double-check this useMemo dep
-  }, [observationsTableContext._muiDataGridApiRef.current?.getAllColumns]);
+    const anchorElement = document.createElement('a');
+    anchorElement.href = url;
+    anchorElement.download = fileName;
+    anchorElement.click();
+  }
 
   return (
     <Button
-      startIcon={<Icon path={mdiTable} />}
-      href={headerCsvDownloadHref}
+      startIcon={<Icon path={mdiTable} size={0.75} />}
+      variant='outlined'
+      onClick={handleDownload}
     >Export Headers</Button>
   )
 }


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-536](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-536)

## Description of Changes

- Adds the **Export Headers** button to the _Configure Observations_ menu, allowing users to download a template CSV file.

## Testing Notes

1. Import some survey observations with measurement columns included.
2. Go to _Manage Observations._
3. Open the _Configure Observations_ menu (the cog icon button)
4. Click **Export Headers**. The headers CSV should:
  - [ ] automatically begin downloading in your browser.
  - [ ] be named **"SIMS_Observations_Template_YYYY_MM_DD_HH_MM_SS"**
  - [ ] contain all of the default observations table columns (excluding sampling columns), _plus_ any measurement columns that are visible in the observations table.
