### PR TITLE
SIMSBIOHUB-627: Manual Telemetry Endpoints

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as db from '../../../../../../../../database/db';
+import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
+import { bulkDeleteManualTelemetry } from './delete';
+
+describe('telemetry/manual/delete', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('bulkDeleteManualTelemetry', () => {
+    it('should return status 200', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        release: sinon.stub(),
+        open: sinon.stub(),
+        rollback: sinon.stub()
+      });
+
+      sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+      const serviceStub = sinon.stub(TelemetryVendorService.prototype, 'bulkDeleteManualTelemetry');
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.params = {
+        projectId: '1',
+        surveyId: '2'
+      };
+
+      mockReq.body = {
+        telemetry_manual_ids: ['uuid1', 'uuid2']
+      };
+
+      const requestHandler = bulkDeleteManualTelemetry();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+
+      expect(serviceStub).to.have.been.calledOnceWithExactly(2, ['uuid1', 'uuid2']);
+
+      expect(mockRes.status).calledOnceWithExactly(200);
+      expect(mockRes.send).calledOnceWithExactly();
+
+      expect(mockDBConnection.commit).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+
+      expect(mockDBConnection.rollback).to.not.have.been.called;
+    });
+  });
+});

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete.ts
@@ -1,0 +1,142 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../../../database/db';
+import { authorizeRequestHandler } from '../../../../../../../../request-handlers/security/authorization';
+import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
+import { getLogger } from '../../../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete');
+
+export const POST: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      or: [
+        {
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
+          discriminator: 'ProjectPermission'
+        },
+        {
+          validSystemRoles: [SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  bulkDeleteManualTelemetry()
+];
+
+POST.apiDoc = {
+  description: 'Bulk delete manual telemetry records.',
+  tags: ['telemetry'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  parameters: [
+    {
+      in: 'path',
+      name: 'projectId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    },
+    {
+      in: 'path',
+      name: 'surveyId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    }
+  ],
+  requestBody: {
+    description: 'Manual telemetry bulk delete payload.',
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['telemetry_manual_ids'],
+          properties: {
+            telemetry_manual_ids: {
+              type: 'array',
+              items: {
+                type: 'string',
+                format: 'uuid'
+              },
+              minItems: 1
+            }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Responds successfully if the telemetry records were deleted.'
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    409: {
+      $ref: '#/components/responses/409'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Bulk delete manual telemetry records.
+ *
+ * @export
+ * @return {*} {RequestHandler}
+ */
+export function bulkDeleteManualTelemetry(): RequestHandler {
+  return async (req, res) => {
+    const surveyId = Number(req.params.surveyId);
+    const telemetryManualIds: string[] = req.body.telemetry_manual_ids;
+
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const telemetryVendorService = new TelemetryVendorService(connection);
+
+      await telemetryVendorService.bulkDeleteManualTelemetry(surveyId, telemetryManualIds);
+
+      await connection.commit();
+
+      return res.status(200).send();
+    } catch (error) {
+      defaultLog.error({ label: 'bulkDeleteManualTelemetry', message: 'error', error });
+      await connection.rollback();
+
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.test.ts
@@ -5,7 +5,7 @@ import * as db from '../../../../../../../../database/db';
 import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
 
-describe.only('getTelemetryForDeployments', () => {
+describe('telemetry/manual/index', () => {
   afterEach(() => {
     sinon.restore();
   });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.test.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { bulkCreateManualTelemetry, bulkUpdateManualTelemetry } from '.';
+import * as db from '../../../../../../../../database/db';
+import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
+
+describe.only('getTelemetryForDeployments', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('bulkCreateManualTelemetry', () => {
+    it('should return status 200', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        release: sinon.stub(),
+        open: sinon.stub(),
+        rollback: sinon.stub()
+      });
+
+      sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+      const serviceStub = sinon.stub(TelemetryVendorService.prototype, 'bulkCreateManualTelemetry');
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      const mockTelemetry = [
+        {
+          deployment2_id: 1,
+          latitude: 1,
+          longitude: 1,
+          acquisition_date: '2021-01-01',
+          transmission_date: '2021-01-01'
+        }
+      ];
+
+      mockReq.params = {
+        projectId: '1',
+        surveyId: '2'
+      };
+
+      mockReq.body = {
+        telemetry: mockTelemetry
+      };
+
+      const requestHandler = bulkCreateManualTelemetry();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+
+      expect(serviceStub).to.have.been.calledOnceWithExactly(2, mockTelemetry);
+
+      expect(mockRes.status).calledOnceWithExactly(201);
+      expect(mockRes.send).calledOnceWithExactly();
+
+      expect(mockDBConnection.commit).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+
+      expect(mockDBConnection.rollback).to.not.have.been.called;
+    });
+  });
+
+  describe('bulkUpdateManualTelemetry', () => {
+    {
+      it('should return status 200', async () => {
+        const mockDBConnection = getMockDBConnection({
+          commit: sinon.stub(),
+          release: sinon.stub(),
+          open: sinon.stub(),
+          rollback: sinon.stub()
+        });
+
+        sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+        const serviceStub = sinon.stub(TelemetryVendorService.prototype, 'bulkUpdateManualTelemetry');
+
+        const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+        const mockTelemetry = [
+          {
+            telemetry_manual_id: 'uuid',
+            latitude: 1,
+            longitude: 1,
+            acquisition_date: '2021-01-01',
+            transmission_date: '2021-01-01'
+          }
+        ];
+
+        mockReq.params = {
+          projectId: '1',
+          surveyId: '2'
+        };
+
+        mockReq.body = {
+          telemetry: mockTelemetry
+        };
+
+        const requestHandler = bulkUpdateManualTelemetry();
+
+        await requestHandler(mockReq, mockRes, mockNext);
+
+        expect(mockDBConnection.open).to.have.been.calledOnce;
+
+        expect(serviceStub).to.have.been.calledOnceWithExactly(2, mockTelemetry);
+
+        expect(mockRes.status).calledOnceWithExactly(200);
+        expect(mockRes.send).calledOnceWithExactly();
+
+        expect(mockDBConnection.commit).to.have.been.calledOnce;
+        expect(mockDBConnection.release).to.have.been.calledOnce;
+
+        expect(mockDBConnection.rollback).to.not.have.been.called;
+      });
+    }
+  });
+});

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.ts
@@ -1,11 +1,9 @@
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../../constants/roles';
+import { TelemetryManualRecord } from '../../../../../../../../database-models/telemetry_manual';
 import { getDBConnection } from '../../../../../../../../database/db';
-import {
-  CreateManualTelemetry,
-  UpdateManualTelemetry
-} from '../../../../../../../../repositories/telemetry-repositories/telemetry-manual-repository.interface';
+import { CreateManualTelemetry } from '../../../../../../../../repositories/telemetry-repositories/telemetry-manual-repository.interface';
 import { authorizeRequestHandler } from '../../../../../../../../request-handlers/security/authorization';
 import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
 import { getLogger } from '../../../../../../../../utils/logger';
@@ -192,7 +190,7 @@ export const PUT: Operation = [
   bulkUpdateManualTelemetry()
 ];
 
-POST.apiDoc = {
+PUT.apiDoc = {
   description: 'Bulk update manual telemetry records.',
   tags: ['telemetry'],
   security: [
@@ -235,11 +233,22 @@ POST.apiDoc = {
               items: {
                 type: 'object',
                 additionalProperties: false,
-                required: ['latitude', 'longitude', 'acquisition_date', 'transmission_date'],
+                required: [
+                  'telemetry_manual_id',
+                  'deployment2_id',
+                  'latitude',
+                  'longitude',
+                  'acquisition_date',
+                  'transmission_date'
+                ],
                 properties: {
                   telemetry_manual_id: {
                     type: 'string',
                     format: 'uuid'
+                  },
+                  deployment2_id: {
+                    type: 'integer',
+                    minimum: 1
                   },
                   latitude: {
                     type: 'number',
@@ -301,7 +310,7 @@ POST.apiDoc = {
 export function bulkUpdateManualTelemetry(): RequestHandler {
   return async (req, res) => {
     const surveyId = Number(req.params.surveyId);
-    const telemetry: UpdateManualTelemetry[] = req.body.telemetry;
+    const telemetry: TelemetryManualRecord[] = req.body.telemetry;
 
     const connection = getDBConnection(req.keycloak_token);
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index.ts
@@ -1,0 +1,327 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../../../database/db';
+import {
+  CreateManualTelemetry,
+  UpdateManualTelemetry
+} from '../../../../../../../../repositories/telemetry-repositories/telemetry-manual-repository.interface';
+import { authorizeRequestHandler } from '../../../../../../../../request-handlers/security/authorization';
+import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
+import { getLogger } from '../../../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/index');
+
+export const POST: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      or: [
+        {
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
+          discriminator: 'ProjectPermission'
+        },
+        {
+          validSystemRoles: [SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  bulkCreateManualTelemetry()
+];
+
+POST.apiDoc = {
+  description: 'Bulk create manual telemetry records.',
+  tags: ['telemetry'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  parameters: [
+    {
+      in: 'path',
+      name: 'projectId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    },
+    {
+      in: 'path',
+      name: 'surveyId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    }
+  ],
+  requestBody: {
+    description: 'Manual telemetry bulk create payload.',
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['telemetry'],
+          properties: {
+            telemetry: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['deployment2_id', 'latitude', 'longitude', 'acquisition_date', 'transmission_date'],
+                properties: {
+                  deployment2_id: {
+                    type: 'integer',
+                    minimum: 1
+                  },
+                  latitude: {
+                    type: 'number',
+                    minimum: -90,
+                    maximum: 90
+                  },
+                  longitude: {
+                    type: 'number',
+                    minimum: -180,
+                    maximum: 180
+                  },
+                  acquisition_date: {
+                    type: 'string'
+                  },
+                  transmission_date: {
+                    type: 'string',
+                    nullable: true
+                  }
+                }
+              },
+              minItems: 1
+            }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Responds successfully if the telemetry records were created.'
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    409: {
+      $ref: '#/components/responses/409'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Bulk create manual telemetry records.
+ *
+ * @export
+ * @return {*} {RequestHandler}
+ */
+export function bulkCreateManualTelemetry(): RequestHandler {
+  return async (req, res) => {
+    const surveyId = Number(req.params.surveyId);
+    const telemetry: CreateManualTelemetry[] = req.body.telemetry;
+
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const telemetryVendorService = new TelemetryVendorService(connection);
+
+      await telemetryVendorService.bulkCreateManualTelemetry(surveyId, telemetry);
+
+      await connection.commit();
+
+      return res.status(201).send();
+    } catch (error) {
+      defaultLog.error({ label: 'bulkCreateManualTelemetry', message: 'error', error });
+      await connection.rollback();
+
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const PUT: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      or: [
+        {
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
+          discriminator: 'ProjectPermission'
+        },
+        {
+          validSystemRoles: [SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  bulkUpdateManualTelemetry()
+];
+
+POST.apiDoc = {
+  description: 'Bulk update manual telemetry records.',
+  tags: ['telemetry'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  parameters: [
+    {
+      in: 'path',
+      name: 'projectId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    },
+    {
+      in: 'path',
+      name: 'surveyId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    }
+  ],
+  requestBody: {
+    description: 'Manual telemetry bulk create payload.',
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['telemetry'],
+          properties: {
+            telemetry: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['latitude', 'longitude', 'acquisition_date', 'transmission_date'],
+                properties: {
+                  telemetry_manual_id: {
+                    type: 'string',
+                    format: 'uuid'
+                  },
+                  latitude: {
+                    type: 'number',
+                    minimum: -90,
+                    maximum: 90
+                  },
+                  longitude: {
+                    type: 'number',
+                    minimum: -180,
+                    maximum: 180
+                  },
+                  acquisition_date: {
+                    type: 'string'
+                  },
+                  transmission_date: {
+                    type: 'string',
+                    nullable: true
+                  }
+                }
+              },
+              minItems: 1
+            }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Responds successfully if the telemetry records were updated.'
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    409: {
+      $ref: '#/components/responses/409'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Bulk update manual telemetry records.
+ *
+ * @export
+ * @return {*} {RequestHandler}
+ */
+export function bulkUpdateManualTelemetry(): RequestHandler {
+  return async (req, res) => {
+    const surveyId = Number(req.params.surveyId);
+    const telemetry: UpdateManualTelemetry[] = req.body.telemetry;
+
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const telemetryVendorService = new TelemetryVendorService(connection);
+
+      await telemetryVendorService.bulkUpdateManualTelemetry(surveyId, telemetry);
+
+      await connection.commit();
+
+      return res.status(200).send();
+    } catch (error) {
+      defaultLog.error({ label: 'bulkUpdateManualTelemetry', message: 'error', error });
+      await connection.rollback();
+
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/repositories/telemetry-repositories/telemetry-manual-repository.interface.ts
+++ b/api/src/repositories/telemetry-repositories/telemetry-manual-repository.interface.ts
@@ -8,9 +8,3 @@ export type CreateManualTelemetry = Pick<
   TelemetryManualRecord,
   'deployment2_id' | 'latitude' | 'longitude' | 'acquisition_date' | 'transmission_date'
 >;
-
-/**
- * Interface reflecting the telemetry manual data required to update an existing manual telemetry record.
- *
- */
-export type UpdateManualTelemetry = Omit<TelemetryManualRecord, 'deployment2_id'>;

--- a/api/src/repositories/telemetry-repositories/telemetry-manual-repository.ts
+++ b/api/src/repositories/telemetry-repositories/telemetry-manual-repository.ts
@@ -2,7 +2,7 @@ import { TelemetryManualRecord } from '../../database-models/telemetry_manual';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { BaseRepository } from '../base-repository';
-import { CreateManualTelemetry, UpdateManualTelemetry } from './telemetry-manual-repository.interface';
+import { CreateManualTelemetry } from './telemetry-manual-repository.interface';
 
 /**
  * A repository class for working with Manual telemetry data.
@@ -61,16 +61,17 @@ export class TelemetryManualRepository extends BaseRepository {
    *
    * Note: Deployment IDs need to be pre-validated against the survey ID in the service.
    *
-   * @param {UpdateManualTelemetry[]} telemetry - List of Manual telemetry data to update
+   * @param {TelemetryManualRecord[]} telemetry - List of Manual telemetry data to update
    * @returns {Promise<void>}
    */
-  async bulkUpdateManualTelemetry(telemetry: UpdateManualTelemetry[]): Promise<void> {
+  async bulkUpdateManualTelemetry(telemetry: TelemetryManualRecord[]): Promise<void> {
     const knex = getKnex();
 
     const queryBuilder = knex
       .insert(telemetry)
       .into('telemetry_manual')
       .onConflict('telemetry_manual_id')
+      // intentionally omitting the deployment_id
       .merge(['latitude', 'longitude', 'acquisition_date', 'transmission_date']);
 
     const response = await this.connection.knex(queryBuilder);

--- a/api/src/services/telemetry-services/telemetry-vendor-service.test.ts
+++ b/api/src/services/telemetry-services/telemetry-vendor-service.test.ts
@@ -152,6 +152,7 @@ describe('TelemetryVendorService', () => {
       await service.bulkUpdateManualTelemetry(1, [
         {
           telemetry_manual_id: '09556e24-153b-4dbb-add6-f00e74131e48',
+          deployment2_id: 1,
           latitude: 1,
           longitude: 1,
           acquisition_date: '2021-01-01',
@@ -163,6 +164,7 @@ describe('TelemetryVendorService', () => {
       expect(repoStub).to.have.been.calledWith([
         {
           telemetry_manual_id: '09556e24-153b-4dbb-add6-f00e74131e48',
+          deployment2_id: 1,
           latitude: 1,
           longitude: 1,
           acquisition_date: '2021-01-01',
@@ -181,6 +183,7 @@ describe('TelemetryVendorService', () => {
         await service.bulkUpdateManualTelemetry(1, [
           {
             telemetry_manual_id: '09556e24-153b-4dbb-add6-f00e74131e48',
+            deployment2_id: 1,
             latitude: 1,
             longitude: 1,
             acquisition_date: '2021-01-01',

--- a/api/src/services/telemetry-services/telemetry-vendor-service.ts
+++ b/api/src/services/telemetry-services/telemetry-vendor-service.ts
@@ -1,10 +1,8 @@
+import { TelemetryManualRecord } from '../../database-models/telemetry_manual';
 import { IDBConnection } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';
 import { TelemetryManualRepository } from '../../repositories/telemetry-repositories/telemetry-manual-repository';
-import {
-  CreateManualTelemetry,
-  UpdateManualTelemetry
-} from '../../repositories/telemetry-repositories/telemetry-manual-repository.interface';
+import { CreateManualTelemetry } from '../../repositories/telemetry-repositories/telemetry-manual-repository.interface';
 import { TelemetryVendorRepository } from '../../repositories/telemetry-repositories/telemetry-vendor-repository';
 import { Telemetry } from '../../repositories/telemetry-repositories/telemetry-vendor-repository.interface';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
@@ -129,12 +127,14 @@ export class TelemetryVendorService extends DBService {
   /**
    * Update manual telemetry records.
    *
+   * Note: Since this is a bulk update request, the payload must include all the properties to PUT.
+   *
    * @async
    * @param {number} surveyId
-   * @param {UpdateManualTelemetry[]} telemetry - List of manual telemetry data to update
+   * @param {TelemetryManualRecord[]} telemetry - List of manual telemetry data to update
    * @returns {Promise<void>}
    */
-  async bulkUpdateManualTelemetry(surveyId: number, telemetry: UpdateManualTelemetry[]): Promise<void> {
+  async bulkUpdateManualTelemetry(surveyId: number, telemetry: TelemetryManualRecord[]): Promise<void> {
     const telemetryManualIds = telemetry.map((record) => record.telemetry_manual_id);
     const manualTelemetry = await this.manualRepository.getManualTelemetryByIds(surveyId, telemetryManualIds);
 


### PR DESCRIPTION
## Notes
This is what I currently have for the new manual telemetry paths. Uncertain if they should be under `deployments2/` or up a level under `{surveyId}/`

createManualTelemetry: 
POST `api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual`

updateManualTelemetry:
PUT `api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual`

deleteManualTelemetry:
POST `api/src/paths/project/{projectId}/survey/{surveyId}/deployments2/telemetry/manual/delete`
