### PR TITLE
BugFix: Fix typo in BCTW deployment object

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.ts
@@ -238,10 +238,12 @@ PATCH.apiDoc = {
 export function deployDevice(): RequestHandler {
   return async (req, res) => {
     const critterId = Number(req.params.critterId);
+
     const newDeploymentId = v4(); // New deployment ID
+
     const newDeploymentDevice = {
       ...req.body,
-      deploymentId: newDeploymentId
+      deployment_id: newDeploymentId
     };
 
     const connection = getDBConnection(req.keycloak_token);


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Changed `deploymentId` to `deployment_id`, fixing a bug where BCTW created a new deployment ID that did not match any record in the SIMS deployment table. BCTW expects `deployment_id`, but because this didn't exist, BCTW created a new UUID for the deployment record.
