### PR TITLE
Fix bug in observation inserts and updates

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
@@ -75,7 +75,7 @@ describe('insertUpdateManualSurveyObservations', () => {
       surveyObservations
     };
 
-    const requestHandler = observationRecords.insertUpdateManualSurveyObservations();
+    const requestHandler = observationRecords.putObservations();
 
     await requestHandler(mockReq, mockRes, mockNext);
 
@@ -126,7 +126,7 @@ describe('insertUpdateManualSurveyObservations', () => {
     };
 
     try {
-      const requestHandler = observationRecords.insertUpdateManualSurveyObservations();
+      const requestHandler = observationRecords.putObservations();
 
       await requestHandler(mockReq, mockRes, mockNext);
       expect.fail();

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.ts
@@ -52,7 +52,7 @@ export const PUT: Operation = [
       ]
     };
   }),
-  insertUpdateManualSurveyObservations()
+  putObservations()
 ];
 
 GET.apiDoc = {
@@ -168,7 +168,8 @@ PUT.apiDoc = {
                         type: 'integer',
                         minimum: 1,
                         nullable: true,
-                        description: 'The survey observation ID. If provided observation, the record will be updated.'
+                        description:
+                          'The survey observation ID. If provided, the matching existing observation record will be updated. If not provided, a new observation record will be inserted.'
                       },
                       itis_tsn: {
                         type: 'integer'
@@ -229,9 +230,11 @@ PUT.apiDoc = {
                       ],
                       properties: {
                         observation_subcount_id: {
-                          type: 'number',
+                          type: 'integer',
+                          minimum: 1,
                           nullable: true,
-                          description: 'The observation subcount ID. If provided, the subcount record will be updated.'
+                          description:
+                            'The observation subcount ID. If provided, the mataching existing subcount record will be updated. If not provided, a new subcount record will be inserted.'
                         },
                         subcount: {
                           type: 'number',
@@ -407,7 +410,7 @@ export function getSurveyObservations(): RequestHandler {
  * @export
  * @return {*}  {RequestHandler}
  */
-export function insertUpdateManualSurveyObservations(): RequestHandler {
+export function putObservations(): RequestHandler {
   return async (req, res) => {
     const surveyId = Number(req.params.surveyId);
 

--- a/api/src/repositories/observation-repository/observation-repository.ts
+++ b/api/src/repositories/observation-repository/observation-repository.ts
@@ -304,7 +304,9 @@ export class ObservationRepository extends BaseRepository {
       observations
         .map((observation) => {
           return `(${[
-            'survey_observation_id' in observation ? observation.survey_observation_id : 'DEFAULT',
+            'survey_observation_id' in observation && observation.survey_observation_id
+              ? observation.survey_observation_id
+              : 'DEFAULT',
             surveyId,
             observation.survey_sample_site_id ?? 'NULL',
             observation.survey_sample_method_id ?? 'NULL',
@@ -320,6 +322,8 @@ export class ObservationRepository extends BaseRepository {
         })
         .join(', ')
     );
+
+    console.log(sqlStatement);
 
     sqlStatement.append(`
       ON CONFLICT

--- a/api/src/repositories/observation-repository/observation-repository.ts
+++ b/api/src/repositories/observation-repository/observation-repository.ts
@@ -323,8 +323,6 @@ export class ObservationRepository extends BaseRepository {
         .join(', ')
     );
 
-    console.log(sqlStatement);
-
     sqlStatement.append(`
       ON CONFLICT
         (survey_observation_id)

--- a/api/src/services/observation-service.test.ts
+++ b/api/src/services/observation-service.test.ts
@@ -2,11 +2,8 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
-  InsertObservation,
-  ObservationRecord,
   ObservationRecordWithSamplingAndSubcountData,
-  ObservationRepository,
-  UpdateObservation
+  ObservationRepository
 } from '../repositories/observation-repository/observation-repository';
 import * as file_utils from '../utils/file-utils';
 import { getMockDBConnection } from '../__mocks__/db';
@@ -26,92 +23,6 @@ describe('ObservationService', () => {
     const observationService = new ObservationService(mockDBConnection);
 
     expect(observationService).to.be.instanceof(ObservationService);
-  });
-
-  describe('insertUpdateDeleteSurveyObservations', () => {
-    it('deletes, creates, and updates observation records', async () => {
-      const mockDBConnection = getMockDBConnection();
-
-      const deleteObservationsNotInArrayStub = sinon
-        .stub(ObservationRepository.prototype, 'deleteObservationsNotInArray')
-        .resolves();
-
-      const mockInsertUpdateResponse: ObservationRecord[] = [
-        {
-          survey_observation_id: 11,
-          survey_id: 1,
-          latitude: 3,
-          longitude: 4,
-          count: 5,
-          itis_tsn: 6,
-          itis_scientific_name: 'itis_scientific_name',
-          observation_date: '2023-01-01',
-          observation_time: '12:00:00',
-          create_date: '2023-04-04',
-          create_user: 1,
-          update_date: null,
-          update_user: null,
-          revision_count: 0,
-          survey_sample_site_id: 1,
-          survey_sample_method_id: 1,
-          survey_sample_period_id: 1
-        },
-        {
-          survey_observation_id: 6,
-          survey_id: 1,
-          latitude: 8,
-          longitude: 9,
-          count: 10,
-          itis_tsn: 6,
-          itis_scientific_name: 'itis_scientific_name',
-          observation_date: '2023-02-02',
-          observation_time: '13:00:00',
-          create_date: '2023-03-03',
-          create_user: 1,
-          update_date: '2023-04-04',
-          update_user: 2,
-          revision_count: 1,
-          survey_sample_site_id: 1,
-          survey_sample_method_id: 1,
-          survey_sample_period_id: 1
-        }
-      ];
-      const insertUpdateSurveyObservationsStub = sinon
-        .stub(ObservationRepository.prototype, 'insertUpdateSurveyObservations')
-        .resolves(mockInsertUpdateResponse);
-
-      const surveyId = 1;
-      const observations: (InsertObservation | UpdateObservation)[] = [
-        {
-          survey_id: 1,
-          latitude: 3,
-          longitude: 4,
-          count: 5,
-          itis_tsn: 6,
-          itis_scientific_name: 'itis_scientific_name',
-          observation_date: '2023-01-01',
-          observation_time: '12:00:00'
-        } as InsertObservation,
-        {
-          survey_observation_id: 6,
-          latitude: 8,
-          longitude: 9,
-          count: 10,
-          itis_tsn: 6,
-          itis_scientific_name: 'itis_scientific_name',
-          observation_date: '2023-02-02',
-          observation_time: '13:00:00'
-        } as UpdateObservation
-      ];
-
-      const observationService = new ObservationService(mockDBConnection);
-
-      const response = await observationService.insertUpdateDeleteSurveyObservations(surveyId, observations);
-
-      expect(deleteObservationsNotInArrayStub).to.have.been.calledOnceWith(surveyId, [6]);
-      expect(insertUpdateSurveyObservationsStub).to.have.been.calledOnceWith(surveyId, observations);
-      expect(response).to.eql(mockInsertUpdateResponse);
-    });
   });
 
   describe('getSurveyObservationsWithSupplementaryAndSamplingDataAndAttributeData', () => {

--- a/api/src/services/observation-service.ts
+++ b/api/src/services/observation-service.ts
@@ -141,31 +141,6 @@ export class ObservationService extends DBService {
   }
 
   /**
-   * Performs an upsert for all observation records belonging to the given survey, while removing
-   * any records associated for the survey that aren't included in the given records, then
-   * returns the updated rows
-   *
-   * @param {number} surveyId
-   * @param {((Observation | ObservationRecord)[])} observations
-   * @return {*}  {Promise<ObservationRecord[]>}
-   * @memberof ObservationService
-   */
-  async insertUpdateDeleteSurveyObservations(
-    surveyId: number,
-    observations: (InsertObservation | UpdateObservation)[]
-  ): Promise<ObservationRecord[]> {
-    const retainedObservationIds = observations
-      .filter((observation): observation is UpdateObservation => {
-        return 'survey_observation_id' in observation && Boolean(observation.survey_observation_id);
-      })
-      .map((observation) => observation.survey_observation_id);
-
-    await this.observationRepository.deleteObservationsNotInArray(surveyId, retainedObservationIds);
-
-    return this.observationRepository.insertUpdateSurveyObservations(surveyId, observations);
-  }
-
-  /**
    * Upserts the given observation records and their associated measurements.
    *
    * @param {number} surveyId


### PR DESCRIPTION
## Description of Changes

Fixes a bug in the SQL when inserting and updating species observations.
- species_observation_id could exist in the object but be null, in which case the SQL was incorrect
