### PR TITLE
TechDebt: CSV Row Validation With Row State

### DIFF
--- a/api/src/services/import-services/critter/critter-header-configs.test.ts
+++ b/api/src/services/import-services/critter/critter-header-configs.test.ts
@@ -7,7 +7,6 @@ import {
   getCritterAliasCellValidator,
   getCritterCollectionUnitCellSetter,
   getCritterCollectionUnitCellValidator,
-  getCritterSexCellSetter,
   getCritterSexCellValidator,
   getWlhIDCellValidator
 } from './critter-header-configs';
@@ -336,30 +335,6 @@ describe('critter-header-configs', () => {
       });
 
       expect(result[0].error).to.be.equal('Sex cell value is invalid');
-    });
-  });
-
-  describe('getCritterSexCellSetter', () => {
-    it('should return the uuid', () => {
-      const nestedRecord = new NestedRecord({
-        1: {
-          male: 'uuid'
-        }
-      });
-      const cellSetter = getCritterSexCellSetter(
-        nestedRecord,
-        new CSVConfigUtils(xlsx.utils.json_to_sheet([]), mockConfig)
-      );
-
-      const result = cellSetter({
-        cell: 'MALE',
-        row: { ITIS_TSN: 1 },
-        header: 'HEADER',
-        rowIndex: 0,
-        mutateCell: 'MALE'
-      });
-
-      expect(result).to.be.equal('uuid');
     });
   });
 

--- a/api/src/services/import-services/critter/critter-header-configs.ts
+++ b/api/src/services/import-services/critter/critter-header-configs.ts
@@ -4,10 +4,9 @@ import {
   CSVCellSetter,
   CSVCellValidator,
   CSVError,
-  CSVParams,
-  CSVRowState
+  CSVParams
 } from '../../../utils/csv-utils/csv-config-validation.interface';
-import { validateZodCell } from '../../../utils/csv-utils/csv-header-configs';
+import { updateCSVRowState, validateZodCell } from '../../../utils/csv-utils/csv-header-configs';
 import { NestedRecord } from '../../../utils/nested-record';
 import { CritterCSVStaticHeader } from './import-critters-service';
 
@@ -195,9 +194,7 @@ export const getCritterSexCellValidator = (
     }
 
     // Set the row state to store the qualitative option id for the sex
-    params.row[CSVRowState] = {
-      sexId: rowDictionarySex
-    };
+    updateCSVRowState(params.row, { sexId: rowDictionarySex });
 
     return [];
   };

--- a/api/src/services/import-services/critter/critter-header-configs.ts
+++ b/api/src/services/import-services/critter/critter-header-configs.ts
@@ -203,21 +203,6 @@ export const getCritterSexCellValidator = (
   };
 };
 
-///**
-// * Get the critter sex cell setter.
-// *
-// * @returns {*} {CSVCellValidator} The validate cell callback
-// */
-//export const getCritterSexCellSetter = (): CSVCellSetter => {
-//  return (params: CSVParams) => {
-//    if (params.cell === undefined) {
-//      return undefined;
-//    }
-//
-//    return params.row[CSVRowState]?.sex_qualitative_option_id;
-//  };
-//};
-
 /**
  * Get the Wildlife Health ID header cell validator.
  *

--- a/api/src/services/import-services/critter/critter-header-configs.ts
+++ b/api/src/services/import-services/critter/critter-header-configs.ts
@@ -196,7 +196,7 @@ export const getCritterSexCellValidator = (
 
     // Set the row state to store the qualitative option id for the sex
     params.row[CSVRowState] = {
-      id: rowDictionarySex
+      sexId: rowDictionarySex
     };
 
     return [];

--- a/api/src/services/import-services/critter/critter-header-configs.ts
+++ b/api/src/services/import-services/critter/critter-header-configs.ts
@@ -4,7 +4,8 @@ import {
   CSVCellSetter,
   CSVCellValidator,
   CSVError,
-  CSVParams
+  CSVParams,
+  CSVRowState
 } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { validateZodCell } from '../../../utils/csv-utils/csv-header-configs';
 import { NestedRecord } from '../../../utils/nested-record';
@@ -193,32 +194,29 @@ export const getCritterSexCellValidator = (
       ];
     }
 
+    // Set the row state to store the qualitative option id for the sex
+    params.row[CSVRowState] = {
+      id: rowDictionarySex
+    };
+
     return [];
   };
 };
 
-/**
- * Get the critter sex cell setter.
- *
- * @param {NestedRecord<string>} rowDictionary The row dictionary.
- * @param {CSVConfigUtils<CrittterCSVConfig>} configUtils The CSV config utils.
- * @returns {*} {CSVCellValidator} The validate cell callback
- */
-export const getCritterSexCellSetter = (
-  rowDictionary: NestedRecord<string>,
-  configUtils: CSVConfigUtils<CritterCSVStaticHeader>
-): CSVCellSetter => {
-  return (params: CSVParams) => {
-    if (params.cell === undefined) {
-      return undefined;
-    }
-
-    const rowTsn = Number(configUtils.getCellValue('ITIS_TSN', params.row));
-    const sexCellValue = String(params.cell);
-
-    return rowDictionary.get(rowTsn, sexCellValue);
-  };
-};
+///**
+// * Get the critter sex cell setter.
+// *
+// * @returns {*} {CSVCellValidator} The validate cell callback
+// */
+//export const getCritterSexCellSetter = (): CSVCellSetter => {
+//  return (params: CSVParams) => {
+//    if (params.cell === undefined) {
+//      return undefined;
+//    }
+//
+//    return params.row[CSVRowState]?.sex_qualitative_option_id;
+//  };
+//};
 
 /**
  * Get the Wildlife Health ID header cell validator.

--- a/api/src/services/import-services/critter/import-critters-service.test.ts
+++ b/api/src/services/import-services/critter/import-critters-service.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import xlsx from 'xlsx';
 import { CSVConfigUtils } from '../../../utils/csv-utils/csv-config-utils';
+import { CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import * as headerConfig from '../../../utils/csv-utils/csv-header-configs';
 import { NestedRecord } from '../../../utils/nested-record';
 import { getMockDBConnection } from '../../../__mocks__/db';
@@ -179,7 +180,6 @@ describe('ImportCrittersService', () => {
       } as any);
 
       const getSexCellValidatorStub = sinon.stub(critterConfig, 'getCritterSexCellValidator').returns(() => []);
-      const getSexCellSetterStub = sinon.stub(critterConfig, 'getCritterSexCellSetter').returns(() => 'A');
 
       const sexHeaderConfig = await service._getSexHeaderConfig();
 
@@ -191,15 +191,8 @@ describe('ImportCrittersService', () => {
         service.configUtils
       );
 
-      expect(getSexCellSetterStub).to.have.been.calledWithExactly(
-        new NestedRecord({
-          1234: { male: 'maleUUID', female: 'femaleUUID' }
-        }),
-        service.configUtils
-      );
-
       expect(sexHeaderConfig.validateCell).to.be.a('function');
-      expect(sexHeaderConfig.setCellValue).to.be.a('function');
+      expect(sexHeaderConfig.setCellValue).to.be.undefined;
     });
   });
 
@@ -252,7 +245,10 @@ describe('ImportCrittersService', () => {
           WLH_ID: '12-2222',
           DESCRIPTION: 'comment',
           POPULATION_UNIT: 'unit',
-          COLLECTION_UNIT: 'collection'
+          COLLECTION_UNIT: 'collection',
+          [CSVRowState]: {
+            sexId: 'sexId'
+          }
         }
       ];
       const worksheet = xlsx.utils.json_to_sheet(rows);
@@ -265,7 +261,7 @@ describe('ImportCrittersService', () => {
 
       expect(payloads.critterbasePayload.critters?.[0].itis_tsn).to.be.equal('1234');
       expect(payloads.critterbasePayload.critters?.[0].animal_id).to.be.equal('test');
-      expect(payloads.critterbasePayload.critters?.[0].sex_qualitative_option_id).to.be.equal('male');
+      expect(payloads.critterbasePayload.critters?.[0].sex_qualitative_option_id).to.be.equal('sexId');
       expect(payloads.critterbasePayload.critters?.[0].wlh_id).to.be.equal('12-2222');
       expect(payloads.critterbasePayload.critters?.[0].critter_comment).to.be.equal('comment');
       expect(payloads.critterbasePayload.critters?.[0].critter_id).to.be.a('string');

--- a/api/src/services/import-services/critter/import-critters-service.ts
+++ b/api/src/services/import-services/critter/import-critters-service.ts
@@ -172,10 +172,6 @@ export class ImportCrittersService extends DBService {
       // SIMS payload
       simsPayload.push(critterId);
 
-      if (!row[CSVRowState]?.sexId) {
-        throw new Error('no state');
-      }
-
       // Critterbase static headers payload
       critterbasePayload.critters?.push({
         critter_id: critterId,

--- a/api/src/services/import-services/critter/import-critters-service.ts
+++ b/api/src/services/import-services/critter/import-critters-service.ts
@@ -169,19 +169,13 @@ export class ImportCrittersService extends DBService {
     for (const row of rows) {
       const critterId = v4();
 
-      console.log({ rowState: row[CSVRowState] });
-
-      if (!row[CSVRowState]?.id) {
-        throw new Error('Row does not have row state');
-      }
-
       // SIMS payload
       simsPayload.push(critterId);
 
       // Critterbase static headers payload
       critterbasePayload.critters?.push({
         critter_id: critterId,
-        sex_qualitative_option_id: row[CSVRowState]?.id,
+        sex_qualitative_option_id: row[CSVRowState]?.sexId,
         itis_tsn: row.ITIS_TSN,
         animal_id: row.ALIAS,
         wlh_id: row.WLH_ID,
@@ -275,7 +269,6 @@ export class ImportCrittersService extends DBService {
 
     return {
       validateCell: getCritterSexCellValidator(rowDictionary, this.configUtils)
-      //setCellValue: getCritterSexCellSetter(rowDictionary, this.configUtils)
     };
   }
 

--- a/api/src/services/import-services/critter/import-critters-service.ts
+++ b/api/src/services/import-services/critter/import-critters-service.ts
@@ -9,6 +9,7 @@ import {
   CSVConfig,
   CSVError,
   CSVHeaderConfig,
+  CSVRowState,
   CSVRowValidated
 } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { getDescriptionCellValidator, getTsnCellValidator } from '../../../utils/csv-utils/csv-header-configs';
@@ -22,7 +23,6 @@ import {
   getCritterAliasCellValidator,
   getCritterCollectionUnitCellSetter,
   getCritterCollectionUnitCellValidator,
-  getCritterSexCellSetter,
   getCritterSexCellValidator,
   getWlhIDCellValidator
 } from './critter-header-configs';
@@ -169,13 +169,19 @@ export class ImportCrittersService extends DBService {
     for (const row of rows) {
       const critterId = v4();
 
+      console.log({ rowState: row[CSVRowState] });
+
+      if (!row[CSVRowState]?.id) {
+        throw new Error('Row does not have row state');
+      }
+
       // SIMS payload
       simsPayload.push(critterId);
 
       // Critterbase static headers payload
       critterbasePayload.critters?.push({
         critter_id: critterId,
-        sex_qualitative_option_id: row.SEX,
+        sex_qualitative_option_id: row[CSVRowState]?.id,
         itis_tsn: row.ITIS_TSN,
         animal_id: row.ALIAS,
         wlh_id: row.WLH_ID,
@@ -268,8 +274,8 @@ export class ImportCrittersService extends DBService {
     });
 
     return {
-      validateCell: getCritterSexCellValidator(rowDictionary, this.configUtils),
-      setCellValue: getCritterSexCellSetter(rowDictionary, this.configUtils)
+      validateCell: getCritterSexCellValidator(rowDictionary, this.configUtils)
+      //setCellValue: getCritterSexCellSetter(rowDictionary, this.configUtils)
     };
   }
 

--- a/api/src/services/import-services/critter/import-critters-service.ts
+++ b/api/src/services/import-services/critter/import-critters-service.ts
@@ -172,6 +172,10 @@ export class ImportCrittersService extends DBService {
       // SIMS payload
       simsPayload.push(critterId);
 
+      if (!row[CSVRowState]?.sexId) {
+        throw new Error('no state');
+      }
+
       // Critterbase static headers payload
       critterbasePayload.critters?.push({
         critter_id: critterId,

--- a/api/src/utils/csv-utils/csv-config-validation.interface.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.interface.ts
@@ -8,7 +8,6 @@ export const CSV_ERROR_MESSAGE =
  *  1. Allow or disallow duplicate CSV rows
  *    - Similar to a DB unique constraint? ie: ['NAME', 'AGE']
  *  2. Support CSVWarnings
- *  3. Support CSVRowValidation? ie: Validate the entire row before / after the cell validation
  */
 export interface CSVConfig<THeader extends Uppercase<string> = Uppercase<string>> {
   /**
@@ -40,6 +39,15 @@ export interface CSVConfig<THeader extends Uppercase<string> = Uppercase<string>
    */
   dynamicHeadersConfig?: CSVHeaderConfig;
 
+  /**
+   * A list of row validators
+   *
+   * Note: These are called BEFORE the static and dynamic cell validators.
+   * Useful if needing to validate multiple headers (ex: ALIAS, DATE, TIME) or applying some preliminary
+   * validation before the cell validation.
+   *
+   * @type {CSVRowValidator[] | undefined}
+   */
   rowValidators?: CSVRowValidator[];
 }
 
@@ -68,6 +76,13 @@ interface CSVStaticHeaderConfig {
  */
 export type CSVCellValidator = (params: CSVParams) => CSVError[];
 
+/**
+ * The CSV row validator function
+ *
+ * @param {CSVRowParams} params - The CSV row parameters
+ * @returns {CSVError[]} - The list of CSV errors
+ *
+ */
 export type CSVRowValidator = (params: CSVRowParams) => CSVError[];
 
 /**
@@ -100,7 +115,19 @@ export interface CSVHeaderConfig {
 }
 
 export interface CSVRowParams {
+  /**
+   * The data row object.
+   *
+   * @type {CSVRow}
+   */
   row: CSVRow;
+  /**
+   * The row index.
+   *
+   * Note: First data row index 0.
+   *
+   * @type {number}
+   */
   rowIndex: number;
 }
 
@@ -206,8 +233,11 @@ export interface CSVError {
    */
   row?: number;
 }
-
-// The CSV row state symbol to store additional row metadata
+/**
+ * The CSV row state symbol to store additional row metadata
+ * without interfering with the row shape or structure
+ *
+ */
 export const CSVRowState = Symbol('CSVRowStateSymbol');
 
 /**

--- a/api/src/utils/csv-utils/csv-config-validation.interface.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.interface.ts
@@ -21,6 +21,14 @@ export interface CSVConfig<THeader extends Uppercase<string> = Uppercase<string>
    */
   staticHeadersConfig: Record<THeader, CSVStaticHeaderConfig & CSVHeaderConfig>;
   /**
+   * Boolean to ignore dynamic headers.
+   *
+   * ie: If true, the dynamic headers will not be processed.
+   *
+   * @type {boolean}
+   */
+  ignoreDynamicHeaders: boolean;
+  /**
    * Contains the `validateCell` and `setCellValue` callbacks to be called for each dynamic cell.
    *
    * Note: A dynamic header is a header that is not known and defined in the configuration.
@@ -31,14 +39,8 @@ export interface CSVConfig<THeader extends Uppercase<string> = Uppercase<string>
    * @type {CSVHeaderConfig | undefined}
    */
   dynamicHeadersConfig?: CSVHeaderConfig;
-  /**
-   * Boolean to ignore dynamic headers.
-   *
-   * ie: If true, the dynamic headers will not be processed.
-   *
-   * @type {boolean}
-   */
-  ignoreDynamicHeaders: boolean;
+
+  rowValidators?: CSVRowValidator[];
 }
 
 interface CSVStaticHeaderConfig {
@@ -65,6 +67,8 @@ interface CSVStaticHeaderConfig {
  * @returns {CSVError[]} - The list of CSV errors
  */
 export type CSVCellValidator = (params: CSVParams) => CSVError[];
+
+export type CSVRowValidator = (params: CSVRowParams) => CSVError[];
 
 /**
  * The CSV header config cell setter function
@@ -93,6 +97,11 @@ export interface CSVHeaderConfig {
    * @type {CSVCellSetter | undefined} The cell setter function
    */
   setCellValue?: CSVCellSetter;
+}
+
+export interface CSVRowParams {
+  row: CSVRow;
+  rowIndex: number;
 }
 
 /**
@@ -198,16 +207,25 @@ export interface CSVError {
   row?: number;
 }
 
+// The CSV row state symbol to store additional row metadata
+export const CSVRowState = Symbol('CSVRowStateSymbol');
+
 /**
  * The raw unvalidated CSV row
  *
  */
-export type CSVRow = Record<Uppercase<string>, any>;
+export type CSVRow = Record<Uppercase<string>, any> & {
+  // The CSV row state symbol to store additional row metadata
+  [CSVRowState]?: Record<string, any>;
+};
 
 /**
  * The validated CSV row keyed by the static headers
  *
  */
-export type CSVRowValidated<StaticHeaderType extends Uppercase<string>> = Record<StaticHeaderType, any>;
+export type CSVRowValidated<StaticHeaderType extends Uppercase<string>> = Record<StaticHeaderType, any> & {
+  // The CSV row state symbol to store additional row metadata
+  [CSVRowState]?: Record<string, any>;
+};
 
 export type CSVCell = string | number | undefined;

--- a/api/src/utils/csv-utils/csv-config-validation.test.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.test.ts
@@ -6,7 +6,6 @@ import { WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import {
   executeSetCellValue,
   executeValidateCell,
-  forEachCSVCell,
   validateCSVHeaders,
   validateCSVWorksheet
 } from './csv-config-validation';
@@ -198,144 +197,144 @@ describe('csv-config-validation', () => {
     });
   });
 
-  describe('forEachCSVCell', () => {
-    it('should iterate over each cell in the worksheet', () => {
-      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST: 'cellValue' }]);
-
-      const validateCellStub = sinon.stub();
-      const setCellValueStub = sinon.stub();
-
-      const config: CSVConfig = {
-        staticHeadersConfig: {
-          TEST: {
-            aliases: [],
-            validateCell: validateCellStub,
-            setCellValue: setCellValueStub
-          }
-        },
-        ignoreDynamicHeaders: true
-      };
-
-      const callbackStub = sinon.stub();
-
-      forEachCSVCell(worksheet, config, callbackStub);
-
-      expect(callbackStub).to.have.been.calledOnceWithExactly(
-        {
-          cell: 'cellValue',
-          header: 'TEST',
-          rowIndex: 0,
-          row: { TEST: 'cellValue' },
-          staticHeader: 'TEST',
-          mutateCell: 'cellValue'
-        },
-        {
-          validateCell: validateCellStub,
-          setCellValue: setCellValueStub
-        }
-      );
-    });
-
-    it('should iterate over each cell in the worksheet when alias is used', () => {
-      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST_ALIAS: 'cellValue' }]);
-
-      const validateCellStub = sinon.stub();
-      const setCellValueStub = sinon.stub();
-
-      const config: CSVConfig = {
-        staticHeadersConfig: {
-          TEST: {
-            aliases: ['TEST_ALIAS'],
-            validateCell: validateCellStub,
-            setCellValue: setCellValueStub
-          }
-        },
-        ignoreDynamicHeaders: true
-      };
-
-      const callbackStub = sinon.stub();
-
-      forEachCSVCell(worksheet, config, callbackStub);
-
-      expect(callbackStub).to.have.been.calledOnceWithExactly(
-        {
-          cell: 'cellValue',
-          header: 'TEST_ALIAS',
-          rowIndex: 0,
-          row: { TEST_ALIAS: 'cellValue' },
-          staticHeader: 'TEST',
-          mutateCell: 'cellValue'
-        },
-        {
-          validateCell: validateCellStub,
-          setCellValue: setCellValueStub
-        }
-      );
-    });
-
-    it('should iterate over dynamic cell values', () => {
-      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([
-        { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue' }
-      ]);
-
-      const staticValidateCellStub = sinon.stub();
-      const staticSetCellValueStub = sinon.stub();
-
-      const validateDynamicCellStub = sinon.stub();
-      const setCellValueDynamicStub = sinon.stub();
-
-      const config: CSVConfig = {
-        staticHeadersConfig: {
-          TEST: {
-            aliases: ['TEST_ALIAS'],
-            validateCell: staticValidateCellStub,
-            setCellValue: staticSetCellValueStub
-          }
-        },
-        dynamicHeadersConfig: {
-          validateCell: validateDynamicCellStub,
-          setCellValue: setCellValueDynamicStub
-        },
-        ignoreDynamicHeaders: false
-      };
-
-      const callbackStub = sinon.stub();
-
-      forEachCSVCell(worksheet, config, callbackStub);
-
-      expect(callbackStub).to.have.been.calledTwice;
-
-      expect(callbackStub.getCall(0).args).to.deep.equal([
-        {
-          cell: 'cellValue',
-          header: 'TEST_ALIAS',
-          rowIndex: 0,
-          row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
-          staticHeader: 'TEST',
-          mutateCell: 'cellValue'
-        },
-        {
-          validateCell: staticValidateCellStub,
-          setCellValue: staticSetCellValueStub
-        }
-      ]);
-
-      expect(callbackStub.getCall(1).args).to.deep.equal([
-        {
-          cell: 'dynamicValue',
-          header: 'DYNAMIC_HEADER',
-          rowIndex: 0,
-          row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
-          staticHeader: undefined, // Dynamic headers have no static header mapping
-          mutateCell: 'dynamicValue'
-        },
-        {
-          validateCell: validateDynamicCellStub,
-          setCellValue: setCellValueDynamicStub
-        }
-      ]);
-    });
-  });
+  //describe('forEachCSVRowCell', () => {
+  //  it('should iterate over each cell in the worksheet', () => {
+  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST: 'cellValue' }]);
+  //
+  //    const validateCellStub = sinon.stub();
+  //    const setCellValueStub = sinon.stub();
+  //
+  //    const config: CSVConfig = {
+  //      staticHeadersConfig: {
+  //        TEST: {
+  //          aliases: [],
+  //          validateCell: validateCellStub,
+  //          setCellValue: setCellValueStub
+  //        }
+  //      },
+  //      ignoreDynamicHeaders: true
+  //    };
+  //
+  //    const callbackStub = sinon.stub();
+  //
+  //    forEachCSVRowCell(worksheet, config, callbackStub);
+  //
+  //    expect(callbackStub).to.have.been.calledOnceWithExactly(
+  //      {
+  //        cell: 'cellValue',
+  //        header: 'TEST',
+  //        rowIndex: 0,
+  //        row: { TEST: 'cellValue' },
+  //        staticHeader: 'TEST',
+  //        mutateCell: 'cellValue'
+  //      },
+  //      {
+  //        validateCell: validateCellStub,
+  //        setCellValue: setCellValueStub
+  //      }
+  //    );
+  //  });
+  //
+  //  it('should iterate over each cell in the worksheet when alias is used', () => {
+  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST_ALIAS: 'cellValue' }]);
+  //
+  //    const validateCellStub = sinon.stub();
+  //    const setCellValueStub = sinon.stub();
+  //
+  //    const config: CSVConfig = {
+  //      staticHeadersConfig: {
+  //        TEST: {
+  //          aliases: ['TEST_ALIAS'],
+  //          validateCell: validateCellStub,
+  //          setCellValue: setCellValueStub
+  //        }
+  //      },
+  //      ignoreDynamicHeaders: true
+  //    };
+  //
+  //    const callbackStub = sinon.stub();
+  //
+  //    forEachCSVRowCell(worksheet, config, callbackStub);
+  //
+  //    expect(callbackStub).to.have.been.calledOnceWithExactly(
+  //      {
+  //        cell: 'cellValue',
+  //        header: 'TEST_ALIAS',
+  //        rowIndex: 0,
+  //        row: { TEST_ALIAS: 'cellValue' },
+  //        staticHeader: 'TEST',
+  //        mutateCell: 'cellValue'
+  //      },
+  //      {
+  //        validateCell: validateCellStub,
+  //        setCellValue: setCellValueStub
+  //      }
+  //    );
+  //  });
+  //
+  //  it('should iterate over dynamic cell values', () => {
+  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([
+  //      { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue' }
+  //    ]);
+  //
+  //    const staticValidateCellStub = sinon.stub();
+  //    const staticSetCellValueStub = sinon.stub();
+  //
+  //    const validateDynamicCellStub = sinon.stub();
+  //    const setCellValueDynamicStub = sinon.stub();
+  //
+  //    const config: CSVConfig = {
+  //      staticHeadersConfig: {
+  //        TEST: {
+  //          aliases: ['TEST_ALIAS'],
+  //          validateCell: staticValidateCellStub,
+  //          setCellValue: staticSetCellValueStub
+  //        }
+  //      },
+  //      dynamicHeadersConfig: {
+  //        validateCell: validateDynamicCellStub,
+  //        setCellValue: setCellValueDynamicStub
+  //      },
+  //      ignoreDynamicHeaders: false
+  //    };
+  //
+  //    const callbackStub = sinon.stub();
+  //
+  //    forEachCSVRowCell(worksheet, config, callbackStub);
+  //
+  //    expect(callbackStub).to.have.been.calledTwice;
+  //
+  //    expect(callbackStub.getCall(0).args).to.deep.equal([
+  //      {
+  //        cell: 'cellValue',
+  //        header: 'TEST_ALIAS',
+  //        rowIndex: 0,
+  //        row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
+  //        staticHeader: 'TEST',
+  //        mutateCell: 'cellValue'
+  //      },
+  //      {
+  //        validateCell: staticValidateCellStub,
+  //        setCellValue: staticSetCellValueStub
+  //      }
+  //    ]);
+  //
+  //    expect(callbackStub.getCall(1).args).to.deep.equal([
+  //      {
+  //        cell: 'dynamicValue',
+  //        header: 'DYNAMIC_HEADER',
+  //        rowIndex: 0,
+  //        row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
+  //        staticHeader: undefined, // Dynamic headers have no static header mapping
+  //        mutateCell: 'dynamicValue'
+  //      },
+  //      {
+  //        validateCell: validateDynamicCellStub,
+  //        setCellValue: setCellValueDynamicStub
+  //      }
+  //    ]);
+  //  });
+  //});
 
   describe('executeValidateCell', () => {
     it('should call the validateCell callback and mutate errors array', () => {

--- a/api/src/utils/csv-utils/csv-config-validation.test.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.test.ts
@@ -6,10 +6,10 @@ import { WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import {
   executeRowValidator,
   executeSetCellValue,
-  executeUpdateRowState,
   executeValidateCell,
   forEachCSVRow,
   forEachCSVRowCell,
+  updateRowState,
   validateCSVHeaders,
   validateCSVWorksheet
 } from './csv-config-validation';
@@ -103,6 +103,56 @@ describe('csv-config-validation', () => {
         ],
         rows: []
       });
+    });
+
+    it('should call the row validators and return the errors early', () => {
+      const validateRowStub = sinon.stub().returns([{ error: 'error', solution: 'solution' }]);
+
+      const mockConfig: CSVConfig = {
+        staticHeadersConfig: {
+          ALIAS: {
+            aliases: ['ALIAS_2']
+          }
+        },
+        ignoreDynamicHeaders: true,
+        rowValidators: [validateRowStub]
+      };
+
+      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ ALIAS: 'value' }, { ALIAS: 'value' }]);
+
+      const result = validateCSVWorksheet(worksheet, mockConfig);
+
+      expect(validateRowStub).to.have.been.calledTwice;
+      expect(result.errors.length).to.be.equal(2);
+    });
+
+    it('should update the row state with the CSVRowState', () => {
+      const mockConfig: CSVConfig = {
+        staticHeadersConfig: {
+          ALIAS: {
+            aliases: [],
+            validateCell: (params) => {
+              params.row[CSVRowState] = { stateValue: 'newNewValue' };
+              return [];
+            }
+          }
+        },
+        ignoreDynamicHeaders: true,
+        rowValidators: [
+          (params) => {
+            params.row[CSVRowState] = { stateValue: 'newValue', rowValidatorValue: 'rowValidator', otherValue: 'test' };
+            return [];
+          }
+        ]
+      };
+
+      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ ALIAS: 'value' }]);
+
+      const result = validateCSVWorksheet(worksheet, mockConfig);
+
+      expect(result.rows[0][CSVRowState]?.stateValue).to.equal('newNewValue');
+      expect(result.rows[0][CSVRowState]?.rowValidatorValue).to.equal('rowValidator');
+      expect(result.rows[0][CSVRowState]?.otherValue).to.equal('test');
     });
   });
 
@@ -360,12 +410,12 @@ describe('csv-config-validation', () => {
     });
   });
 
-  describe('executeUpdateRowState', () => {
+  describe('updateRowState', () => {
     it('should mutate the row state with the CSVRowState when rows empty', () => {
       const mutableRows: CSVRow[] = [];
       const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
 
-      executeUpdateRowState({ row, rowIndex: 0 }, mutableRows);
+      updateRowState({ row, rowIndex: 0 }, mutableRows);
 
       expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
     });
@@ -374,7 +424,7 @@ describe('csv-config-validation', () => {
       const mutableRows: CSVRow[] = [{ NEW: 'cellValue' }];
       const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
 
-      executeUpdateRowState({ row, rowIndex: 0 }, mutableRows);
+      updateRowState({ row, rowIndex: 0 }, mutableRows);
 
       expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
       expect(mutableRows[0].NEW).to.equal('cellValue');

--- a/api/src/utils/csv-utils/csv-config-validation.test.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.test.ts
@@ -9,11 +9,11 @@ import {
   executeValidateCell,
   forEachCSVRow,
   forEachCSVRowCell,
-  updateRowState,
   validateCSVHeaders,
   validateCSVWorksheet
 } from './csv-config-validation';
-import { CSVConfig, CSVError, CSVRow, CSVRowState } from './csv-config-validation.interface';
+import { CSVConfig, CSVRowState } from './csv-config-validation.interface';
+import { updateCSVRowState } from './csv-header-configs';
 chai.use(sinonChai);
 
 describe('csv-config-validation', () => {
@@ -56,15 +56,14 @@ describe('csv-config-validation', () => {
       expect(validateDynamicCellStub).to.have.been.calledTwice;
       expect(setCellValueDynamicStub).to.have.been.calledTwice;
 
-      expect(result).to.deep.equal({
-        errors: [],
-        rows: [
-          {
-            ALIAS: 'newValue',
-            DYNAMIC_HEADER: 'newDynamicValue',
-            OTHER_DYNAMIC_HEADER: 'newDynamicValue'
-          }
-        ]
+      expect(result.errors.length).to.be.equal(0);
+      expect(result.rows.length).to.be.equal(1);
+
+      expect(result.rows[0]).to.deep.equal({
+        ALIAS: 'newValue',
+        DYNAMIC_HEADER: 'newDynamicValue',
+        OTHER_DYNAMIC_HEADER: 'newDynamicValue',
+        [CSVRowState]: undefined
       });
     });
 
@@ -132,7 +131,8 @@ describe('csv-config-validation', () => {
           ALIAS: {
             aliases: [],
             validateCell: (params) => {
-              params.row[CSVRowState] = { stateValue: 'newNewValue' };
+              updateCSVRowState(params.row, { stateValue: 'newValue' });
+
               return [];
             }
           }
@@ -140,7 +140,12 @@ describe('csv-config-validation', () => {
         ignoreDynamicHeaders: true,
         rowValidators: [
           (params) => {
-            params.row[CSVRowState] = { stateValue: 'newValue', rowValidatorValue: 'rowValidator', otherValue: 'test' };
+            updateCSVRowState(params.row, {
+              stateValue: 'value',
+              rowValidatorValue: 'rowValidator',
+              otherValue: 'test'
+            });
+
             return [];
           }
         ]
@@ -150,7 +155,7 @@ describe('csv-config-validation', () => {
 
       const result = validateCSVWorksheet(worksheet, mockConfig);
 
-      expect(result.rows[0][CSVRowState]?.stateValue).to.equal('newNewValue');
+      expect(result.rows[0][CSVRowState]?.stateValue).to.equal('newValue');
       expect(result.rows[0][CSVRowState]?.rowValidatorValue).to.equal('rowValidator');
       expect(result.rows[0][CSVRowState]?.otherValue).to.equal('test');
     });
@@ -410,38 +415,16 @@ describe('csv-config-validation', () => {
     });
   });
 
-  describe('updateRowState', () => {
-    it('should mutate the row state with the CSVRowState when rows empty', () => {
-      const mutableRows: CSVRow[] = [];
-      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
-
-      updateRowState({ row, rowIndex: 0 }, mutableRows);
-
-      expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
-    });
-
-    it('should mutate the row state with the CSVRowState when rows not empty', () => {
-      const mutableRows: CSVRow[] = [{ NEW: 'cellValue' }];
-      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
-
-      updateRowState({ row, rowIndex: 0 }, mutableRows);
-
-      expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
-      expect(mutableRows[0].NEW).to.equal('cellValue');
-    });
-  });
-
   describe('executeRowValidator', () => {
-    it('should call the row validator callback and mutate errors array', () => {
-      const mutableErrors: CSVError[] = [];
-
+    it('should call the row validator callback and return errors array', () => {
       const validateRowStub = sinon.stub().returns([{ error: 'error', solution: 'solution' }]);
 
       const row = { TEST: 'cellValue', [WorksheetRowIndexSymbol]: 1 };
 
-      executeRowValidator({ row, rowIndex: 0 }, validateRowStub, mutableErrors);
+      const rowErrors = executeRowValidator({ row, rowIndex: 0 }, validateRowStub);
+
       expect(validateRowStub).to.have.been.calledOnceWithExactly({ row, rowIndex: 0 });
-      expect(mutableErrors).to.deep.equal([
+      expect(rowErrors).to.deep.equal([
         {
           error: 'error',
           solution: 'solution',
@@ -454,9 +437,7 @@ describe('csv-config-validation', () => {
     });
   });
   describe('executeValidateCell', () => {
-    it('should call the validateCell callback and mutate errors array', () => {
-      const errors: any[] = [];
-
+    it('should call the validateCell callback and return errors array', () => {
       const validateCellStub = sinon.stub().returns([{ error: 'error', solution: 'solution' }]);
 
       const params = {
@@ -468,11 +449,7 @@ describe('csv-config-validation', () => {
         mutateCell: 'cellValue'
       };
 
-      const headerConfig = {
-        validateCell: validateCellStub
-      };
-
-      executeValidateCell(params, headerConfig, errors);
+      const errors = executeValidateCell(params, validateCellStub);
       expect(validateCellStub).to.have.been.calledOnceWithExactly(params);
       expect(errors).to.deep.equal([
         {
@@ -488,7 +465,7 @@ describe('csv-config-validation', () => {
   });
 
   describe('executeSetCellValue', () => {
-    it('should call the setCellValue callback and mutate the row', () => {
+    it('should call the setCellValue callback and return the row', () => {
       const row = { TEST: 'cellValue' };
 
       const setCellValueStub = sinon.stub().returns('newValue');
@@ -502,16 +479,11 @@ describe('csv-config-validation', () => {
         mutateCell: 'cellValue'
       };
 
-      const headerConfig = {
-        setCellValue: setCellValueStub
-      };
-
-      const mutableRows = [row];
-
-      executeSetCellValue(params, headerConfig, mutableRows);
+      const { header, cell } = executeSetCellValue(params, setCellValueStub);
 
       expect(setCellValueStub).to.have.been.calledOnceWithExactly(params);
-      expect(mutableRows).to.deep.equal([{ TEST: 'newValue' }]);
+      expect(header).to.equal('TEST');
+      expect(cell).to.equal('newValue');
     });
 
     it('should remap the key for a static header alias', () => {
@@ -528,16 +500,11 @@ describe('csv-config-validation', () => {
         mutateCell: 'cellValue'
       };
 
-      const headerConfig = {
-        setCellValue: setCellValueStub
-      };
-
-      const mutableRows = [row];
-
-      executeSetCellValue(params, headerConfig, mutableRows);
+      const { header, cell } = executeSetCellValue(params, setCellValueStub);
 
       expect(setCellValueStub).to.have.been.calledOnceWithExactly(params);
-      expect(mutableRows).to.deep.equal([{ NEW_KEY: 'newValue' }]);
+      expect(header).to.equal('NEW_KEY');
+      expect(cell).to.equal('newValue');
     });
   });
 });

--- a/api/src/utils/csv-utils/csv-config-validation.test.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.test.ts
@@ -4,12 +4,16 @@ import sinonChai from 'sinon-chai';
 import xlsx, { WorkSheet } from 'xlsx';
 import { WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import {
+  executeRowValidator,
   executeSetCellValue,
+  executeUpdateRowState,
   executeValidateCell,
+  forEachCSVRow,
+  forEachCSVRowCell,
   validateCSVHeaders,
   validateCSVWorksheet
 } from './csv-config-validation';
-import { CSVConfig } from './csv-config-validation.interface';
+import { CSVConfig, CSVError, CSVRow, CSVRowState } from './csv-config-validation.interface';
 chai.use(sinonChai);
 
 describe('csv-config-validation', () => {
@@ -197,145 +201,208 @@ describe('csv-config-validation', () => {
     });
   });
 
-  //describe('forEachCSVRowCell', () => {
-  //  it('should iterate over each cell in the worksheet', () => {
-  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST: 'cellValue' }]);
-  //
-  //    const validateCellStub = sinon.stub();
-  //    const setCellValueStub = sinon.stub();
-  //
-  //    const config: CSVConfig = {
-  //      staticHeadersConfig: {
-  //        TEST: {
-  //          aliases: [],
-  //          validateCell: validateCellStub,
-  //          setCellValue: setCellValueStub
-  //        }
-  //      },
-  //      ignoreDynamicHeaders: true
-  //    };
-  //
-  //    const callbackStub = sinon.stub();
-  //
-  //    forEachCSVRowCell(worksheet, config, callbackStub);
-  //
-  //    expect(callbackStub).to.have.been.calledOnceWithExactly(
-  //      {
-  //        cell: 'cellValue',
-  //        header: 'TEST',
-  //        rowIndex: 0,
-  //        row: { TEST: 'cellValue' },
-  //        staticHeader: 'TEST',
-  //        mutateCell: 'cellValue'
-  //      },
-  //      {
-  //        validateCell: validateCellStub,
-  //        setCellValue: setCellValueStub
-  //      }
-  //    );
-  //  });
-  //
-  //  it('should iterate over each cell in the worksheet when alias is used', () => {
-  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST_ALIAS: 'cellValue' }]);
-  //
-  //    const validateCellStub = sinon.stub();
-  //    const setCellValueStub = sinon.stub();
-  //
-  //    const config: CSVConfig = {
-  //      staticHeadersConfig: {
-  //        TEST: {
-  //          aliases: ['TEST_ALIAS'],
-  //          validateCell: validateCellStub,
-  //          setCellValue: setCellValueStub
-  //        }
-  //      },
-  //      ignoreDynamicHeaders: true
-  //    };
-  //
-  //    const callbackStub = sinon.stub();
-  //
-  //    forEachCSVRowCell(worksheet, config, callbackStub);
-  //
-  //    expect(callbackStub).to.have.been.calledOnceWithExactly(
-  //      {
-  //        cell: 'cellValue',
-  //        header: 'TEST_ALIAS',
-  //        rowIndex: 0,
-  //        row: { TEST_ALIAS: 'cellValue' },
-  //        staticHeader: 'TEST',
-  //        mutateCell: 'cellValue'
-  //      },
-  //      {
-  //        validateCell: validateCellStub,
-  //        setCellValue: setCellValueStub
-  //      }
-  //    );
-  //  });
-  //
-  //  it('should iterate over dynamic cell values', () => {
-  //    const worksheet: WorkSheet = xlsx.utils.json_to_sheet([
-  //      { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue' }
-  //    ]);
-  //
-  //    const staticValidateCellStub = sinon.stub();
-  //    const staticSetCellValueStub = sinon.stub();
-  //
-  //    const validateDynamicCellStub = sinon.stub();
-  //    const setCellValueDynamicStub = sinon.stub();
-  //
-  //    const config: CSVConfig = {
-  //      staticHeadersConfig: {
-  //        TEST: {
-  //          aliases: ['TEST_ALIAS'],
-  //          validateCell: staticValidateCellStub,
-  //          setCellValue: staticSetCellValueStub
-  //        }
-  //      },
-  //      dynamicHeadersConfig: {
-  //        validateCell: validateDynamicCellStub,
-  //        setCellValue: setCellValueDynamicStub
-  //      },
-  //      ignoreDynamicHeaders: false
-  //    };
-  //
-  //    const callbackStub = sinon.stub();
-  //
-  //    forEachCSVRowCell(worksheet, config, callbackStub);
-  //
-  //    expect(callbackStub).to.have.been.calledTwice;
-  //
-  //    expect(callbackStub.getCall(0).args).to.deep.equal([
-  //      {
-  //        cell: 'cellValue',
-  //        header: 'TEST_ALIAS',
-  //        rowIndex: 0,
-  //        row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
-  //        staticHeader: 'TEST',
-  //        mutateCell: 'cellValue'
-  //      },
-  //      {
-  //        validateCell: staticValidateCellStub,
-  //        setCellValue: staticSetCellValueStub
-  //      }
-  //    ]);
-  //
-  //    expect(callbackStub.getCall(1).args).to.deep.equal([
-  //      {
-  //        cell: 'dynamicValue',
-  //        header: 'DYNAMIC_HEADER',
-  //        rowIndex: 0,
-  //        row: { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue', [WorksheetRowIndexSymbol]: 1 },
-  //        staticHeader: undefined, // Dynamic headers have no static header mapping
-  //        mutateCell: 'dynamicValue'
-  //      },
-  //      {
-  //        validateCell: validateDynamicCellStub,
-  //        setCellValue: setCellValueDynamicStub
-  //      }
-  //    ]);
-  //  });
-  //});
+  describe('forEachCSVRow', () => {
+    it('should invoke the callback for each row in the worksheet', () => {
+      const worksheet: WorkSheet = xlsx.utils.json_to_sheet([{ TEST: 'cellValue' }, { TEST: 'cellValue2' }]);
 
+      const callbackStub = sinon.stub();
+
+      forEachCSVRow(
+        worksheet,
+        { staticHeadersConfig: { TEST: { aliases: [] } }, ignoreDynamicHeaders: true },
+        callbackStub
+      );
+
+      expect(callbackStub).to.have.been.calledTwice;
+    });
+  });
+
+  describe('forEachCSVRowCell', () => {
+    it('should iterate over each cell in the worksheet', () => {
+      const row = { TEST: 'cellValue' };
+
+      const validateCellStub = sinon.stub();
+      const setCellValueStub = sinon.stub();
+
+      const config: CSVConfig = {
+        staticHeadersConfig: {
+          TEST: {
+            aliases: [],
+            validateCell: validateCellStub,
+            setCellValue: setCellValueStub
+          }
+        },
+        ignoreDynamicHeaders: true
+      };
+
+      const callbackStub = sinon.stub();
+
+      forEachCSVRowCell(row, 0, config, callbackStub);
+
+      expect(callbackStub).to.have.been.calledOnceWithExactly(
+        {
+          cell: 'cellValue',
+          header: 'TEST',
+          rowIndex: 0,
+          row: { TEST: 'cellValue' },
+          staticHeader: 'TEST',
+          mutateCell: 'cellValue'
+        },
+        {
+          validateCell: validateCellStub,
+          setCellValue: setCellValueStub
+        }
+      );
+    });
+
+    it('should iterate over each cell in the worksheet when alias is used', () => {
+      const row = { TEST_ALIAS: 'cellValue' };
+
+      const validateCellStub = sinon.stub();
+      const setCellValueStub = sinon.stub();
+
+      const config: CSVConfig = {
+        staticHeadersConfig: {
+          TEST: {
+            aliases: ['TEST_ALIAS'],
+            validateCell: validateCellStub,
+            setCellValue: setCellValueStub
+          }
+        },
+        ignoreDynamicHeaders: true
+      };
+
+      const callbackStub = sinon.stub();
+
+      forEachCSVRowCell(row, 0, config, callbackStub);
+
+      expect(callbackStub).to.have.been.calledOnceWithExactly(
+        {
+          cell: 'cellValue',
+          header: 'TEST_ALIAS',
+          rowIndex: 0,
+          row: { TEST_ALIAS: 'cellValue' },
+          staticHeader: 'TEST',
+          mutateCell: 'cellValue'
+        },
+        {
+          validateCell: validateCellStub,
+          setCellValue: setCellValueStub
+        }
+      );
+    });
+
+    it('should iterate over dynamic cell values', () => {
+      const row = { TEST_ALIAS: 'cellValue', DYNAMIC_HEADER: 'dynamicValue' };
+
+      const staticValidateCellStub = sinon.stub();
+      const staticSetCellValueStub = sinon.stub();
+
+      const validateDynamicCellStub = sinon.stub();
+      const setCellValueDynamicStub = sinon.stub();
+
+      const config: CSVConfig = {
+        staticHeadersConfig: {
+          TEST: {
+            aliases: ['TEST_ALIAS'],
+            validateCell: staticValidateCellStub,
+            setCellValue: staticSetCellValueStub
+          }
+        },
+        dynamicHeadersConfig: {
+          validateCell: validateDynamicCellStub,
+          setCellValue: setCellValueDynamicStub
+        },
+        ignoreDynamicHeaders: false
+      };
+
+      const callbackStub = sinon.stub();
+
+      forEachCSVRowCell(row, 0, config, callbackStub);
+
+      expect(callbackStub).to.have.been.calledTwice;
+
+      expect(callbackStub.getCall(0).args).to.deep.equal([
+        {
+          cell: 'cellValue',
+          header: 'TEST_ALIAS',
+          rowIndex: 0,
+          row: {
+            TEST_ALIAS: 'cellValue',
+            DYNAMIC_HEADER: 'dynamicValue'
+          },
+          staticHeader: 'TEST',
+          mutateCell: 'cellValue'
+        },
+        {
+          validateCell: staticValidateCellStub,
+          setCellValue: staticSetCellValueStub
+        }
+      ]);
+
+      expect(callbackStub.getCall(1).args).to.deep.equal([
+        {
+          cell: 'dynamicValue',
+          header: 'DYNAMIC_HEADER',
+          rowIndex: 0,
+          row: {
+            TEST_ALIAS: 'cellValue',
+            DYNAMIC_HEADER: 'dynamicValue'
+          },
+          staticHeader: undefined, // Dynamic headers have no static header mapping
+          mutateCell: 'dynamicValue'
+        },
+        {
+          validateCell: validateDynamicCellStub,
+          setCellValue: setCellValueDynamicStub
+        }
+      ]);
+    });
+  });
+
+  describe('executeUpdateRowState', () => {
+    it('should mutate the row state with the CSVRowState when rows empty', () => {
+      const mutableRows: CSVRow[] = [];
+      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
+
+      executeUpdateRowState({ row, rowIndex: 0 }, mutableRows);
+
+      expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
+    });
+
+    it('should mutate the row state with the CSVRowState when rows not empty', () => {
+      const mutableRows: CSVRow[] = [{ NEW: 'cellValue' }];
+      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'value' } };
+
+      executeUpdateRowState({ row, rowIndex: 0 }, mutableRows);
+
+      expect(mutableRows[0][CSVRowState]?.stateValue).to.equal('value');
+      expect(mutableRows[0].NEW).to.equal('cellValue');
+    });
+  });
+
+  describe('executeRowValidator', () => {
+    it('should call the row validator callback and mutate errors array', () => {
+      const mutableErrors: CSVError[] = [];
+
+      const validateRowStub = sinon.stub().returns([{ error: 'error', solution: 'solution' }]);
+
+      const row = { TEST: 'cellValue', [WorksheetRowIndexSymbol]: 1 };
+
+      executeRowValidator({ row, rowIndex: 0 }, validateRowStub, mutableErrors);
+      expect(validateRowStub).to.have.been.calledOnceWithExactly({ row, rowIndex: 0 });
+      expect(mutableErrors).to.deep.equal([
+        {
+          error: 'error',
+          solution: 'solution',
+          cell: null,
+          header: null,
+          row: 2,
+          values: null
+        }
+      ]);
+    });
+  });
   describe('executeValidateCell', () => {
     it('should call the validateCell callback and mutate errors array', () => {
       const errors: any[] = [];

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -1,5 +1,4 @@
 import { WorkSheet } from 'xlsx';
-import { Row } from '../../services/import-services/import-csv.interface';
 import { getWorksheetRowObjects, WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import { CSVConfigUtils } from './csv-config-utils';
 import {
@@ -36,6 +35,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
 
   // Iterate over each row in the worksheet and execute the row validators
   forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
+    // Update the row state for each row
     executeUpdateRowState(rowParams, rows);
 
     // Execute the row validators and modify the errors
@@ -61,6 +61,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
       // Set the cell value and modify the rows
       executeSetCellValue(cellParams, headerConfig, rows); // Mutates `rows`
 
+      // Update the row state for each cell
       executeUpdateRowState(rowParams, rows);
     });
   });
@@ -146,6 +147,14 @@ export const validateCSVHeaders = (worksheet: WorkSheet, config: CSVConfig): CSV
   return csvErrors;
 };
 
+/**
+ * Iterate over each row in the CSV worksheet.
+ *
+ * @param {WorkSheet} worksheet - The worksheet
+ * @param {CSVConfig} config - The CSV configuration
+ * @param {(params: CSVRowParams, rowValidators: CSVRowValidator[]) => void} callback - The callback function
+ * @returns {*} {void}
+ */
 export const forEachCSVRow = (
   worksheet: WorkSheet,
   config: CSVConfig,
@@ -163,13 +172,14 @@ export const forEachCSVRow = (
 /**
  * Iterate over each cell in the CSV worksheet.
  *
- * @param {WorkSheet} worksheet - The worksheet
+ * @param {CSVRow} worksheetRow - The worksheet row object
+ * @param {number} rowIndex - The worksheet row index - 0 is the first data row
  * @param {CSVConfig} config - The CSV configuration
  * @param {(params: CSVParams, headerConfig: CSVHeaderConfig) => void} callback - The callback function
  * @returns {*} {void}
  */
 export const forEachCSVRowCell = (
-  worksheetRow: Row,
+  worksheetRow: CSVRow,
   rowIndex: number,
   config: CSVConfig,
   callback: (params: CSVParams, headerConfig: CSVHeaderConfig) => void
@@ -197,16 +207,37 @@ export const forEachCSVRowCell = (
   }
 };
 
+/**
+ * Execute the row state update.
+ *
+ * Note: This mutates the CSV row objects `mutableRows`.
+ *
+ * @param {CSVRowParams} params - The CSV row parameters
+ * @param {CSVRow[]} mutableRows - The mutable rows array
+ * @returns {*} {void}
+ */
 export const executeUpdateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
-  if (!mutableRows[params.rowIndex]) {
+  // Initialize the row if it does not exist
+  if (!mutableRows[params.rowIndex] && params.row[CSVRowState]) {
     mutableRows[params.rowIndex] = {};
   }
 
-  if (!mutableRows[params.rowIndex]?.[CSVRowState] && params.row?.[CSVRowState]) {
+  // Update the validated row state
+  if (params.row?.[CSVRowState]) {
     mutableRows[params.rowIndex][CSVRowState] = params.row[CSVRowState];
   }
 };
 
+/**
+ * Execute the row validator.
+ *
+ * Note: This mutates the CSV errors array `mutableErrors`.
+ *
+ * @param {CSVRowParams} params - The CSV row parameters
+ * @param {CSVRowValidator} rowValidator - The row validator
+ * @param {CSVError[]} mutableErrors - The mutable errors array
+ * @returns {*} {void}
+ */
 export const executeRowValidator = (params: CSVRowParams, rowValidator: CSVRowValidator, mutableErrors: CSVError[]) => {
   const rowErrors = rowValidator(params);
 

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -250,8 +250,7 @@ export const executeRowValidator = (params: CSVRowParams, rowValidator: CSVRowVa
       values: error.values ?? null,
       cell: error.cell ?? null,
       header: error.header ?? null,
-      // WorksheetRowIndexSymbol is the original row index from the worksheet ie: before filtering empty rows
-      row: error.row ?? params.row[WorksheetRowIndexSymbol] + 1 ?? params.rowIndex + 2 // headers: 1, data row: 2
+      row: _getErrorRowIndex(params, error.row)
     });
   });
 };
@@ -311,8 +310,7 @@ export const executeValidateCell = (
         values: error.values ?? null,
         cell: (error.cell === undefined ? params.cell : error.cell) ?? null, // Use cell value if intentionally null
         header: (error.header === undefined ? params.header : error.header) ?? null, // Use header value if intentionally null
-        // WorksheetRowIndexSymbol is the original row index from the worksheet ie: before filtering empty rows
-        row: error.row ?? params.row[WorksheetRowIndexSymbol] + 1 ?? params.rowIndex + 2 // headers: 1, data row: 2
+        row: _getErrorRowIndex(params, error.row)
       });
     });
   }
@@ -342,4 +340,29 @@ export const _getCSVStaticHeaderMap = (config: CSVConfig) => {
   }
 
   return headerMap;
+};
+
+/**
+ * Get the row index the error occurred on.
+ *
+ * Note: Header row index 1. First data row index 2.
+ * Note: `WorksheetRowIndexSymbol` is the original row index from the worksheet ie: before filtering empty rows
+ *
+ * @param {CSVRowParams} params - The CSV row or cell parameters
+ * @param {number} [errorIndex] - The error index
+ * @returns {*} {number} - The error row index
+ */
+const _getErrorRowIndex = (params: { row: CSVRow; rowIndex: number }, errorIndex?: number) => {
+  // If the error index is provided use that
+  if (errorIndex) {
+    return errorIndex;
+  }
+
+  // This is injected by the `getWorksheetRowObjects` function
+  if (params.row[WorksheetRowIndexSymbol]) {
+    return params.row[WorksheetRowIndexSymbol] + 1;
+  }
+
+  // Params row index is 0 based
+  return params.rowIndex + 2;
 };

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -353,7 +353,6 @@ export const _getCSVStaticHeaderMap = (config: CSVConfig) => {
  * @returns {*} {number} - The error row index
  */
 const _getErrorRowIndex = (params: { row: CSVRow; rowIndex: number }, errorIndex?: number) => {
-  // If the error index is provided use that
   if (errorIndex) {
     return errorIndex;
   }

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -1,4 +1,5 @@
 import { WorkSheet } from 'xlsx';
+import { Row } from '../../services/import-services/import-csv.interface';
 import { getWorksheetRowObjects, WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import { CSVConfigUtils } from './csv-config-utils';
 import {
@@ -7,7 +8,10 @@ import {
   CSVHeaderConfig,
   CSVParams,
   CSVRow,
-  CSVRowValidated
+  CSVRowParams,
+  CSVRowState,
+  CSVRowValidated,
+  CSVRowValidator
 } from './csv-config-validation.interface';
 
 /**
@@ -30,18 +34,35 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
     return { errors: errors, rows: [] };
   }
 
-  // Iterate over each cell in the worksheet and validate + set cell values
-  forEachCSVCell(worksheet, config, (params, headerConfig) => {
-    // Validate the cell value and modify the errors
-    executeValidateCell(params, headerConfig, errors); // Mutates `errors`
+  // Iterate over each row in the worksheet and execute the row validators
+  forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
+    executeUpdateRowState(rowParams, rows);
 
-    // If there are errors in the cell don't set the cell value
+    // Execute the row validators and modify the errors
+    rowValidators.forEach((rowValidator) => {
+      executeRowValidator(rowParams, rowValidator, errors);
+    });
+
+    // If there are errors in the row abort early
     if (errors.length) {
       return;
     }
 
-    // Set the cell value and modify the rows
-    executeSetCellValue(params, headerConfig, rows); // Mutates `rows`
+    // Iterate over each cell in the row and validate + set cell values
+    forEachCSVRowCell(rowParams.row, rowParams.rowIndex, config, (cellParams, headerConfig) => {
+      // Validate the cell value and modify the errors
+      executeValidateCell(cellParams, headerConfig, errors); // Mutates `errors`
+
+      // If there are errors in the cell don't set the cell value
+      if (errors.length) {
+        return;
+      }
+
+      // Set the cell value and modify the rows
+      executeSetCellValue(cellParams, headerConfig, rows); // Mutates `rows`
+
+      executeUpdateRowState(rowParams, rows);
+    });
   });
 
   if (errors.length) {
@@ -125,6 +146,20 @@ export const validateCSVHeaders = (worksheet: WorkSheet, config: CSVConfig): CSV
   return csvErrors;
 };
 
+export const forEachCSVRow = (
+  worksheet: WorkSheet,
+  config: CSVConfig,
+  callback: (params: CSVRowParams, rowValidators: CSVRowValidator[]) => void
+): void => {
+  const worksheetRows = getWorksheetRowObjects(worksheet);
+
+  for (let i = 0; i < worksheetRows.length; i++) {
+    const worksheetRow = worksheetRows[i];
+
+    callback({ row: worksheetRow, rowIndex: i }, config.rowValidators ?? []);
+  }
+};
+
 /**
  * Iterate over each cell in the CSV worksheet.
  *
@@ -133,36 +168,59 @@ export const validateCSVHeaders = (worksheet: WorkSheet, config: CSVConfig): CSV
  * @param {(params: CSVParams, headerConfig: CSVHeaderConfig) => void} callback - The callback function
  * @returns {*} {void}
  */
-export const forEachCSVCell = (
-  worksheet: WorkSheet,
+export const forEachCSVRowCell = (
+  worksheetRow: Row,
+  rowIndex: number,
   config: CSVConfig,
   callback: (params: CSVParams, headerConfig: CSVHeaderConfig) => void
 ): void => {
   const staticHeaderConfigMap = _getCSVStaticHeaderMap(config);
-  const worksheetRows = getWorksheetRowObjects(worksheet);
 
-  for (let i = 0; i < worksheetRows.length; i++) {
-    const worksheetRow = worksheetRows[i];
+  for (const header in worksheetRow) {
+    // Get the header config for the cell (static or dynamic)
+    const headerConfig = staticHeaderConfigMap.get(header) ?? config.dynamicHeadersConfig ?? {};
+    const cell = worksheetRow[header];
 
-    for (const header in worksheetRow) {
-      // Get the header config for the cell (static or dynamic)
-      const headerConfig = staticHeaderConfigMap.get(header) ?? config.dynamicHeadersConfig ?? {};
-      const cell = worksheetRow[header];
-      const params: CSVParams = {
-        cell: cell,
-        mutateCell: cell, // Set the mutate cell to the cell value
-        header: header,
-        row: worksheetRow,
-        rowIndex: i,
-        staticHeader: staticHeaderConfigMap.get(header)?.staticHeader
-      };
+    const params: CSVParams = {
+      cell: cell,
+      mutateCell: cell, // Set the mutate cell to the cell value
+      header: header,
+      row: worksheetRow,
+      rowIndex: rowIndex,
+      staticHeader: staticHeaderConfigMap.get(header)?.staticHeader
+    };
 
-      callback(params, {
-        validateCell: headerConfig.validateCell,
-        setCellValue: headerConfig.setCellValue
-      });
-    }
+    callback(params, {
+      validateCell: headerConfig.validateCell,
+      setCellValue: headerConfig.setCellValue
+    });
   }
+};
+
+export const executeUpdateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
+  if (!mutableRows[params.rowIndex]) {
+    mutableRows[params.rowIndex] = {};
+  }
+
+  if (!mutableRows[params.rowIndex]?.[CSVRowState] && params.row?.[CSVRowState]) {
+    mutableRows[params.rowIndex][CSVRowState] = params.row[CSVRowState];
+  }
+};
+
+export const executeRowValidator = (params: CSVRowParams, rowValidator: CSVRowValidator, mutableErrors: CSVError[]) => {
+  const rowErrors = rowValidator(params);
+
+  rowErrors.forEach((error) => {
+    mutableErrors.push({
+      error: error.error,
+      solution: error.solution,
+      values: error.values ?? null,
+      cell: error.cell ?? null,
+      header: error.header ?? null,
+      // WorksheetRowIndexSymbol is the original row index from the worksheet ie: before filtering empty rows
+      row: error.row ?? params.row[WorksheetRowIndexSymbol] + 1 ?? params.rowIndex + 2 // headers: 1, data row: 2
+    });
+  });
 };
 
 /**

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -37,7 +37,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
 
   // Iterate over each row in the worksheet and execute the row validators
   forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
-    // Execute the row validators and modify the errors
+    // Execute the row validators and push the errors
     rowValidators.forEach((rowValidator) => {
       errors.push(...executeRowValidator(rowParams, rowValidator));
     });

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -2,6 +2,8 @@ import { WorkSheet } from 'xlsx';
 import { getWorksheetRowObjects, WorksheetRowIndexSymbol } from '../xlsx-utils/worksheet-utils';
 import { CSVConfigUtils } from './csv-config-utils';
 import {
+  CSVCellSetter,
+  CSVCellValidator,
   CSVConfig,
   CSVError,
   CSVHeaderConfig,
@@ -37,9 +39,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
   forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
     // Execute the row validators and modify the errors
     rowValidators.forEach((rowValidator) => {
-      executeRowValidator(rowParams, rowValidator, errors);
-      // Update the row state for each row validator
-      updateRowState(rowParams, rows);
+      errors.push(...executeRowValidator(rowParams, rowValidator));
     });
 
     // If there are errors in the row abort early
@@ -47,22 +47,29 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
       return;
     }
 
+    const validatedRow: CSVRow = {};
+
     // Iterate over each cell in the row and validate + set cell values
     forEachCSVRowCell(rowParams.row, rowParams.rowIndex, config, (cellParams, headerConfig) => {
-      // Validate the cell value and modify the errors
-      executeValidateCell(cellParams, headerConfig, errors); // Mutates `errors`
+      // Validate the cell value and push the cell errors
+      if (headerConfig.validateCell) {
+        errors.push(...executeValidateCell(cellParams, headerConfig.validateCell));
+      }
 
       // If there are errors in the cell don't set the cell value
       if (errors.length) {
         return;
       }
 
-      // Set the cell value and modify the rows
-      executeSetCellValue(cellParams, headerConfig, rows); // Mutates `rows`
+      const { header, cell } = executeSetCellValue(cellParams, headerConfig.setCellValue);
 
-      // Update the row state for each cell
-      updateRowState(rowParams, rows);
+      // Set the header and cell value in the validated row
+      validatedRow[header] = cell;
+      // Copy the row state to the validated row
+      validatedRow[CSVRowState] = rowParams.row[CSVRowState];
     });
+
+    rows.push(validatedRow);
   });
 
   if (errors.length) {
@@ -207,113 +214,59 @@ export const forEachCSVRowCell = (
 };
 
 /**
- * Update the row state.
- *
- * Note: This mutates the CSV row objects `mutableRows`.
- *
- * @param {CSVRowParams} params - The CSV row parameters
- * @param {CSVRow[]} mutableRows - The mutable rows array
- * @returns {*} {void}
- */
-export const updateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
-  // Initialize the row if it does not exist
-  if (!mutableRows[params.rowIndex] && params.row[CSVRowState]) {
-    mutableRows[params.rowIndex] = {};
-  }
-
-  // Update the validated row state
-  if (params.row?.[CSVRowState]) {
-    const currentState = mutableRows[params.rowIndex][CSVRowState];
-    const newState = params.row[CSVRowState];
-
-    mutableRows[params.rowIndex][CSVRowState] = { ...currentState, ...newState };
-  }
-};
-
-/**
  * Execute the row validator.
- *
- * Note: This mutates the CSV errors array `mutableErrors`.
  *
  * @param {CSVRowParams} params - The CSV row parameters
  * @param {CSVRowValidator} rowValidator - The row validator
- * @param {CSVError[]} mutableErrors - The mutable errors array
- * @returns {*} {void}
+ * @returns {*} {CSVError[]}
  */
-export const executeRowValidator = (params: CSVRowParams, rowValidator: CSVRowValidator, mutableErrors: CSVError[]) => {
+export const executeRowValidator = (params: CSVRowParams, rowValidator: CSVRowValidator) => {
   const rowErrors = rowValidator(params);
 
-  rowErrors.forEach((error) => {
-    mutableErrors.push({
-      error: error.error,
-      solution: error.solution,
-      values: error.values ?? null,
-      cell: error.cell ?? null,
-      header: error.header ?? null,
-      row: _getErrorRowIndex(params, error.row)
-    });
-  });
+  return rowErrors.map((error) => ({
+    error: error.error,
+    solution: error.solution,
+    values: error.values ?? null,
+    cell: error.cell ?? null,
+    header: error.header ?? null,
+    row: _getErrorRowIndex(params, error.row)
+  }));
 };
 
 /**
  * Execute the CSVConfig `setCellValue` callback for the cell.
  *
- * Note: This mutates the CSV row objects `mutableRows`.
+ * Note: This also swaps the aliased header for the known static header.
  *
  * @param {CSVParams} params - The CSV parameters
- * @param {CSVHeaderConfig} headerConfig - The header configuration
- * @param {CSVRow[]} mutableRows - The mutable rows array
+ * @param {CSVCellSetter} setCellValue - The header configuration
  * @returns {*} {CSVRow[]} - The updated row
  */
-export const executeSetCellValue = (params: CSVParams, headerConfig: CSVHeaderConfig, mutableRows: CSVRow[]) => {
-  const row = { ...mutableRows[params.rowIndex] };
+export const executeSetCellValue = (params: CSVParams, setCellValue?: CSVCellSetter) => {
+  const header = params.staticHeader?.toUpperCase() ?? params.header.toUpperCase();
+  const cell = setCellValue?.(params) ?? params.mutateCell;
 
-  const headerKey = params.staticHeader?.toUpperCase() ?? params.header.toUpperCase();
-  const cellValue = headerConfig?.setCellValue?.(params) ?? params.mutateCell;
-
-  // Remove the aliased header if it is not the static header
-  if (params.staticHeader && params.header !== params.staticHeader) {
-    delete row[params.header as Uppercase<string>];
-  }
-
-  row[headerKey as Uppercase<string>] = cellValue;
-
-  mutableRows[params.rowIndex] = row;
+  return { header, cell };
 };
 
 /**
  * Execute the CSVConfig `validateCell` callback for the cell.
  *
- * Note: This mutates the CSV errors array `mutableErrors`.
- *
  * @param {CSVParams} params - The CSV parameters
- * @param {CSVHeaderConfig} headerConfig - The header configuration
- * @param {CSVError[]} mutableErrors - The mutable errors array
- * @returns {*} {void}
+ * @param {CSVCellValidator} validateCell - The cell validator
+ * @returns {*} {CSVError[]}
  */
-export const executeValidateCell = (
-  params: CSVParams,
-  headerConfig: CSVHeaderConfig,
-  mutableErrors: CSVError[]
-): void => {
-  if (!headerConfig.validateCell) {
-    return;
-  }
+export const executeValidateCell = (params: CSVParams, validateCell: CSVCellValidator): CSVError[] => {
+  const cellErrors = validateCell(params);
 
-  const cellErrors = headerConfig.validateCell(params);
-
-  if (cellErrors.length) {
-    cellErrors.forEach((error) => {
-      mutableErrors.push({
-        error: error.error,
-        solution: error.solution,
-        values: error.values ?? null,
-        cell: (error.cell === undefined ? params.cell : error.cell) ?? null, // Use cell value if intentionally null
-        header: (error.header === undefined ? params.header : error.header) ?? null, // Use header value if intentionally null
-        row: _getErrorRowIndex(params, error.row)
-      });
-    });
-  }
+  return cellErrors.map((error) => ({
+    error: error.error,
+    solution: error.solution,
+    values: error.values ?? null,
+    cell: (error.cell === undefined ? params.cell : error.cell) ?? null, // Use cell value if intentionally null
+    header: (error.header === undefined ? params.header : error.header) ?? null, // Use header value if intentionally null
+    row: _getErrorRowIndex(params, error.row)
+  }));
 };
 
 /**

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -35,12 +35,11 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
 
   // Iterate over each row in the worksheet and execute the row validators
   forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
-    // Update the row state for each row
-    updateRowState(rowParams, rows);
-
     // Execute the row validators and modify the errors
     rowValidators.forEach((rowValidator) => {
       executeRowValidator(rowParams, rowValidator, errors);
+      // Update the row state for each row validator
+      updateRowState(rowParams, rows);
     });
 
     // If there are errors in the row abort early
@@ -224,7 +223,10 @@ export const updateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
 
   // Update the validated row state
   if (params.row?.[CSVRowState]) {
-    mutableRows[params.rowIndex][CSVRowState] = params.row[CSVRowState];
+    const currentState = mutableRows[params.rowIndex][CSVRowState];
+    const newState = params.row[CSVRowState];
+
+    mutableRows[params.rowIndex][CSVRowState] = { ...currentState, ...newState };
   }
 };
 

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -36,7 +36,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
   // Iterate over each row in the worksheet and execute the row validators
   forEachCSVRow(worksheet, config, (rowParams, rowValidators) => {
     // Update the row state for each row
-    executeUpdateRowState(rowParams, rows);
+    updateRowState(rowParams, rows);
 
     // Execute the row validators and modify the errors
     rowValidators.forEach((rowValidator) => {
@@ -62,7 +62,7 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
       executeSetCellValue(cellParams, headerConfig, rows); // Mutates `rows`
 
       // Update the row state for each cell
-      executeUpdateRowState(rowParams, rows);
+      updateRowState(rowParams, rows);
     });
   });
 
@@ -170,7 +170,7 @@ export const forEachCSVRow = (
 };
 
 /**
- * Iterate over each cell in the CSV worksheet.
+ * Iterate over each cell in the CSV row.
  *
  * @param {CSVRow} worksheetRow - The worksheet row object
  * @param {number} rowIndex - The worksheet row index - 0 is the first data row
@@ -208,7 +208,7 @@ export const forEachCSVRowCell = (
 };
 
 /**
- * Execute the row state update.
+ * Update the row state.
  *
  * Note: This mutates the CSV row objects `mutableRows`.
  *
@@ -216,7 +216,7 @@ export const forEachCSVRowCell = (
  * @param {CSVRow[]} mutableRows - The mutable rows array
  * @returns {*} {void}
  */
-export const executeUpdateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
+export const updateRowState = (params: CSVRowParams, mutableRows: CSVRow[]) => {
   // Initialize the row if it does not exist
   if (!mutableRows[params.rowIndex] && params.row[CSVRowState]) {
     mutableRows[params.rowIndex] = {};

--- a/api/src/utils/csv-utils/csv-header-configs.test.ts
+++ b/api/src/utils/csv-utils/csv-header-configs.test.ts
@@ -1,15 +1,32 @@
 import { expect } from 'chai';
 import { z } from 'zod';
-import { CSVParams } from './csv-config-validation.interface';
+import { CSVParams, CSVRowState } from './csv-config-validation.interface';
 import {
   getDescriptionCellValidator,
   getLatitudeCellValidator,
   getLongitudeCellValidator,
   getTsnCellValidator,
+  updateCSVRowState,
   validateZodCell
 } from './csv-header-configs';
 
 describe('CSVHeaderConfigs', () => {
+  describe('updateRowState', () => {
+    it('should create the state in the row and add the new value', () => {
+      const row = { TEST: 'cellValue' };
+
+      updateCSVRowState(row, { stateValue: 'value' });
+
+      expect(row[CSVRowState]?.stateValue).to.equal('value');
+    });
+
+    it('should update the state in the row and add the new value', () => {
+      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'oldValue' } };
+
+      updateCSVRowState(row, { stateValue: 'newValue' });
+    });
+  });
+
   describe('validateZodCell', () => {
     it('should return an empty array if the cell is valid', () => {
       const result = validateZodCell({ cell: 123 } as any, z.number());

--- a/api/src/utils/csv-utils/csv-header-configs.test.ts
+++ b/api/src/utils/csv-utils/csv-header-configs.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { z } from 'zod';
-import { CSVParams, CSVRowState } from './csv-config-validation.interface';
+import { CSVParams, CSVRow, CSVRowState } from './csv-config-validation.interface';
 import {
   getDescriptionCellValidator,
   getLatitudeCellValidator,
@@ -24,6 +24,25 @@ describe('CSVHeaderConfigs', () => {
       const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'oldValue' } };
 
       updateCSVRowState(row, { stateValue: 'newValue' });
+
+      expect(row[CSVRowState]?.stateValue).to.equal('newValue');
+    });
+
+    it('should remove the state in the row', () => {
+      const row = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'oldValue' } };
+
+      updateCSVRowState(row, { stateValue: undefined });
+
+      expect(row[CSVRowState]?.stateValue).to.be.undefined;
+    });
+
+    it('should add additional state values', () => {
+      const row: CSVRow = { TEST: 'cellValue', [CSVRowState]: { stateValue: 'oldValue' } };
+
+      updateCSVRowState(row, { stateValue: 'newValue', additionalValue: 'value' });
+
+      expect(row[CSVRowState]?.stateValue).to.equal('newValue');
+      expect(row[CSVRowState]?.additionalValue).to.equal('value');
     });
   });
 

--- a/api/src/utils/csv-utils/csv-header-configs.ts
+++ b/api/src/utils/csv-utils/csv-header-configs.ts
@@ -1,10 +1,32 @@
 import { z } from 'zod';
 import { formatTimeString } from '../../services/import-services/utils/datetime';
-import { CSVCellSetter, CSVCellValidator, CSVError, CSVParams } from './csv-config-validation.interface';
+import {
+  CSVCellSetter,
+  CSVCellValidator,
+  CSVError,
+  CSVParams,
+  CSVRow,
+  CSVRowState
+} from './csv-config-validation.interface';
 
 // CSVOptionalCell - Optional cell config override
 type CSVOptionalCell = {
   optional: boolean;
+};
+
+/**
+ * Helper to update the CSV row state, if the state does not exist it will be created.
+ *
+ * Note: To remove a state value set it to `undefined`.
+ *
+ * @returns {*} {void}
+ */
+export const updateCSVRowState = (row: CSVRow, state: Record<string, any>) => {
+  if (!row[CSVRowState]) {
+    row[CSVRowState] = {};
+  }
+
+  row[CSVRowState] = { ...row[CSVRowState], ...state };
 };
 
 /**


### PR DESCRIPTION
## Description of Changes

- Adds row-level validation the the CSVConfig
- Adds row level state for additional validation metadata
- Slightly modifies existing Critter CSV import to use the CSVRowState

## Testing Notes

- Critter import should work as normal
- Check the Critter sex values are persisted (it now uses CSVRowState to store the uuid value for the sex_qualitative_option_id)
