### PR TITLE
BugFix: Remove Duplicate Environment Columns in Observations Table

### DIFF
--- a/api/src/repositories/observation-subcount-environment-repository.ts
+++ b/api/src/repositories/observation-subcount-environment-repository.ts
@@ -285,7 +285,7 @@ export class ObservationSubCountEnvironmentRepository extends BaseRepository {
     surveyId: number
   ): Promise<QuantitativeEnvironmentTypeDefinition[]> {
     const sqlStatement = SQL`
-      SELECT
+      SELECT DISTINCT
         environment_quantitative.environment_quantitative_id,
         environment_quantitative.name,
         environment_quantitative.description,


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-624

## Description of Changes

- Changed SELECT to SELECT DISTINCT when retrieving quantitative environment definitions
- Fixes a bug where if a quantitative environment value is given for 2 or more records while editing, that environment variable's column gets duplicated in the observations table

## Testing Notes

- When editing 2 rows and adding a quantitative environment value to both (eg. setting air temperature for both records), the modified measurement's column should not be duplicated
