### PR TITLE
BugFix: Fix migration to drop missed instance of wldtaxonomic_units_id column

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     branches-ignore:
+      - test
       - prod
 
 concurrency:

--- a/database/src/migrations/20240624000000_attachment_type_fix.ts
+++ b/database/src/migrations/20240624000000_attachment_type_fix.ts
@@ -1,9 +1,6 @@
 import { Knex } from 'knex';
 
 /**
- * Drop deprecated study_species.wldtaxonomic_units_id column.
- * Drop deprecated survey.field_method_id column.
- *
  * Migrate outdated project_attachment.file_type and survey_attachment.file_type values:
  * - Deprecated values 'Spatial Data' and 'Data File' are now 'Other'.
  *
@@ -14,33 +11,13 @@ import { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`--sql  
     ----------------------------------------------------------------------------------------
-    -- Drop views
-    ----------------------------------------------------------------------------------------
-    SET SEARCH_PATH=biohub_dapi_v1;
-
-    DROP VIEW IF EXISTS study_species;
-    DROP VIEW IF EXISTS survey;
-
-    ----------------------------------------------------------------------------------------
     -- Alter tables/data
     ----------------------------------------------------------------------------------------
     SET SEARCH_PATH=biohub;
 
-    -- Drop deprecated columns
-    ALTER TABLE study_species DROP COLUMN wldtaxonomic_units_id;
-    ALTER TABLE survey DROP COLUMN field_method_id;
-
     -- Migrate deprecated file_type values
     UPDATE project_attachment SET file_type = 'Other' WHERE file_type NOT IN ('Other', 'KeyX', 'Report');
     UPDATE survey_attachment SET file_type = 'Other' WHERE file_type NOT IN ('Other', 'KeyX', 'Report');
-
-    ----------------------------------------------------------------------------------------
-    -- Update views
-    ----------------------------------------------------------------------------------------
-    SET SEARCH_PATH=biohub_dapi_v1;
-
-    CREATE OR REPLACE VIEW study_species as SELECT * FROM biohub.study_species;
-    CREATE OR REPLACE VIEW survey as SELECT * FROM biohub.survey;
   `);
 }
 

--- a/database/src/migrations/20240625000000_deprecated_columns.ts
+++ b/database/src/migrations/20240625000000_deprecated_columns.ts
@@ -1,0 +1,50 @@
+import { Knex } from 'knex';
+
+/**
+ * Drop deprecated study_species.wldtaxonomic_units_id column.
+ * Drop deprecated survey_observation.wldtaxonomic_units_id column.
+ * Drop deprecated survey.field_method_id column.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql  
+    ----------------------------------------------------------------------------------------
+    -- Drop views
+    ----------------------------------------------------------------------------------------
+    SET SEARCH_PATH=biohub_dapi_v1;
+
+    DROP VIEW IF EXISTS study_species;
+    DROP VIEW IF EXISTS survey_observation;
+
+    DROP VIEW IF EXISTS survey;
+
+    ----------------------------------------------------------------------------------------
+    -- Alter tables/data
+    ----------------------------------------------------------------------------------------
+    SET SEARCH_PATH=biohub;
+
+    -- Drop deprecated wldtaxonomic_units_id column
+    ALTER TABLE study_species DROP COLUMN IF EXISTS wldtaxonomic_units_id;
+    ALTER TABLE survey_observation DROP COLUMN IF EXISTS wldtaxonomic_units_id;
+
+    -- Drop deprecated field_method_id column
+    ALTER TABLE survey DROP COLUMN IF EXISTS field_method_id;
+
+    ----------------------------------------------------------------------------------------
+    -- Update views
+    ----------------------------------------------------------------------------------------
+    SET SEARCH_PATH=biohub_dapi_v1;
+
+    CREATE OR REPLACE VIEW study_species as SELECT * FROM biohub.study_species;
+    CREATE OR REPLACE VIEW survey_observation as SELECT * FROM biohub.survey_observation;
+
+    CREATE OR REPLACE VIEW survey as SELECT * FROM biohub.survey;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

#### Add migration to drop some deprecated columns.
- Missed an instance of the wldtaxonomic_units_id column. The original migration deprecated old file_type values AND dropped columns in the same PR. Split those two groups of changes into two separate PRs. Will be safe to move existing migration code from the old file to the new file because they all use `IF EXISTS`.

#### Disable PR deployment Git Action for Dev->Test PRs (already disabled for Test->Prod PRs)

## Testing Notes

Editing an observation record works (does not result in zod validation errors).

Editing the existing migration should be safe, as the commands moved to the new migration all include `IF EXISTS`.