### PR TITLE
TechDebt: Fix Patch System User SQL

### DIFF
--- a/api/src/paths/user/self.test.ts
+++ b/api/src/paths/user/self.test.ts
@@ -6,7 +6,7 @@ import * as db from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { UserService } from '../../services/user-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as self from './self';
+import { getSelf } from './self';
 
 chai.use(sinonChai);
 
@@ -23,7 +23,7 @@ describe('getUser', () => {
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
     try {
-      const requestHandler = self.getUser();
+      const requestHandler = getSelf();
 
       await requestHandler(mockReq, mockRes, mockNext);
       expect.fail();
@@ -57,7 +57,7 @@ describe('getUser', () => {
       agency: null
     });
 
-    const requestHandler = self.getUser();
+    const requestHandler = getSelf();
 
     await requestHandler(mockReq, mockRes, mockNext);
 
@@ -84,7 +84,7 @@ describe('getUser', () => {
     });
 
     try {
-      const requestHandler = self.getUser();
+      const requestHandler = getSelf();
 
       await requestHandler(mockReq, mockRes, mockNext);
       expect.fail();

--- a/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
@@ -159,6 +159,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
         <Stack direction="row" gap={0.5} flexWrap="wrap">
           {params.row.members.map((member) => (
             <TeamMemberAvatar
+              key={member.system_user_id}
               title={member.display_name}
               label={member.display_name
                 .split(',')


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

- Fix Patch System User SQL
- Fix `/self` endpoint
  - The endpoint was rejecting any system user that had no user_guid, because the authorization check runs before the patch sql, and only uses the user_guid. It is safe to remove the authorization scheme because the endpoint already checks for a valid systemUserId, which can only exist if the connection is opened with the token successfully.
  - Rename endpoint function to `getSelf` for better readability.
  
## Testing Notes

- When a user logs in, everything should work as expected: (the patch is called, the user context is set, and the self endpoint is called).
- If you manually set the `user_guid` column of your `system_user` record to `null`, and then log in, all of the calls should succeed, and your user_guid should be re-added to your system_user record.
