### PR TITLE
Text input for capture and mortality locations

### DIFF
--- a/api/src/paths/project/list.test.ts
+++ b/api/src/paths/project/list.test.ts
@@ -142,7 +142,7 @@ describe('list', () => {
         const requestHandler = list.getProjectList();
 
         await requestHandler(sampleReq, sampleRes as any, null as unknown as any);
-        expect.fail();
+        expect.fail('Expected an error to be thrown');
       } catch (actualError) {
         expect(dbConnectionObj.release).to.have.been.called;
 

--- a/app/src/components/map/components/DrawControls.tsx
+++ b/app/src/components/map/components/DrawControls.tsx
@@ -51,11 +51,22 @@ export interface IDrawControlsRef {
   /**
    * Adds a GeoJson feature to a new layer in the draw controls layer group.
    *
-   * @memberof IDrawControlsRef
+   * @param feature The GeoJson feature to add as a layer.
+   * @param layerId A function to receive the unique ID assigned to the added layer.
    */
   addLayer: (feature: Feature, layerId: (id: number) => void) => void;
 
+  /**
+   * Deletes a layer from the draw controls layer group by its unique ID.
+   *
+   * @param layerId The unique ID of the layer to delete.
+   */
   deleteLayer: (layerId: number) => void;
+
+  /**
+   * Clears all layers from the draw controls layer group.
+   */
+  clearLayers: () => void;
 }
 
 /**
@@ -196,6 +207,10 @@ const DrawControls = forwardRef<IDrawControlsRef | undefined, IDrawControlsProps
       deleteLayer: (layerId: number) => {
         const featureGroup = getFeatureGroup();
         featureGroup.removeLayer(layerId);
+      },
+      clearLayers: () => {
+        const featureGroup = getFeatureGroup();
+        featureGroup.clearLayers();
       }
     }),
     [getFeatureGroup]

--- a/app/src/components/map/components/ImportBoundaryDialog.tsx
+++ b/app/src/components/map/components/ImportBoundaryDialog.tsx
@@ -6,6 +6,7 @@ import { Feature } from 'geojson';
 import { boundaryUploadHelper } from 'utils/mapBoundaryUploadHelpers';
 
 export interface IImportBoundaryDialogProps {
+  dialogTitle: string;
   isOpen: boolean;
   onClose: () => void;
   onSuccess: (features: Feature[]) => void;
@@ -13,9 +14,9 @@ export interface IImportBoundaryDialogProps {
 }
 
 const ImportBoundaryDialog = (props: IImportBoundaryDialogProps) => {
-  const { isOpen, onClose, onSuccess, onFailure } = props;
+  const { dialogTitle, isOpen, onClose, onSuccess, onFailure } = props;
   return (
-    <ComponentDialog open={isOpen} dialogTitle="Import Boundary" onClose={onClose}>
+    <ComponentDialog open={isOpen} dialogTitle={dialogTitle} onClose={onClose}>
       <Box>
         <Box mb={3}>
           <Alert severity="info">

--- a/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
@@ -4,7 +4,7 @@ import FormikErrorSnackbar from 'components/alert/FormikErrorSnackbar';
 import HorizontalSplitFormComponent from 'components/fields/HorizontalSplitFormComponent';
 import { Formik, FormikProps } from 'formik';
 import { ICreateCaptureRequest, IEditCaptureRequest } from 'interfaces/useCritterApi.interface';
-import { isDefined } from 'utils/Utils';
+import { isDefined, isValidCoordinates } from 'utils/Utils';
 import yup from 'utils/YupSchema';
 import { MarkingsForm } from '../../../markings/MarkingsForm';
 import { MeasurementsForm } from '../../../measurements/MeasurementsForm';
@@ -49,20 +49,11 @@ export const AnimalCaptureForm = <FormikValuesType extends ICreateCaptureRequest
               .of(yup.number())
               .min(2)
               .max(3)
-              .test('is-valid-coordinates', 'Invalid coordinates', function (value) {
+              .test('is-valid-coordinates', 'Latitude or longitude values are outside of the valid range.', (value) => {
                 if (!value) {
                   return false;
                 }
-
-                const [lon, lat] = value;
-
-                if (!(lat && lon && lat > -90 && lat < 90 && lon > -180 && lon < 180)) {
-                  return this.createError({
-                    message: 'The latitude or longitude values are outside of the valid range.'
-                  });
-                }
-
-                return true;
+                return isValidCoordinates(value[1], value[0]);
               })
               .required('Coordinates are invalid')
           }),

--- a/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
@@ -4,7 +4,7 @@ import FormikErrorSnackbar from 'components/alert/FormikErrorSnackbar';
 import HorizontalSplitFormComponent from 'components/fields/HorizontalSplitFormComponent';
 import { Formik, FormikProps } from 'formik';
 import { ICreateCaptureRequest, IEditCaptureRequest } from 'interfaces/useCritterApi.interface';
-import { isDefined, isValidCoordinates } from 'utils/Utils';
+import { isDefined } from 'utils/Utils';
 import yup from 'utils/YupSchema';
 import { MarkingsForm } from '../../../markings/MarkingsForm';
 import { MeasurementsForm } from '../../../measurements/MeasurementsForm';
@@ -49,12 +49,7 @@ export const AnimalCaptureForm = <FormikValuesType extends ICreateCaptureRequest
               .of(yup.number())
               .min(2)
               .max(3)
-              .test('is-valid-coordinates', 'Latitude or longitude values are outside of the valid range.', (value) => {
-                if (!value) {
-                  return false;
-                }
-                return isValidCoordinates(value[1], value[0]);
-              })
+              .isValidPointCoordinates('Latitude or longitude values are outside of the valid range.')
               .required('Latitude or longitude values are outside of the valid range.')
           }),
           properties: yup.object().optional()
@@ -63,13 +58,24 @@ export const AnimalCaptureForm = <FormikValuesType extends ICreateCaptureRequest
         .default(undefined)
         .required('Capture location is required'),
       release_location: yup
-        .array(
-          yup.object({
-            geojson: yup.array().min(1, 'Release location is required if it is different from the capture location')
-          })
-        )
-        .min(1, 'Release location is required if it is different from the capture location')
+        .object()
+        .shape({
+          type: yup.string(),
+          // Points may have 3 coords for [lon, lat, elevation]
+          geometry: yup.object({
+            type: yup.string(),
+            coordinates: yup
+              .array()
+              .of(yup.number())
+              .min(2)
+              .max(3)
+              .isValidPointCoordinates('Latitude or longitude values are outside of the valid range.')
+              .required('Latitude or longitude values are outside of the valid range.')
+          }),
+          properties: yup.object().optional()
+        })
         .nullable()
+        .default(undefined)
     }),
     measurements: yup.array(
       yup

--- a/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
@@ -55,7 +55,7 @@ export const AnimalCaptureForm = <FormikValuesType extends ICreateCaptureRequest
                 }
                 return isValidCoordinates(value[1], value[0]);
               })
-              .required('Coordinates are invalid')
+              .required('Latitude or longitude values are outside of the valid range.')
           }),
           properties: yup.object().optional()
         })

--- a/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/components/AnimalCaptureForm.tsx
@@ -44,7 +44,27 @@ export const AnimalCaptureForm = <FormikValuesType extends ICreateCaptureRequest
           // Points may have 3 coords for [lon, lat, elevation]
           geometry: yup.object({
             type: yup.string(),
-            coordinates: yup.array().of(yup.number()).min(2).max(3)
+            coordinates: yup
+              .array()
+              .of(yup.number())
+              .min(2)
+              .max(3)
+              .test('is-valid-coordinates', 'Invalid coordinates', function (value) {
+                if (!value) {
+                  return false;
+                }
+
+                const [lon, lat] = value;
+
+                if (!(lat && lon && lat > -90 && lat < 90 && lon > -180 && lon < 180)) {
+                  return this.createError({
+                    message: 'The latitude or longitude values are outside of the valid range.'
+                  });
+                }
+
+                return true;
+              })
+              .required('Coordinates are invalid')
           }),
           properties: yup.object().optional()
         })

--- a/app/src/features/surveys/animals/profile/captures/components/AnimalCaptureCardContainer.tsx
+++ b/app/src/features/surveys/animals/profile/captures/components/AnimalCaptureCardContainer.tsx
@@ -169,8 +169,8 @@ export const AnimalCaptureCardContainer = (props: IAnimalCaptureCardContainer) =
                     {capture.capture_location.latitude && capture.capture_location.longitude && (
                       <Box>
                         <Typography color="textSecondary" variant="body2">
-                          {capture.capture_location.longitude},&nbsp;
-                          {capture.capture_location.latitude}
+                          {capture.capture_location.latitude},&nbsp;
+                          {capture.capture_location.longitude}
                         </Typography>
                       </Box>
                     )}

--- a/app/src/features/surveys/animals/profile/captures/components/capture-card-details/components/CaptureDetails.tsx
+++ b/app/src/features/surveys/animals/profile/captures/components/capture-card-details/components/CaptureDetails.tsx
@@ -53,7 +53,7 @@ export const CaptureDetails = (props: ICaptureDetailsProps) => {
             Capture location
           </Typography>
           <Typography color="textSecondary" variant="body2">
-            {captureLocation.longitude},&nbsp;{captureLocation.latitude}
+            {captureLocation.latitude},&nbsp;{captureLocation.longitude}
           </Typography>
         </Box>
       </Stack>

--- a/app/src/features/surveys/animals/profile/captures/components/capture-card-details/components/ReleaseDetails.tsx
+++ b/app/src/features/surveys/animals/profile/captures/components/capture-card-details/components/ReleaseDetails.tsx
@@ -57,7 +57,7 @@ export const ReleaseDetails = (props: IReleaseDetailsProps) => {
             </Typography>
             {releaseLocation && (
               <Typography color="textSecondary" variant="body2">
-                {releaseLocation.longitude},&nbsp;{releaseLocation.latitude}
+                {releaseLocation.latitude},&nbsp;{releaseLocation.longitude}
               </Typography>
             )}
           </Box>

--- a/app/src/features/surveys/animals/profile/components/LatitudeLongitudeTextFields.tsx
+++ b/app/src/features/surveys/animals/profile/components/LatitudeLongitudeTextFields.tsx
@@ -1,0 +1,37 @@
+import { SxProps } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { ChangeEvent } from 'react';
+
+interface ILatitudeLongitudeTextFieldsProps {
+  sx: SxProps;
+  latitudeValue: string;
+  longitudeValue: string;
+  onLatitudeChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onLongitudeChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+const LatitudeLongitudeTextFields = (props: ILatitudeLongitudeTextFieldsProps) => {
+  return (
+    <Stack direction="row" gap={1} sx={props.sx}>
+      <TextField
+        label="Latitude"
+        name="Latitude"
+        size="small"
+        value={props.latitudeValue}
+        type="number"
+        onChange={props.onLatitudeChange}
+      />
+      <TextField
+        label="Longitude"
+        name="Longitude"
+        size="small"
+        value={props.longitudeValue}
+        type="number"
+        onChange={props.onLongitudeChange}
+      />
+    </Stack>
+  );
+};
+
+export default LatitudeLongitudeTextFields;

--- a/app/src/features/surveys/animals/profile/mortality/components/AnimalMortalityCardContainer.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/components/AnimalMortalityCardContainer.tsx
@@ -162,8 +162,8 @@ export const AnimalMortalityCardContainer = (props: IAnimalMortalityCardContaine
                     {mortality.location?.latitude && mortality.location?.longitude && (
                       <Box>
                         <Typography color="textSecondary" variant="body2">
-                          {mortality.location.longitude},&nbsp;
-                          {mortality.location.latitude}
+                          {mortality.location.latitude},&nbsp;
+                          {mortality.location.longitude}
                         </Typography>
                       </Box>
                     )}

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
@@ -47,7 +47,7 @@ export const AnimalMortalityForm = <FormikValuesType extends ICreateMortalityReq
               .of(yup.number())
               .min(2)
               .max(3)
-              .test('is-valid-coordinates', 'Invalid coordinates', (value) => {
+              .test('is-valid-coordinates', 'Latitude or longitude values are outside of the valid range.', (value) => {
                 if (!value) {
                   return false;
                 }
@@ -59,7 +59,7 @@ export const AnimalMortalityForm = <FormikValuesType extends ICreateMortalityReq
         })
         .nullable()
         .default(undefined)
-        .required('mortality location is required')
+        .required('Mortality location is required')
     }),
     measurements: yup.array(
       yup

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
@@ -42,7 +42,27 @@ export const AnimalMortalityForm = <FormikValuesType extends ICreateMortalityReq
           // Points may have 3 coords for [lon, lat, elevation]
           geometry: yup.object({
             type: yup.string(),
-            coordinates: yup.array().of(yup.number()).min(2).max(3)
+            coordinates: yup
+              .array()
+              .of(yup.number())
+              .min(2)
+              .max(3)
+              .test('is-valid-coordinates', 'Invalid coordinates', function (value) {
+                if (!value) {
+                  return false;
+                }
+
+                const [lon, lat] = value;
+
+                if (!(lat && lon && lat > -90 && lat < 90 && lon > -180 && lon < 180)) {
+                  return this.createError({
+                    message: 'The latitude or longitude values are outside of the valid range.'
+                  });
+                }
+
+                return true;
+              })
+              .required('Coordinates are invalid')
           }),
           properties: yup.object().optional()
         })

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
@@ -6,7 +6,7 @@ import { MarkingsForm } from 'features/surveys/animals/profile/markings/Markings
 import { MeasurementsForm } from 'features/surveys/animals/profile/measurements/MeasurementsForm';
 import { Formik, FormikProps } from 'formik';
 import { ICreateMortalityRequest, IEditMortalityRequest } from 'interfaces/useCritterApi.interface';
-import { isDefined, isValidCoordinates } from 'utils/Utils';
+import { isDefined } from 'utils/Utils';
 import yup from 'utils/YupSchema';
 import { CauseOfDeathForm } from './cause-of-death/CauseOfDeathForm';
 import { MortalityGeneralInformationForm } from './general-information/MortalityGeneralInformationForm';
@@ -47,12 +47,7 @@ export const AnimalMortalityForm = <FormikValuesType extends ICreateMortalityReq
               .of(yup.number())
               .min(2)
               .max(3)
-              .test('is-valid-coordinates', 'Latitude or longitude values are outside of the valid range.', (value) => {
-                if (!value) {
-                  return false;
-                }
-                return isValidCoordinates(value[1], value[0]);
-              })
+              .isValidPointCoordinates('Latitude or longitude values are outside of the valid range.')
               .required('Latitude or longitude values are outside of the valid range.')
           }),
           properties: yup.object().optional()

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/components/AnimalMortalityForm.tsx
@@ -6,7 +6,7 @@ import { MarkingsForm } from 'features/surveys/animals/profile/markings/Markings
 import { MeasurementsForm } from 'features/surveys/animals/profile/measurements/MeasurementsForm';
 import { Formik, FormikProps } from 'formik';
 import { ICreateMortalityRequest, IEditMortalityRequest } from 'interfaces/useCritterApi.interface';
-import { isDefined } from 'utils/Utils';
+import { isDefined, isValidCoordinates } from 'utils/Utils';
 import yup from 'utils/YupSchema';
 import { CauseOfDeathForm } from './cause-of-death/CauseOfDeathForm';
 import { MortalityGeneralInformationForm } from './general-information/MortalityGeneralInformationForm';
@@ -47,22 +47,13 @@ export const AnimalMortalityForm = <FormikValuesType extends ICreateMortalityReq
               .of(yup.number())
               .min(2)
               .max(3)
-              .test('is-valid-coordinates', 'Invalid coordinates', function (value) {
+              .test('is-valid-coordinates', 'Invalid coordinates', (value) => {
                 if (!value) {
                   return false;
                 }
-
-                const [lon, lat] = value;
-
-                if (!(lat && lon && lat > -90 && lat < 90 && lon > -180 && lon < 180)) {
-                  return this.createError({
-                    message: 'The latitude or longitude values are outside of the valid range.'
-                  });
-                }
-
-                return true;
+                return isValidCoordinates(value[1], value[0]);
               })
-              .required('Coordinates are invalid')
+              .required('Latitude or longitude values are outside of the valid range.')
           }),
           properties: yup.object().optional()
         })

--- a/app/src/features/surveys/components/locations/SurveyAreaMapControl.tsx
+++ b/app/src/features/surveys/components/locations/SurveyAreaMapControl.tsx
@@ -49,6 +49,7 @@ export const SurveyAreaMapControl = (props: ISurveyAreMapControlProps) => {
   return (
     <>
       <ImportBoundaryDialog
+        dialogTitle="Import Study Area"
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         onSuccess={(features) => {

--- a/app/src/features/surveys/observations/sampling-sites/components/map/SamplingSiteEditMapControl.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/components/map/SamplingSiteEditMapControl.tsx
@@ -24,6 +24,7 @@ import { Feature } from 'geojson';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
+import { IGetSampleLocationDetails } from 'interfaces/useSamplingSiteApi.interface';
 import { DrawEvents, LatLngBoundsExpression } from 'leaflet';
 import get from 'lodash-es/get';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -51,7 +52,7 @@ const useStyles = () => {
 export interface ISamplingSiteEditMapControlProps {
   name: string;
   mapId: string;
-  formikProps: FormikContextType<any>;
+  formikProps: FormikContextType<IGetSampleLocationDetails>;
 }
 
 /**

--- a/app/src/features/surveys/observations/sampling-sites/components/map/SamplingSiteMapControl.tsx
+++ b/app/src/features/surveys/observations/sampling-sites/components/map/SamplingSiteMapControl.tsx
@@ -22,6 +22,7 @@ import SampleSiteFileUploadItemProgressBar from 'features/surveys/observations/s
 import SampleSiteFileUploadItemSubtext from 'features/surveys/observations/sampling-sites/components/map/file-upload/SampleSiteFileUploadItemSubtext';
 import { FormikContextType } from 'formik';
 import { Feature } from 'geojson';
+import { ICreateSamplingSiteRequest } from 'interfaces/useSamplingSiteApi.interface';
 import { DrawEvents, LatLngBoundsExpression } from 'leaflet';
 import 'leaflet-fullscreen/dist/leaflet.fullscreen.css';
 import 'leaflet-fullscreen/dist/Leaflet.fullscreen.js';
@@ -53,7 +54,7 @@ export interface ISamplingSiteMapControlProps {
   name: string;
   title: string;
   mapId: string;
-  formikProps: FormikContextType<any>;
+  formikProps: FormikContextType<ICreateSamplingSiteRequest>;
 }
 
 /**

--- a/app/src/features/surveys/telemetry/ManualTelemetryList.tsx
+++ b/app/src/features/surveys/telemetry/ManualTelemetryList.tsx
@@ -540,7 +540,7 @@ const ManualTelemetryList = () => {
                   </Button>
                 </Toolbar>
                 <Divider flexItem></Divider>
-                <Box position="relative" display="flex" flex="1 1 auto" overflow="hidden">
+                <Box position="relative" display="flex" flex="1 1 auto" overflow="auto">
                   <Box
                     position="absolute"
                     top="0"

--- a/app/src/types/yup.d.ts
+++ b/app/src/types/yup.d.ts
@@ -8,7 +8,7 @@ import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import yup from 'utils/YupSchema';
 
 declare module 'yup' {
-  export class StringSchema extends yup.StringSchema {
+  interface StringSchema {
     /**
      * Determine if the string is a valid date string. Does nothing if the string is null.
      *
@@ -99,7 +99,7 @@ declare module 'yup' {
     ): yup.StringSchema<string | undefined, Record<string, any>, string | undefined>;
   }
 
-  export class ArraySchema extends yup.ArraySchema {
+  interface ArraySchema {
     /**
      * Determine if the array of classification details has duplicates
      *
@@ -160,5 +160,16 @@ declare module 'yup' {
       startKey: string,
       endKey: string
     ): yup.StringSchema<string | undefined, Record<string, any>, string | undefined>;
+
+    /**
+     * Validates that the GeoJson point coordinates (latitude/longitude) are valid
+     *
+     * @param {string} message Error message to display
+     * @return {*}  {(yup.NumberSchema<number | undefined, Record<string, any>, number | undefined>)}
+     * @memberof ArraySchema
+     */
+    isValidPointCoordinates(
+      message: string
+    ): yup.NumberSchema<number | undefined, Record<string, any>, number | undefined>;
   }
 }

--- a/app/src/utils/Utils.tsx
+++ b/app/src/utils/Utils.tsx
@@ -462,3 +462,30 @@ export const getRandomHexColor = (seed: number, min = 100, max = 170): string =>
  * @return {*}  {value is T}
  */
 export const isDefined = <T,>(value: T | undefined | null): value is T => value !== undefined && value !== null;
+
+/**
+ * Checks whether a latitude-longitude pair of coordinates is valid
+ *
+ * @param {number} latitude
+ * @param {number} longitude
+ * @returns boolean
+ */
+export const isValidCoordinates = (latitude: number | undefined, longitude: number | undefined) => {
+  return latitude && longitude && latitude > -90 && latitude < 90 && longitude > -180 && longitude < 180 ? true : false;
+};
+
+/**
+ * Gets latitude and longitude values from a GeoJson
+ *
+ * @param {Feature} feature
+ * @param {'string' | 'number'} type
+ * @returns boolean
+ */
+export const getCoordinatesFromGeoJson = (feature: Feature): { latitude: number; longitude: number } | undefined => {
+  if (feature.geometry && 'coordinates' in feature.geometry) {
+    const lon = feature.geometry.coordinates[0];
+    const lat = feature.geometry.coordinates[1];
+
+    return { latitude: lat as number, longitude: lon as number };
+  }
+};

--- a/app/src/utils/Utils.tsx
+++ b/app/src/utils/Utils.tsx
@@ -412,8 +412,6 @@ export const shapeFileFeatureDesc = (geometry: Feature<Geometry, GeoJsonProperti
   return descKey && geometry.properties ? geometry.properties[descKey].substring(0, 250) : undefined;
 };
 
-// JSX Functions //
-//
 /**
  * Simple reusable method to make a snackbar appear with a string of your choice.
  *
@@ -462,30 +460,3 @@ export const getRandomHexColor = (seed: number, min = 100, max = 170): string =>
  * @return {*}  {value is T}
  */
 export const isDefined = <T,>(value: T | undefined | null): value is T => value !== undefined && value !== null;
-
-/**
- * Checks whether a latitude-longitude pair of coordinates is valid
- *
- * @param {number} latitude
- * @param {number} longitude
- * @returns boolean
- */
-export const isValidCoordinates = (latitude: number | undefined, longitude: number | undefined) => {
-  return latitude && longitude && latitude > -90 && latitude < 90 && longitude > -180 && longitude < 180 ? true : false;
-};
-
-/**
- * Gets latitude and longitude values from a GeoJson
- *
- * @param {Feature} feature
- * @param {'string' | 'number'} type
- * @returns boolean
- */
-export const getCoordinatesFromGeoJson = (feature: Feature): { latitude: number; longitude: number } | undefined => {
-  if (feature.geometry && 'coordinates' in feature.geometry) {
-    const lon = feature.geometry.coordinates[0];
-    const lat = feature.geometry.coordinates[1];
-
-    return { latitude: lat as number, longitude: lon as number };
-  }
-};

--- a/app/src/utils/YupSchema.ts
+++ b/app/src/utils/YupSchema.ts
@@ -5,6 +5,7 @@
 
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { default as dayjs } from 'dayjs';
+import { isValidCoordinates } from 'utils/spatial-utils';
 import * as yup from 'yup';
 
 yup.addMethod(yup.array, 'isUniqueIUCNClassificationDetail', function (message: string) {
@@ -226,6 +227,15 @@ yup.addMethod(yup.array, 'hasUniqueDateRanges', function (message: string, start
     }
 
     return true;
+  });
+});
+
+yup.addMethod(yup.array, 'isValidPointCoordinates', function (message: string) {
+  return this.test('has-at-least-one-value', message, (value) => {
+    if (!value || !value.length) {
+      return false;
+    }
+    return isValidCoordinates(value[1], value[0]);
   });
 });
 

--- a/app/src/utils/spatial-utils.ts
+++ b/app/src/utils/spatial-utils.ts
@@ -1,4 +1,4 @@
-import { Feature } from 'geojson';
+import { Feature, Point } from 'geojson';
 import { isDefined } from 'utils/Utils';
 
 /**
@@ -32,4 +32,38 @@ export const getPointFeature = <Return00PointType extends boolean = false>(param
     },
     properties: { ...params.properties }
   };
+};
+
+/**
+ * Checks whether a latitude-longitude pair of coordinates is valid
+ *
+ * @param {number} latitude
+ * @param {number} longitude
+ * @returns boolean
+ */
+export const isValidCoordinates = (latitude: number | undefined, longitude: number | undefined) => {
+  return latitude && longitude && latitude > -90 && latitude < 90 && longitude > -180 && longitude < 180 ? true : false;
+};
+
+/**
+ * Gets latitude and longitude values from a GeoJson Point Feature.
+ *
+ * @param {Feature<Point>} feature
+ * @return {*}  {{ latitude: number; longitude: number }}
+ */
+export const getCoordinatesFromGeoJson = (feature: Feature<Point>): { latitude: number; longitude: number } => {
+  const lon = feature.geometry.coordinates[0];
+  const lat = feature.geometry.coordinates[1];
+
+  return { latitude: lat as number, longitude: lon as number };
+};
+
+/**
+ * Checks if the given feature is a GeoJson Feature containing a Point.
+ *
+ * @param {(Feature | any)} [feature]
+ * @return {*}  {feature is Feature<Point>}
+ */
+export const isGeoJsonPointFeature = (feature?: Feature | any): feature is Feature<Point> => {
+  return (feature as Feature)?.geometry.type === 'Point';
 };


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Added input textfield boxes to manually enter capture and mortality latitude/longitude values
- Updated validation of coordinates
- Bug fix: remove overflow hidden from the telemetry deployments list

## Testing Notes

- There should only ever be one point on the map when adding/editing capture and mortality locations