### PR TITLE
BugFix: Bad Deployments Bandaid

### DIFF
--- a/api/.pipeline/config.js
+++ b/api/.pipeline/config.js
@@ -218,7 +218,7 @@ const phases = {
     s3KeyPrefix: 'sims',
     tz: config.timezone.api,
     sso: config.sso.prod,
-    featureFlags: 'API_FF_SUBMIT_BIOHUB',
+    featureFlags: 'API_FF_SUBMIT_BIOHUB,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK',
     logLevel: 'silent',
     logLevelFile: 'debug',
     logFileDir: 'data/logs',

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/delete.ts
@@ -133,6 +133,8 @@ export function deleteDeploymentsInSurvey(): RequestHandler {
 
       await Promise.all(deletePromises);
 
+      await connection.commit();
+
       return res.status(200).send();
     } catch (error) {
       defaultLog.error({ label: 'deleteDeploymentsInSurvey', message: 'error', error });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.ts
@@ -153,8 +153,9 @@ export function getDeploymentsInSurvey(): RequestHandler {
           (deployment) => deployment.deployment_id === surveyDeployment.bctw_deployment_id
         );
 
-        // If the feature flag exists: we allow multiple active deployments to exist for the same deployment ID.
-        if (!isFeatureFlagPresent(['API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS'])) {
+        // TODO: If the feature flag exists, then we allow multiple active deployments to exist for the same deployment
+        // ID (when normally we would return a bad deployment).
+        if (!isFeatureFlagPresent(['API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK'])) {
           if (matchingBctwDeployments.length > 1) {
             defaultLog.warn({
               label: 'getDeploymentById',

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.ts
@@ -9,6 +9,7 @@ import { authorizeRequestHandler } from '../../../../../../request-handlers/secu
 import { BctwDeploymentService } from '../../../../../../services/bctw-service/bctw-deployment-service';
 import { ICritterbaseUser } from '../../../../../../services/critterbase-service';
 import { DeploymentService } from '../../../../../../services/deployment-service';
+import { isFeatureFlagPresent } from '../../../../../../utils/feature-flag-utils';
 import { getLogger } from '../../../../../../utils/logger';
 
 const defaultLog = getLogger('paths/project/{projectId}/survey/{surveyId}/deployments/index');
@@ -152,25 +153,26 @@ export function getDeploymentsInSurvey(): RequestHandler {
           (deployment) => deployment.deployment_id === surveyDeployment.bctw_deployment_id
         );
 
-        if (matchingBctwDeployments.length > 1) {
-          defaultLog.warn({
-            label: 'getDeploymentById',
-            message: 'Multiple active deployments found for the same deployment ID, when only one should exist.',
-            sims_deployment_id: surveyDeployment.deployment_id,
-            bctw_deployment_id: surveyDeployment.bctw_deployment_id
-          });
-
-          badDeployments.push({
-            name: 'BCTW Data Error',
-            message: 'Multiple active deployments found for the same deployment ID, when only one should exist.',
-            data: {
+        // If the feature flag exists: we allow multiple active deployments to exist for the same deployment ID.
+        if (!isFeatureFlagPresent(['API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS'])) {
+          if (matchingBctwDeployments.length > 1) {
+            defaultLog.warn({
+              label: 'getDeploymentById',
+              message: 'Multiple active deployments found for the same deployment ID, when only one should exist.',
               sims_deployment_id: surveyDeployment.deployment_id,
               bctw_deployment_id: surveyDeployment.bctw_deployment_id
-            }
-          });
-
-          // Don't continue processing this deployment
-          continue;
+            });
+            badDeployments.push({
+              name: 'BCTW Data Error',
+              message: 'Multiple active deployments found for the same deployment ID, when only one should exist.',
+              data: {
+                sims_deployment_id: surveyDeployment.deployment_id,
+                bctw_deployment_id: surveyDeployment.bctw_deployment_id
+              }
+            });
+            // Don't continue processing this deployment
+            continue;
+          }
         }
 
         if (matchingBctwDeployments.length === 0) {

--- a/app/.pipeline/config.js
+++ b/app/.pipeline/config.js
@@ -164,7 +164,8 @@ const phases = {
     maxUploadFileSize,
     nodeEnv: 'production',
     sso: config.sso.prod,
-    featureFlags: 'APP_FF_SUBMIT_BIOHUB',
+    featureFlags:
+      'APP_FF_SUBMIT_BIOHUB,APP_FF_DISABLE_BAD_DEPLOYMENT_DELETE,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK',
     cpuRequest: '50m',
     cpuLimit: '1000m',
     memoryRequest: '100Mi',

--- a/app/.pipeline/config.js
+++ b/app/.pipeline/config.js
@@ -164,8 +164,7 @@ const phases = {
     maxUploadFileSize,
     nodeEnv: 'production',
     sso: config.sso.prod,
-    featureFlags:
-      'APP_FF_SUBMIT_BIOHUB,APP_FF_DISABLE_BAD_DEPLOYMENT_DELETE,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK',
+    featureFlags: 'APP_FF_SUBMIT_BIOHUB,APP_FF_DISABLE_BAD_DEPLOYMENT_DELETE',
     cpuRequest: '50m',
     cpuLimit: '1000m',
     memoryRequest: '100Mi',

--- a/app/src/features/surveys/telemetry/list/SurveyBadDeploymentListItem.tsx
+++ b/app/src/features/surveys/telemetry/list/SurveyBadDeploymentListItem.tsx
@@ -71,11 +71,13 @@ export const SurveyBadDeploymentListItem = (props: ISurveyBadDeploymentListItemP
             <Checkbox
               edge="start"
               checked={isChecked}
+              // TODO: This is disabled as a temporary bug fix to prevent deployment data from being deleted
+              disabled
               sx={{ py: 0 }}
-              onClick={(event) => {
-                event.stopPropagation();
-                handleCheckboxChange(data.data.sims_deployment_id);
-              }}
+              // onClick={(event) => {
+              //   event.stopPropagation();
+              //   handleCheckboxChange(data.data.sims_deployment_id);
+              // }}
               inputProps={{ 'aria-label': 'controlled' }}
             />
             <Box>
@@ -103,7 +105,11 @@ export const SurveyBadDeploymentListItem = (props: ISurveyBadDeploymentListItemP
         <IconButton
           sx={{ position: 'absolute', right: '24px' }}
           edge="end"
-          onClick={() => handleDelete(data.data.sims_deployment_id as number)}
+          // TODO: This delete is commented out as a temporary bug fix to prevent deployment data from being deleted
+          // onClick={
+          //   () => {
+          //   handleDelete(data.data.sims_deployment_id as number)}
+          // }
           aria-label="deployment-settings">
           <Icon path={mdiTrashCanOutline} size={1}></Icon>
         </IconButton>

--- a/app/src/features/surveys/telemetry/list/SurveyBadDeploymentListItem.tsx
+++ b/app/src/features/surveys/telemetry/list/SurveyBadDeploymentListItem.tsx
@@ -10,6 +10,7 @@ import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { FeatureFlagGuard } from 'components/security/Guards';
 import { WarningSchema } from 'interfaces/useBioHubApi.interface';
 
 export interface ISurveyBadDeploymentListItemProps {
@@ -68,18 +69,28 @@ export const SurveyBadDeploymentListItem = (props: ISurveyBadDeploymentListItemP
               pr: 2,
               overflow: 'hidden'
             }}>
-            <Checkbox
-              edge="start"
-              checked={isChecked}
-              // TODO: This is disabled as a temporary bug fix to prevent deployment data from being deleted
-              disabled
-              sx={{ py: 0 }}
-              // onClick={(event) => {
-              //   event.stopPropagation();
-              //   handleCheckboxChange(data.data.sims_deployment_id);
-              // }}
-              inputProps={{ 'aria-label': 'controlled' }}
-            />
+            {/* TODO: This delete is commented out as a temporary bug fix to prevent deployment data from being deleted */}
+            <FeatureFlagGuard
+              featureFlags={['APP_FF_DISABLE_BAD_DEPLOYMENT_DELETE']}
+              fallback={
+                <Checkbox
+                  edge="start"
+                  checked={isChecked}
+                  sx={{ py: 0, visibility: 'hidden' }}
+                  inputProps={{ 'aria-label': 'controlled' }}
+                />
+              }>
+              <Checkbox
+                edge="start"
+                checked={isChecked}
+                sx={{ py: 0 }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleCheckboxChange(data.data.sims_deployment_id);
+                }}
+                inputProps={{ 'aria-label': 'controlled' }}
+              />
+            </FeatureFlagGuard>
             <Box>
               <Stack gap={1} direction="row">
                 <Typography
@@ -102,17 +113,16 @@ export const SurveyBadDeploymentListItem = (props: ISurveyBadDeploymentListItemP
             </Box>
           </Stack>
         </AccordionSummary>
-        <IconButton
-          sx={{ position: 'absolute', right: '24px' }}
-          edge="end"
-          // TODO: This delete is commented out as a temporary bug fix to prevent deployment data from being deleted
-          // onClick={
-          //   () => {
-          //   handleDelete(data.data.sims_deployment_id as number)}
-          // }
-          aria-label="deployment-settings">
-          <Icon path={mdiTrashCanOutline} size={1}></Icon>
-        </IconButton>
+        {/* TODO: This delete is commented out as a temporary bug fix to prevent deployment data from being deleted */}
+        <FeatureFlagGuard featureFlags={['APP_FF_DISABLE_BAD_DEPLOYMENT_DELETE']}>
+          <IconButton
+            sx={{ position: 'absolute', right: '24px' }}
+            edge="end"
+            onClick={() => handleDelete(data.data.sims_deployment_id as number)}
+            aria-label="deployment-settings">
+            <Icon path={mdiTrashCanOutline} size={1}></Icon>
+          </IconButton>
+        </FeatureFlagGuard>
       </Box>
       <AccordionDetails sx={{ mt: 0, pt: 0 }}>
         <List

--- a/app/src/features/surveys/telemetry/list/SurveyDeploymentList.tsx
+++ b/app/src/features/surveys/telemetry/list/SurveyDeploymentList.tsx
@@ -15,6 +15,7 @@ import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import AlertBar from 'components/alert/AlertBar';
 import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { SkeletonList } from 'components/loading/SkeletonLoaders';
 import { SurveyBadDeploymentListItem } from 'features/surveys/telemetry/list/SurveyBadDeploymentListItem';
@@ -391,10 +392,11 @@ export const SurveyDeploymentList = (props: ISurveyDeploymentListProps) => {
 
                             // Select all
                             const deploymentIds = deployments.map((deployment) => deployment.deployment_id);
-                            const badDeploymentIds = badDeployments.map(
-                              (deployment) => deployment.data.sims_deployment_id
-                            );
-                            setCheckboxSelectedIds([...badDeploymentIds, ...deploymentIds]);
+                            // const badDeploymentIds = badDeployments.map(
+                            //   (deployment) => deployment.data.sims_deployment_id
+                            // );
+                            // TODO: Temporary bug fix - prevent bad deployment ids from being selected and deleted
+                            setCheckboxSelectedIds([...deploymentIds]);
                           }}
                           inputProps={{ 'aria-label': 'controlled' }}
                         />
@@ -408,6 +410,12 @@ export const SurveyDeploymentList = (props: ISurveyDeploymentListProps) => {
                   sx={{
                     background: grey[100]
                   }}>
+                  <AlertBar
+                    severity="error"
+                    text="We're fixing a bug preventing deployments from loading. Please check back later."
+                    title="There's a Bug!"
+                    variant="standard"
+                  />
                   {badDeployments.map((badDeployment) => {
                     return (
                       <SurveyBadDeploymentListItem


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Add feature flag guards to temporarily disable some of the bad deployment logic.
- Don't return a bad deployment when multiple are found in bctw (return the 0th item)
- Don't render the delete or checkbox actions in the bad deployment card on the frontend
- Add a banner to tell the users about the ongoing issue, pending a fix.

## Testing Notes

Deployments work as above.
