### PR TITLE
BugFix: Fix observations data grid sampling control not filtering on search.

### DIFF
--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridEditCell.tsx
@@ -82,8 +82,8 @@ export const SampleSiteDataGridEditCell = <DataGridType extends GridValidRowMode
         // Update the cached sampling sites
         samplingInformationCache.updateCachedSamplingSites(options);
 
-        // Set the options for the autocomplete
-        setOptions(samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? []);
+        // Set the options for the autocomplete that matched the current search term
+        setOptions(options);
 
         setIsLoading(false);
       }, 500),
@@ -98,6 +98,10 @@ export const SampleSiteDataGridEditCell = <DataGridType extends GridValidRowMode
       fullWidth
       blurOnSelect
       handleHomeEndKeys
+      onOpen={() => {
+        // On opening the dropdown, set the options to all cached sampling sites
+        setOptions(() => samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? []);
+      }}
       loading={isLoading}
       value={currentOption}
       options={options}

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
@@ -69,6 +69,12 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    */
   const initCachedSamplingInformationRef = (params: { periods?: GetSamplingPeriod[] }) => {
     if (!params.periods?.length) {
+      // No periods to initialize with
+      return;
+    }
+
+    if (cachedSamplingInformationRef.current) {
+      // Already initialized
       return;
     }
 


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

 Fix observations data grid sampling control not filtering on search.

## Testing Notes

Sampling sites should filter when searching, and show all 'seen' sites when not searching (after opening the dropdown).
