### PR TITLE
TechDebt: Centralize Virus Scan

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -104,7 +104,12 @@ const openAPIFramework = initialize({
           }
         });
 
-        await Promise.all(virusScanPromises);
+        try {
+          await Promise.all(virusScanPromises);
+        } catch (error) {
+          // If a virus is detected, return error and do not continue
+          return next(error);
+        }
 
         // Ensure `req.files` or `req.body.media` is always set to an array
         const multerFiles = req.files ?? [];

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -5,7 +5,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 import swaggerUIExperss from 'swagger-ui-express';
 import { defaultPoolConfig, initDBPool } from './database/db';
-import { ensureHTTPError, HTTP500 } from './errors/http-error';
+import { ensureHTTPError, HTTP400, HTTP500 } from './errors/http-error';
 import {
   authorizeAndAuthenticateMiddleware,
   getCritterbaseProxyMiddleware,
@@ -13,6 +13,7 @@ import {
 } from './middleware/critterbase-proxy';
 import { rootAPIDoc } from './openapi/root-api-doc';
 import { authenticateRequest, authenticateRequestOptional } from './request-handlers/security/authentication';
+import { scanFileForVirus } from './utils/file-utils';
 import { getLogger } from './utils/logger';
 
 const defaultLog = getLogger('app');
@@ -75,7 +76,7 @@ const openAPIFramework = initialize({
     'application/json': express.json({ limit: MAX_REQ_BODY_SIZE }),
     'multipart/form-data': function (req, res, next) {
       const multerRequestHandler = multer({
-        storage: multer.memoryStorage(),
+        storage: multer.memoryStorage(), // TODO change to local/PVC storage and stream file uploads to S3?
         limits: { fileSize: MAX_UPLOAD_FILE_SIZE }
       }).array('media', MAX_UPLOAD_NUM_FILES);
 
@@ -89,10 +90,21 @@ const openAPIFramework = initialize({
        *
        * @see https://www.npmjs.com/package/express-openapi#argsconsumesmiddleware
        */
-      multerRequestHandler(req, res, (error?: any) => {
+      multerRequestHandler(req, res, async (error?: any) => {
         if (error) {
           return next(error);
         }
+
+        // Scan files for malicious content, if enabled
+        const virusScanPromises = (req.files as Express.Multer.File[]).map(async function (file) {
+          const isSafe = await scanFileForVirus(file);
+
+          if (!isSafe) {
+            throw new HTTP400('Malicious file content detected.', [{ file_name: file.originalname }]);
+          }
+        });
+
+        await Promise.all(virusScanPromises);
 
         // Ensure `req.files` or `req.body.media` is always set to an array
         const multerFiles = req.files ?? [];

--- a/api/src/paths/project/{projectId}/attachments/report/upload.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/report/upload.test.ts
@@ -46,8 +46,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
-
     const expectedError = new Error('cannot process request');
     sinon.stub(AttachmentService.prototype, 'upsertProjectReportAttachment').rejects(expectedError);
 
@@ -69,7 +67,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
     sinon.stub(file_utils, 'uploadFileToS3').resolves();
 
     const expectedResponse = { attachmentId: 1, revision_count: 1 };

--- a/api/src/paths/project/{projectId}/attachments/report/upload.ts
+++ b/api/src/paths/project/{projectId}/attachments/report/upload.ts
@@ -2,11 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../constants/roles';
 import { getDBConnection } from '../../../../../database/db';
-import { HTTP400 } from '../../../../../errors/http-error';
 import { fileSchema } from '../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
 import { AttachmentService } from '../../../../../services/attachment-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../utils/file-utils';
 import { getLogger } from '../../../../../utils/logger';
 import { getFileFromRequest } from '../../../../../utils/request';
 
@@ -157,13 +156,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       const attachmentService = new AttachmentService(connection);
 

--- a/api/src/paths/project/{projectId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/upload.test.ts
@@ -44,8 +44,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
-
     const expectedError = new Error('cannot process request');
     sinon.stub(AttachmentService.prototype, 'upsertProjectAttachment').rejects(expectedError);
 
@@ -67,7 +65,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
     sinon.stub(file_utils, 'uploadFileToS3').resolves();
 
     const expectedResponse = { attachmentId: 1, revision_count: 1 };

--- a/api/src/paths/project/{projectId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/attachments/upload.ts
@@ -3,11 +3,10 @@ import { Operation } from 'express-openapi';
 import { ATTACHMENT_TYPE } from '../../../../constants/attachments';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../constants/roles';
 import { getDBConnection } from '../../../../database/db';
-import { HTTP400 } from '../../../../errors/http-error';
 import { fileSchema } from '../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
 import { AttachmentService } from '../../../../services/attachment-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../utils/file-utils';
 import { getLogger } from '../../../../utils/logger';
 import { getFileFromRequest } from '../../../../utils/request';
 
@@ -132,13 +131,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       const attachmentService = new AttachmentService(connection);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.test.ts
@@ -40,8 +40,6 @@ describe('uploadMedia', () => {
       }
     } as any;
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
-
     const expectedError = new Error('cannot process request');
     sinon.stub(AttachmentService.prototype, 'upsertSurveyReportAttachment').rejects(expectedError);
 
@@ -59,7 +57,6 @@ describe('uploadMedia', () => {
     const dbConnectionObj = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
     sinon.stub(file_utils, 'uploadFileToS3').resolves();
 
     const mockReq = {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.ts
@@ -2,11 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
-import { HTTP400 } from '../../../../../../../errors/http-error';
 import { fileSchema } from '../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
 import { AttachmentService } from '../../../../../../../services/attachment-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../utils/logger';
 import { getFileFromRequest } from '../../../../../../../utils/request';
 
@@ -174,13 +173,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       const attachmentService = new AttachmentService(connection);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.test.ts
@@ -19,45 +19,9 @@ describe('postSurveyTelemetryCredentialAttachment', () => {
     sinon.restore();
   });
 
-  it('should throw an error when file has malicious content', async () => {
-    const dbConnectionObj = getMockDBConnection();
-    sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(false); // fail virus scan
-
-    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-
-    mockReq.keycloak_token = {} as KeycloakUserInformation;
-    mockReq.params = {
-      projectId: '1',
-      surveyId: '2'
-    };
-    mockReq.files = [
-      {
-        fieldname: 'media',
-        originalname: 'test.keyx',
-        encoding: '7bit',
-        mimetype: 'text/plain',
-        size: 340
-      }
-    ] as Express.Multer.File[];
-
-    const requestHandler = postSurveyTelemetryCredentialAttachment();
-
-    try {
-      await requestHandler(mockReq, mockRes, mockNext);
-      expect.fail();
-    } catch (actualError) {
-      expect((actualError as HTTPError).status).to.equal(400);
-      expect((actualError as HTTPError).message).to.equal('Malicious content detected, upload cancelled');
-    }
-  });
-
   it('should throw an error when file type is invalid', async () => {
     const dbConnectionObj = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -92,8 +56,6 @@ describe('postSurveyTelemetryCredentialAttachment', () => {
   it('succeeds and uploads a KeyX file to BCTW', async () => {
     const dbConnectionObj = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
 
     const upsertSurveyTelemetryCredentialAttachmentStub = sinon
       .stub(AttachmentService.prototype, 'upsertSurveyTelemetryCredentialAttachment')
@@ -134,8 +96,6 @@ describe('postSurveyTelemetryCredentialAttachment', () => {
     const dbConnectionObj = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
-
     const upsertSurveyTelemetryCredentialAttachmentStub = sinon
       .stub(AttachmentService.prototype, 'upsertSurveyTelemetryCredentialAttachment')
       .resolves({ survey_telemetry_credential_attachment_id: 44, key: 'path/to/file/test.keyx' });
@@ -174,8 +134,6 @@ describe('postSurveyTelemetryCredentialAttachment', () => {
   it('should catch and re-throw an error', async () => {
     const dbConnectionObj = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
 
     const upsertSurveyTelemetryCredentialAttachmentStub = sinon
       .stub(AttachmentService.prototype, 'upsertSurveyTelemetryCredentialAttachment')

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.ts
@@ -9,7 +9,7 @@ import { authorizeRequestHandler } from '../../../../../../../request-handlers/s
 import { AttachmentService } from '../../../../../../../services/attachment-service';
 import { BctwKeyxService } from '../../../../../../../services/bctw-service/bctw-keyx-service';
 import { getBctwUser } from '../../../../../../../services/bctw-service/bctw-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../utils/logger';
 import { isValidTelementryCredentialFile } from '../../../../../../../utils/media/media-utils';
 import { getFileFromRequest } from '../../../../../../../utils/request';
@@ -138,13 +138,6 @@ export function postSurveyTelemetryCredentialAttachment(): RequestHandler {
         message: 'files',
         files: { ...rawMediaFile, buffer: 'Too big to print' }
       });
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       const isTelemetryCredentialFile = isValidTelementryCredentialFile(rawMediaFile);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.test.ts
@@ -44,8 +44,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
-
     const expectedError = new Error('cannot process request');
     sinon.stub(AttachmentService.prototype, 'upsertSurveyAttachment').rejects(expectedError);
 
@@ -67,7 +65,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
     sinon.stub(file_utils, 'uploadFileToS3').resolves();
 
     const expectedResponse = { attachmentId: 1, revision_count: 1 };

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.ts
@@ -3,11 +3,10 @@ import { Operation } from 'express-openapi';
 import { ATTACHMENT_TYPE } from '../../../../../../constants/attachments';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../database/db';
-import { HTTP400 } from '../../../../../../errors/http-error';
 import { fileSchema } from '../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
 import { AttachmentService } from '../../../../../../services/attachment-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../utils/logger';
 import { getFileFromRequest } from '../../../../../../utils/request';
 
@@ -123,13 +122,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       const attachmentService = new AttachmentService(connection);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/captures/import.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/captures/import.ts
@@ -2,12 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
-import { HTTP400 } from '../../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
 import { ImportCapturesStrategy } from '../../../../../../../services/import-services/capture/import-captures-strategy';
 import { importCSV } from '../../../../../../../services/import-services/import-csv';
-import { scanFileForVirus } from '../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../utils/logger';
 import { parseMulterFile } from '../../../../../../../utils/media/media-utils';
 import { getFileFromRequest } from '../../../../../../../utils/request';
@@ -134,13 +132,6 @@ export function importCsv(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Check for viruses / malware
-      const virusScanResult = await scanFileForVirus(rawFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, import cancelled.');
-      }
 
       const importCsvCaptures = new ImportCapturesStrategy(connection, surveyId);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.test.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as db from '../../../../../../database/db';
-import { HTTP400 } from '../../../../../../errors/http-error';
 import * as strategy from '../../../../../../services/import-services/import-csv';
-import * as fileUtils from '../../../../../../utils/file-utils';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
 import { importCsv } from './import';
 
@@ -16,7 +14,6 @@ describe('importCsv', () => {
     const mockDBConnection = getMockDBConnection({ open: sinon.stub(), commit: sinon.stub(), release: sinon.stub() });
     const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const mockImportCSV = sinon.stub(strategy, 'importCSV').resolves([1, 2]);
-    const mockFileScan = sinon.stub(fileUtils, 'scanFileForVirus').resolves(true);
 
     const mockFile = { originalname: 'test.csv', mimetype: 'test.csv', buffer: Buffer.alloc(1) } as Express.Multer.File;
 
@@ -31,8 +28,6 @@ describe('importCsv', () => {
 
     expect(mockDBConnection.open).to.have.been.calledOnce;
 
-    expect(mockFileScan).to.have.been.calledOnceWithExactly(mockFile);
-
     expect(getDBConnectionStub).to.have.been.calledOnce;
 
     expect(mockImportCSV).to.have.been.calledOnce;
@@ -41,48 +36,5 @@ describe('importCsv', () => {
 
     expect(mockDBConnection.commit).to.have.been.calledOnce;
     expect(mockDBConnection.release).to.have.been.calledOnce;
-  });
-
-  it('should catch error and rollback if file contains malware', async () => {
-    const mockDBConnection = getMockDBConnection({
-      open: sinon.stub(),
-      commit: sinon.stub(),
-      release: sinon.stub(),
-      rollback: sinon.stub()
-    });
-    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-
-    const mockFileScan = sinon.stub(fileUtils, 'scanFileForVirus').resolves(false);
-
-    const mockFile = {
-      originalname: 'test.csv',
-      mimetype: 'test.csv',
-      buffer: Buffer.alloc(1)
-    } as Express.Multer.File;
-
-    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-
-    mockReq.files = [mockFile];
-    mockReq.params.surveyId = '1';
-
-    const requestHandler = importCsv();
-
-    try {
-      await requestHandler(mockReq, mockRes, mockNext);
-      expect.fail();
-    } catch (err: any) {
-      expect(err).to.be.instanceof(HTTP400);
-      expect(err.message).to.be.contains('Malicious content detected');
-    }
-
-    expect(mockDBConnection.open).to.have.been.calledOnce;
-    expect(mockFileScan).to.have.been.calledOnceWithExactly(mockFile);
-
-    expect(getDBConnectionStub).to.have.been.calledOnce;
-    expect(mockRes.json).to.not.have.been.called;
-
-    expect(mockDBConnection.rollback).to.have.been.called;
-    expect(mockDBConnection.commit).to.not.have.been.called;
-    expect(mockDBConnection.release).to.have.been.called;
   });
 });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.ts
@@ -2,12 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../database/db';
-import { HTTP400 } from '../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
 import { ImportCrittersStrategy } from '../../../../../../services/import-services/critter/import-critters-strategy';
 import { importCSV } from '../../../../../../services/import-services/import-csv';
-import { scanFileForVirus } from '../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../utils/logger';
 import { parseMulterFile } from '../../../../../../utils/media/media-utils';
 import { getFileFromRequest } from '../../../../../../utils/request';
@@ -136,13 +134,6 @@ export function importCsv(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Check for viruses / malware
-      const virusScanResult = await scanFileForVirus(rawFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, import cancelled.');
-      }
 
       // Critter CSV import strategy - child of CSVImportStrategy
       const importCsvCritters = new ImportCrittersStrategy(connection, surveyId);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/markings/import.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/markings/import.ts
@@ -2,12 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
-import { HTTP400 } from '../../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
 import { importCSV } from '../../../../../../../services/import-services/import-csv';
 import { ImportMarkingsStrategy } from '../../../../../../../services/import-services/marking/import-markings-strategy';
-import { scanFileForVirus } from '../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../utils/logger';
 import { parseMulterFile } from '../../../../../../../utils/media/media-utils';
 import { getFileFromRequest } from '../../../../../../../utils/request';
@@ -134,13 +132,6 @@ export function importCsv(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Check for viruses / malware
-      const virusScanResult = await scanFileForVirus(rawFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, import cancelled.');
-      }
 
       const importCsvMarkingsStrategy = new ImportMarkingsStrategy(connection, surveyId);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/measurements/import.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/measurements/import.ts
@@ -2,12 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
-import { HTTP400 } from '../../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
 import { importCSV } from '../../../../../../../services/import-services/import-csv';
 import { ImportMeasurementsStrategy } from '../../../../../../../services/import-services/measurement/import-measurements-strategy';
-import { scanFileForVirus } from '../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../utils/logger';
 import { parseMulterFile } from '../../../../../../../utils/media/media-utils';
 import { getFileFromRequest } from '../../../../../../../utils/request';
@@ -134,13 +132,6 @@ export function importCsv(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Check for viruses / malware
-      const virusScanResult = await scanFileForVirus(rawFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, import cancelled.');
-      }
 
       const importCsvMeasurementsStrategy = new ImportMeasurementsStrategy(connection, surveyId);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.test.ts
@@ -36,25 +36,6 @@ describe('uploadMedia', () => {
     body: {}
   } as any;
 
-  it('should throw an error when file has malicious content', async () => {
-    sinon.stub(db, 'getDBConnection').returns({
-      ...dbConnectionObj,
-      systemUserId: () => {
-        return 20;
-      }
-    });
-
-    try {
-      const result = upload.uploadMedia();
-
-      await result(mockReq, null as unknown as any, null as unknown as any);
-      expect.fail();
-    } catch (actualError) {
-      expect((actualError as HTTPError).status).to.equal(400);
-      expect((actualError as HTTPError).message).to.equal('Malicious content detected, upload cancelled');
-    }
-  });
-
   it('should throw an error if failure occurs', async () => {
     sinon.stub(db, 'getDBConnection').returns({
       ...dbConnectionObj,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.test.ts
@@ -44,8 +44,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(false);
-
     try {
       const result = upload.uploadMedia();
 
@@ -64,8 +62,6 @@ describe('uploadMedia', () => {
         return 20;
       }
     });
-
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
 
     const expectedError = new Error('cannot process request');
     sinon.stub(ObservationService.prototype, 'insertSurveyObservationSubmission').rejects(expectedError);
@@ -88,7 +84,6 @@ describe('uploadMedia', () => {
       }
     });
 
-    sinon.stub(file_utils, 'scanFileForVirus').resolves(true);
     sinon.stub(file_utils, 'uploadFileToS3').resolves();
 
     const expectedResponse = { submissionId: 1 };

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/upload.ts
@@ -2,11 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../database/db';
-import { HTTP400 } from '../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
 import { ObservationService } from '../../../../../../services/observation-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../utils/logger';
 import { getFileFromRequest } from '../../../../../../utils/request';
 
@@ -120,13 +119,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       // Insert a new record in the `survey_observation_submission` table
       const observationService = new ObservationService(connection);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/upload.ts
@@ -2,11 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../database/db';
-import { HTTP400 } from '../../../../../../errors/http-error';
 import { csvFileSchema } from '../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
 import { TelemetryService } from '../../../../../../services/telemetry-service';
-import { scanFileForVirus, uploadFileToS3 } from '../../../../../../utils/file-utils';
+import { uploadFileToS3 } from '../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../utils/logger';
 import { getFileFromRequest } from '../../../../../../utils/request';
 
@@ -119,13 +118,6 @@ export function uploadMedia(): RequestHandler {
 
     try {
       await connection.open();
-
-      // Scan file for viruses using ClamAV
-      const virusScanResult = await scanFileForVirus(rawMediaFile);
-
-      if (!virusScanResult) {
-        throw new HTTP400('Malicious content detected, upload cancelled');
-      }
 
       // Insert a new record in the `survey_telemetry_submission` table
       const service = new TelemetryService(connection);


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Move the virus scan step into the app.ts file, so that it doesn't need to be included in every endpoint that handles file uploads.

## Testing Notes

Uploading/Downloading files works as before.

Can use this string (paste into a random txt file) to trigger our APIs file upload virus scans: https://en.wikipedia.org/wiki/EICAR_test_file

I've tested a few places we upload files, and they work as expected. Every file upload goes through the same field and should be handled by the same multer middleware anyways, so if one works they should all work.