### PR TITLE
BugFix: Change Date Format from UTC to Local Time in combineDatetime

### DIFF
--- a/app/src/utils/datetime.test.ts
+++ b/app/src/utils/datetime.test.ts
@@ -3,17 +3,17 @@ import { combineDateTime, formatTimeDifference } from './datetime';
 describe('combineDateTime', () => {
   it('combines date and time into an ISO string', () => {
     const result = combineDateTime('2024-01-01', '12:30:00');
-    expect(result).toEqual('2024-01-01T12:30:00.000Z');
+    expect(result).toEqual('2024-01-01T12:30:00');
   });
 
   it('combines date without time into an ISO string', () => {
     const result = combineDateTime('2024-01-01');
-    expect(result).toEqual('2024-01-01T00:00:00.000Z');
+    expect(result).toEqual('2024-01-01T00:00:00');
   });
 
   it('returns ISO string for a different date and time', () => {
     const result = combineDateTime('2023-12-31', '23:59:59');
-    expect(result).toEqual('2023-12-31T23:59:59.000Z');
+    expect(result).toEqual('2023-12-31T23:59:59');
   });
 
   it('handles invalid date formats gracefully', () => {

--- a/app/src/utils/datetime.ts
+++ b/app/src/utils/datetime.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import duration, { DurationUnitType } from 'dayjs/plugin/duration';
 import { pluralize } from './Utils';
 
-const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 dayjs.extend(duration);
 


### PR DESCRIPTION
## Links to Jira Tickets

- {Include a link to all applicable Jira tickets}

## Description of Changes

- The combineDatetime function is only used to combine local date and times, but the format string was treating the local date and time as UTC, yielding incorrect outputs
- Removed the ```[Z]``` from the end of the format string

## Testing Notes

- When creating an animal capture/mortality event, the displayed date and time should match the event's true date and time (the API responds with local time so the timestamp in the API response should be what is shown on the capture/mortality card)
