### PR TITLE
SIMSBIOHUB-529: Show Error Message If Project List Fails to Load

### DIFF
--- a/api/src/paths/project/{projectId}/view.ts
+++ b/api/src/paths/project/{projectId}/view.ts
@@ -191,7 +191,6 @@ GET.apiDoc = {
  */
 export function viewProject(): RequestHandler {
   return async (req, res) => {
-    throw new Error('This is a sample error for testing purposes and should not be committed.');
     const connection = getDBConnection(req['keycloak_token']);
 
     try {

--- a/api/src/paths/project/{projectId}/view.ts
+++ b/api/src/paths/project/{projectId}/view.ts
@@ -191,6 +191,7 @@ GET.apiDoc = {
  */
 export function viewProject(): RequestHandler {
   return async (req, res) => {
+    throw new Error('This is a sample error for testing purposes and should not be committed.');
     const connection = getDBConnection(req['keycloak_token']);
 
     try {

--- a/app/src/constants/i18n.ts
+++ b/app/src/constants/i18n.ts
@@ -16,6 +16,18 @@ export const EditProjectI18N = {
     'An error has occurred while attempting to edit your project, please try again. If the error persists, please contact your system administrator.'
 };
 
+export const ListProjectsI18N = {
+  listProjectsErrorDialogTitle: 'Failed to load projects list data',
+  listProjectsErrorDialogText:
+    'An error occurred while retrieving your list of projects. Please try again. If the error persists, please contact your system administrator.'
+};
+
+export const ViewProjectI18N = {
+  viewProjectErrorDialogTitle: 'Failed to load project data',
+  viewProjectErrorDialogText:
+    'The data for this project could not be retrieved. Please try again. If the error persists, please contact your system administrator.'
+};
+
 export const CreateSurveyI18N = {
   cancelTitle: 'Discard changes and exit?',
   cancelText: 'Any changes you have made will not be saved. Do you want to proceed?',

--- a/app/src/features/projects/ProjectsRouter.tsx
+++ b/app/src/features/projects/ProjectsRouter.tsx
@@ -48,74 +48,76 @@ const ProjectsRouter: React.FC = () => {
       {/* Project Routes */}
       <RouteWithTitle path="/admin/projects/:id" title={getTitle('Project Details')}>
         <ProjectAuthStateContextProvider>
-          <ProjectContextProvider>
-            {/* Project Details Routes */}
-            <RouteWithTitle exact path="/admin/projects/:id/details" title={getTitle('Projects')}>
-              <ProjectRoleRouteGuard
-                validProjectPermissions={[
-                  PROJECT_PERMISSION.COORDINATOR,
-                  PROJECT_PERMISSION.COLLABORATOR,
-                  PROJECT_PERMISSION.OBSERVER
-                ]}
-                validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
-                <DialogContextProvider>
-                  <ProjectPage />
-                </DialogContextProvider>
-              </ProjectRoleRouteGuard>
-            </RouteWithTitle>
+          <DialogContextProvider>
+            <ProjectContextProvider>
+              {/* Project Details Routes */}
+              <RouteWithTitle exact path="/admin/projects/:id/details" title={getTitle('Projects')}>
+                <ProjectRoleRouteGuard
+                  validProjectPermissions={[
+                    PROJECT_PERMISSION.COORDINATOR,
+                    PROJECT_PERMISSION.COLLABORATOR,
+                    PROJECT_PERMISSION.OBSERVER
+                  ]}
+                  validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+                  <DialogContextProvider>
+                    <ProjectPage />
+                  </DialogContextProvider>
+                </ProjectRoleRouteGuard>
+              </RouteWithTitle>
 
-            {/* Edit Project Route */}
-            <RouteWithTitle exact path="/admin/projects/:id/edit" title={getTitle('Edit Project')}>
-              <ProjectRoleRouteGuard
-                validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR]}
-                validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
-                <DialogContextProvider>
-                  <EditProjectPage />
-                </DialogContextProvider>
-              </ProjectRoleRouteGuard>
-            </RouteWithTitle>
+              {/* Edit Project Route */}
+              <RouteWithTitle exact path="/admin/projects/:id/edit" title={getTitle('Edit Project')}>
+                <ProjectRoleRouteGuard
+                  validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR]}
+                  validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+                  <DialogContextProvider>
+                    <EditProjectPage />
+                  </DialogContextProvider>
+                </ProjectRoleRouteGuard>
+              </RouteWithTitle>
 
-            {/* Project Team Route */}
-            <RouteWithTitle exact path="/admin/projects/:id/users" title={getTitle('Project Team')}>
-              <ProjectRoleRouteGuard
-                validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR]}
-                validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
-                <DialogContextProvider>
-                  <ProjectParticipantsPage />
-                </DialogContextProvider>
-              </ProjectRoleRouteGuard>
-            </RouteWithTitle>
+              {/* Project Team Route */}
+              <RouteWithTitle exact path="/admin/projects/:id/users" title={getTitle('Project Team')}>
+                <ProjectRoleRouteGuard
+                  validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR]}
+                  validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+                  <DialogContextProvider>
+                    <ProjectParticipantsPage />
+                  </DialogContextProvider>
+                </ProjectRoleRouteGuard>
+              </RouteWithTitle>
 
-            {/* Survey Routes */}
-            <RouteWithTitle path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')}>
-              <ProjectRoleRouteGuard
-                validProjectPermissions={[
-                  PROJECT_PERMISSION.COORDINATOR,
-                  PROJECT_PERMISSION.COLLABORATOR,
-                  PROJECT_PERMISSION.OBSERVER
-                ]}
-                validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
-                <SurveyContextProvider>
-                  <ObservationsContextProvider>
-                    <TelemetryDataContextProvider>
-                      <SurveyRouter />
-                    </TelemetryDataContextProvider>
-                  </ObservationsContextProvider>
-                </SurveyContextProvider>
-              </ProjectRoleRouteGuard>
-            </RouteWithTitle>
+              {/* Survey Routes */}
+              <RouteWithTitle path="/admin/projects/:id/surveys/:survey_id" title={getTitle('Surveys')}>
+                <ProjectRoleRouteGuard
+                  validProjectPermissions={[
+                    PROJECT_PERMISSION.COORDINATOR,
+                    PROJECT_PERMISSION.COLLABORATOR,
+                    PROJECT_PERMISSION.OBSERVER
+                  ]}
+                  validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+                  <SurveyContextProvider>
+                    <ObservationsContextProvider>
+                      <TelemetryDataContextProvider>
+                        <SurveyRouter />
+                      </TelemetryDataContextProvider>
+                    </ObservationsContextProvider>
+                  </SurveyContextProvider>
+                </ProjectRoleRouteGuard>
+              </RouteWithTitle>
 
-            {/* Create Survey Route */}
-            <RouteWithTitle exact path="/admin/projects/:id/survey/create" title={getTitle('Create Survey')}>
-              <ProjectRoleRouteGuard
-                validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR]}
-                validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
-                <DialogContextProvider>
-                  <CreateSurveyPage />
-                </DialogContextProvider>
-              </ProjectRoleRouteGuard>
-            </RouteWithTitle>
-          </ProjectContextProvider>
+              {/* Create Survey Route */}
+              <RouteWithTitle exact path="/admin/projects/:id/survey/create" title={getTitle('Create Survey')}>
+                <ProjectRoleRouteGuard
+                  validProjectPermissions={[PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR]}
+                  validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
+                  <DialogContextProvider>
+                    <CreateSurveyPage />
+                  </DialogContextProvider>
+                </ProjectRoleRouteGuard>
+              </RouteWithTitle>
+            </ProjectContextProvider>
+          </DialogContextProvider>
         </ProjectAuthStateContextProvider>
       </RouteWithTitle>
 


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-529](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-529)

## Description of Changes

 - Adds an error dialog whenever the _Projects List_ or _Project Details_ page fails to load.

## Testing Notes

You should see an error dialog when the request fails while attempting to:
 - [ ] View the projects list page
 - [ ] View the project page for a single project

Multiple ways to test this locally:
1. Once you've loaded the project page/project list page, hot-reload the API, and then navitgate to the project page or project list page while the API is compiling. You should see the error dialog.
2. Throw an exception in the project view endpoint or project list endpoint. You should see the error dialog when loading either of the respective pages.
