### PR TITLE
BugFix: Allow Geojson of Survey Blocks to be Null

### DIFF
--- a/api/src/openapi/schemas/survey.ts
+++ b/api/src/openapi/schemas/survey.ts
@@ -507,7 +507,8 @@ export const surveyBlockSchema: OpenAPIV3.SchemaObject = {
     },
     geojson: {
       description: 'Geojson',
-      type: 'object'
+      type: 'object',
+      nullable: true
     },
     sample_block_count: {
       description: 'Sample block count',

--- a/api/src/repositories/survey-block-repository.ts
+++ b/api/src/repositories/survey-block-repository.ts
@@ -19,7 +19,7 @@ export const SurveyBlockRecord = z.object({
   survey_id: z.number(),
   name: z.string(),
   description: z.string(),
-  geojson: z.any(),
+  geojson: z.any().nullable(),
   revision_count: z.number()
 });
 export type SurveyBlockRecord = z.infer<typeof SurveyBlockRecord>;

--- a/app/src/interfaces/useSurveyApi.interface.ts
+++ b/app/src/interfaces/useSurveyApi.interface.ts
@@ -140,7 +140,7 @@ export interface IGetSurveyBlock {
   name: string;
   description: string;
   revision_count: number;
-  geojson: Feature;
+  geojson: Feature | null;
   sample_block_count: number;
 }
 

--- a/database/src/seeds/03_basic_project_survey_setup.ts
+++ b/database/src/seeds/03_basic_project_survey_setup.ts
@@ -92,6 +92,7 @@ export async function seed(knex: Knex): Promise<void> {
           ${insertMethodTechnique(surveyId)}
           ${insertSurveySamplingMethodData(surveyId)}
           ${insertSurveySamplePeriodData(surveyId)}
+          ${insertSurveyBlockData(surveyId)}
         `);
 
         // Insert regions into surveys
@@ -178,6 +179,19 @@ const insertSurveyParticipationData = (surveyId: number) => `
         ), 1)
       ),
       (SELECT survey_job_id FROM survey_job LIMIT 1)
+    )
+  ;
+`;
+
+const insertSurveyBlockData = (surveyId: number) => `
+  INSERT into survey_block
+    ( survey_id, name, description, geojson )
+  VALUES
+    (
+      ${surveyId},
+      '${faker.lorem.words(2)}',
+      '${faker.lorem.words(10)}',
+      NULL
     )
   ;
 `;


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Updates OpenAPI schema to let the geojson property of a survey block to be null
- Adds blocks to the seed data
- This fixes the bug causing the {surveyId}/view endpoint to fail in dev
