### PR TITLE
BugFix: Fix Sampling Information Cache

### DIFF
--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/count/ObservationCountDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/count/ObservationCountDataGridEditCell.tsx
@@ -28,7 +28,7 @@ export const ObservationCountDataGridEditCell = <DataGridType extends GridValidR
   const codesContext = useCodesContext();
 
   const getResponseMetric = () => {
-    const currentTechnique = samplingInformationCache.getCurrentTechnique(dataGridProps);
+    const currentTechnique = samplingInformationCache.getCurrentTechnique(dataGridProps.value);
 
     if (!currentTechnique) {
       return null;

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridEditCell.tsx
@@ -54,7 +54,10 @@ export const SamplePeriodDataGridEditCell = <DataGridType extends GridValidRowMo
   );
   // The options for the autocomplete
   const [options, setOptions] = useState<SamplingInformationCachedPeriod[]>(
-    samplingInformationCache.getPeriodsForRow(dataGridProps.row.method_technique_id)
+    samplingInformationCache.getPeriodsForRow(
+      dataGridProps.row.survey_sample_site_id,
+      dataGridProps.row.method_technique_id
+    )
   );
   // The survey sample site id and method technique id for the current set of options
   // These are used to detect if the site or technique value in the data grid state has changed, and therefore the

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridEditCell.tsx
@@ -50,14 +50,17 @@ export const SamplePeriodDataGridEditCell = <DataGridType extends GridValidRowMo
 
   // The currently selected option
   const [currentOption, setCurrentOption] = useState<SamplingInformationCachedPeriod | null>(
-    samplingInformationCache.getCurrentPeriod(dataGridProps)
+    samplingInformationCache.getCurrentPeriod(dataGridProps.value)
   );
+  // The options for the autocomplete
   const [options, setOptions] = useState<SamplingInformationCachedPeriod[]>(
-    samplingInformationCache.getPeriodsForRow(
-      dataGridProps.row.survey_sample_site_id,
-      dataGridProps.row.method_technique_id
-    )
+    samplingInformationCache.getPeriodsForRow(dataGridProps.row.method_technique_id)
   );
+  // The survey sample site id and method technique id for the current set of options
+  // These are used to detect if the site or technique value in the data grid state has changed, and therefore the
+  // options of this control should be updated.
+  const [currentSiteId, setCurrentSiteId] = useState<number | null>(dataGridProps.row.survey_sample_site_id);
+  const [currentTechniqueId, setCurrentTechniqueId] = useState<number | null>(dataGridProps.row.method_technique_id);
   // Is control loading (search in progress)
   const [isLoading, setIsLoading] = useState(false);
 
@@ -99,11 +102,11 @@ export const SamplePeriodDataGridEditCell = <DataGridType extends GridValidRowMo
 
         samplingInformationCache.updateCachedSamplingPeriods(options);
 
-        const validOptions = samplingInformationCache.getPeriodsForRow(
-          dataGridProps.row.survey_sample_site_id,
-          dataGridProps.row.method_technique_id
-        );
+        const validOptions = samplingInformationCache.getPeriodsForRow(surveySampleSiteId, methodTechniqueId);
 
+        // Track the survey sample site id and method technique id for the current set of options
+        setCurrentSiteId(surveySampleSiteId);
+        setCurrentTechniqueId(methodTechniqueId);
         // Set the options for the autocomplete
         setOptions(validOptions);
 
@@ -129,8 +132,8 @@ export const SamplePeriodDataGridEditCell = <DataGridType extends GridValidRowMo
     }
 
     if (
-      currentOption?.survey_sample_site_id !== dataGridProps.row.survey_sample_site_id ||
-      currentOption?.method_technique_id !== dataGridProps.row.method_technique_id
+      currentSiteId !== dataGridProps.row.survey_sample_site_id ||
+      currentTechniqueId !== dataGridProps.row.method_technique_id
     ) {
       // If the site or technique has changed, then unset any selected period, and update the options to reflect the
       // valid periods for the new site and technique.
@@ -146,8 +149,8 @@ export const SamplePeriodDataGridEditCell = <DataGridType extends GridValidRowMo
       getOptions('');
     }
   }, [
-    currentOption?.method_technique_id,
-    currentOption?.survey_sample_site_id,
+    currentSiteId,
+    currentTechniqueId,
     getOptions,
     dataGridProps.row.method_technique_id,
     dataGridProps.row.survey_sample_site_id,

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridViewCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/periods/SamplePeriodDataGridViewCell.tsx
@@ -20,7 +20,7 @@ export const SamplePeriodDataGridViewCell = <DataGridType extends GridValidRowMo
 ) => {
   const { dataGridProps, samplingInformationCache, error } = props;
 
-  const label = samplingInformationCache.getCurrentPeriod(dataGridProps)?.label ?? '';
+  const label = samplingInformationCache.getCurrentPeriod(dataGridProps.value)?.label ?? '';
 
   return (
     <Typography

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridEditCell.tsx
@@ -50,10 +50,11 @@ export const SampleSiteDataGridEditCell = <DataGridType extends GridValidRowMode
 
   // The currently selected option
   const [currentOption, setCurrentOption] = useState<SamplingInformationCachedSite | null>(
-    samplingInformationCache.getCurrentSite(dataGridProps)
+    samplingInformationCache.getCurrentSite(dataGridProps.value)
   );
+
   const [options, setOptions] = useState<SamplingInformationCachedSite[]>(
-    samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? []
+    Object.values(samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? [])
   );
   // Is control loading (search in progress)
   const [isLoading, setIsLoading] = useState(false);
@@ -100,7 +101,7 @@ export const SampleSiteDataGridEditCell = <DataGridType extends GridValidRowMode
       handleHomeEndKeys
       onOpen={() => {
         // On opening the dropdown, set the options to all cached sampling sites
-        setOptions(() => samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? []);
+        setOptions(Object.values(samplingInformationCache.cachedSamplingInformationRef.current?.sites ?? []));
       }}
       loading={isLoading}
       value={currentOption}

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridViewCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/sites/SampleSiteDataGridViewCell.tsx
@@ -20,7 +20,7 @@ export const SampleSiteDataGridViewCell = <DataGridType extends GridValidRowMode
 ) => {
   const { dataGridProps, samplingInformationCache, error } = props;
 
-  const label = samplingInformationCache.getCurrentSite(dataGridProps)?.label ?? '';
+  const label = samplingInformationCache.getCurrentSite(dataGridProps.value)?.label ?? '';
 
   return (
     <Typography

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
@@ -90,7 +90,7 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
           return;
         }
 
-        const options: SamplingInformationCachedTechnique[] = response.techniques.map((item) => ({
+        const options = response.techniques.map((item) => ({
           method_technique_id: item.method_technique_id,
           survey_sample_site_id: surveySampleSiteId,
           method_response_metric_id: item.method_response_metric_id,

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
@@ -101,13 +101,10 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
         // Update the cached method techniques
         samplingInformationCache.updateCachedMethodTechniques(options);
 
-        // Get the latest valid options for the current row
-        const validOptions = samplingInformationCache.getTechniquesForRow(dataGridProps.row.survey_sample_site_id);
-
         // Track the survey sample site id for the current set of options
         setCurrentSiteId(surveySampleSiteId);
         // Set the options for the autocomplete
-        setOptions(validOptions);
+        setOptions(options);
 
         setIsLoading(false);
       }, 500),
@@ -148,6 +145,12 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
       fullWidth
       blurOnSelect
       handleHomeEndKeys
+      onOpen={() => {
+        // On opening the dropdown, set the options to all valid cached techniques
+        setOptions(
+          Object.values(samplingInformationCache.getTechniquesForRow(dataGridProps.row.survey_sample_site_id) ?? [])
+        );
+      }}
       loading={isLoading}
       value={currentOption}
       options={options}

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridEditCell.tsx
@@ -50,11 +50,16 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
 
   // The currently selected option
   const [currentOption, setCurrentOption] = useState<SamplingInformationCachedTechnique | null>(
-    samplingInformationCache.getCurrentTechnique(dataGridProps)
+    samplingInformationCache.getCurrentTechnique(dataGridProps.value)
   );
+  // The options for the autocomplete
   const [options, setOptions] = useState<SamplingInformationCachedTechnique[]>(
     samplingInformationCache.getTechniquesForRow(dataGridProps.row.survey_sample_site_id)
   );
+  // The survey sample site id for the current set of options
+  // These are used to detect if the site value in the data grid state has changed, and therefore the options of this
+  // control should be updated.
+  const [currentSiteId, setCurrentSiteId] = useState<number | null>(dataGridProps.row.survey_sample_site_id);
   // Is control loading (search in progress)
   const [isLoading, setIsLoading] = useState(false);
 
@@ -99,6 +104,8 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
         // Get the latest valid options for the current row
         const validOptions = samplingInformationCache.getTechniquesForRow(dataGridProps.row.survey_sample_site_id);
 
+        // Track the survey sample site id for the current set of options
+        setCurrentSiteId(surveySampleSiteId);
         // Set the options for the autocomplete
         setOptions(validOptions);
 
@@ -122,7 +129,7 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
       return;
     }
 
-    if (currentOption?.survey_sample_site_id !== dataGridProps.row.survey_sample_site_id) {
+    if (currentSiteId !== dataGridProps.row.survey_sample_site_id) {
       // If the site has changed, then unset any selected technique, and update the options to reflect the
       // valid techniques for the new site.
       setCurrentOption(null);
@@ -131,12 +138,7 @@ export const MethodTechniqueDataGridEditCell = <DataGridType extends GridValidRo
       // Trigger a search to get all of the techniques for the new site
       getOptions('');
     }
-  }, [
-    currentOption?.survey_sample_site_id,
-    getOptions,
-    dataGridProps.row.survey_sample_site_id,
-    samplingInformationCache
-  ]);
+  }, [currentSiteId, getOptions, dataGridProps.row.survey_sample_site_id, samplingInformationCache]);
 
   return (
     <Autocomplete

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridViewCell.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/techniques/MethodTechniqueDataGridViewCell.tsx
@@ -20,7 +20,7 @@ export const MethodTechniqueDataGridViewCell = <DataGridType extends GridValidRo
 ) => {
   const { dataGridProps, samplingInformationCache, error } = props;
 
-  const label = samplingInformationCache.getCurrentTechnique(dataGridProps)?.label ?? '';
+  const label = samplingInformationCache.getCurrentTechnique(dataGridProps.value)?.label ?? '';
 
   return (
     <Typography

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.test.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.test.tsx
@@ -1,0 +1,850 @@
+import { renderHook } from '@testing-library/react';
+import { useSamplingInformationCache } from 'features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache';
+import { GetSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
+
+// All combinations of period records
+const mockBasicPeriods: GetSamplingPeriod[] = [
+  {
+    // all data is not null
+    survey_sample_period_id: 31,
+    survey_id: 1,
+    survey_sample_site_id: 11,
+    method_technique_id: 21,
+    start_date: '2021-01-01',
+    start_time: '08:00:00',
+    end_date: '2022-01-01',
+    end_time: '12:00:00',
+    survey_sample_site: {
+      survey_sample_site_id: 11,
+      name: 'Site 1'
+    },
+    method_technique: {
+      method_technique_id: 21,
+      name: 'Technique 1',
+      description: 'Description 1',
+      method_response_metric_id: 41
+    }
+  },
+  {
+    // method technique data is null
+    survey_sample_period_id: 32,
+    survey_id: 1,
+    survey_sample_site_id: 11,
+    method_technique_id: null,
+    start_date: '2021-01-01',
+    start_time: '08:00:00',
+    end_date: '2022-01-01',
+    end_time: '12:00:00',
+    survey_sample_site: {
+      survey_sample_site_id: 11,
+      name: 'Site 1'
+    },
+    method_technique: null
+  },
+  {
+    // sample site data is null
+    survey_sample_period_id: 33,
+    survey_id: 1,
+    survey_sample_site_id: null,
+    method_technique_id: 21,
+    start_date: '2021-01-01',
+    start_time: '08:00:00',
+    end_date: '2022-01-01',
+    end_time: '12:00:00',
+    survey_sample_site: null,
+    method_technique: {
+      method_technique_id: 21,
+      name: 'Technique 1',
+      description: 'Description 1',
+      method_response_metric_id: 41
+    }
+  },
+  {
+    // period data is null
+    survey_sample_period_id: 34,
+    survey_id: 1,
+    survey_sample_site_id: null,
+    method_technique_id: 21,
+    start_date: null,
+    start_time: null,
+    end_date: null,
+    end_time: null,
+    survey_sample_site: null,
+    method_technique: {
+      method_technique_id: 21,
+      name: 'Technique 1',
+      description: 'Description 1',
+      method_response_metric_id: 41
+    }
+  },
+  {
+    // sample site and period data is null
+    survey_sample_period_id: 35,
+    survey_id: 1,
+    survey_sample_site_id: null,
+    method_technique_id: 21,
+    start_date: null,
+    start_time: null,
+    end_date: null,
+    end_time: null,
+    survey_sample_site: null,
+    method_technique: {
+      method_technique_id: 21,
+      name: 'Technique 1',
+      description: 'Description 1',
+      method_response_metric_id: 41
+    }
+  },
+  {
+    // method technique and period data is null
+    survey_sample_period_id: 36,
+    survey_id: 1,
+    survey_sample_site_id: 11,
+    method_technique_id: null,
+    start_date: '2021-01-01',
+    start_time: '08:00:00',
+    end_date: '2022-01-01',
+    end_time: '12:00:00',
+    survey_sample_site: {
+      survey_sample_site_id: 11,
+      name: 'Site 1'
+    },
+    method_technique: null
+  },
+  {
+    // sample site and method technique data is null
+    survey_sample_period_id: 37,
+    survey_id: 1,
+    survey_sample_site_id: null,
+    method_technique_id: null,
+    start_date: '2021-01-01',
+    start_time: '08:00:00',
+    end_date: '2022-01-01',
+    end_time: '12:00:00',
+    survey_sample_site: null,
+    method_technique: null
+  }
+];
+
+describe('useSamplingInformationCache', () => {
+  describe('useSamplingInformationCache', () => {
+    it('initialized with undefined ref', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current).toBeUndefined();
+    });
+  });
+
+  describe('initCachedSamplingInformationRef', () => {
+    it('initializes empty when no periods provided', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: [] });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current).toEqual({
+        sites: {},
+        techniqueIndex: {},
+        techniques: {},
+        periodIndex: {},
+        periods: {}
+      });
+    });
+
+    it('initializes the provided periods', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+    });
+  });
+
+  describe('updateCachedSamplingSites', () => {
+    it('adds new sites', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      // Assert the initial state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+
+      samplingInformationCache.current.updateCachedSamplingSites([
+        // New
+        {
+          survey_sample_site_id: 120,
+          label: 'Site 2',
+          value: 120
+        },
+        // New
+        {
+          survey_sample_site_id: 130,
+          label: 'Site 3',
+          value: 130
+        },
+        // Existing
+        {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      ]);
+
+      // Assert updated state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        // Existing
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        },
+        // New
+        120: {
+          survey_sample_site_id: 120,
+          label: 'Site 2',
+          value: 120
+        },
+        // New
+        130: {
+          survey_sample_site_id: 130,
+          label: 'Site 3',
+          value: 130
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+    });
+  });
+
+  describe('updateCachedMethodTechniques', () => {
+    it('adds new techniques', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      // Assert the initial state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+
+      samplingInformationCache.current.updateCachedMethodTechniques([
+        // Existing
+        {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          survey_sample_site_id: 11,
+          label: 'Technique 1',
+          value: 21
+        },
+        // New (for existing site)
+        {
+          method_technique_id: 240,
+          method_response_metric_id: 44,
+          survey_sample_site_id: 11,
+          label: 'Technique 4',
+          value: 240
+        },
+        // New (for new site)
+        {
+          method_technique_id: 250,
+          method_response_metric_id: 45,
+          survey_sample_site_id: 140,
+          label: 'Technique 5',
+          value: 250
+        }
+      ]);
+
+      // Assert updated state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        // Existing + New (for existing site)
+        '11': new Set([21, 240]),
+        // New (for new site)
+        '140': new Set([250])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        // Existing
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        },
+        // New (for existing site)
+        240: {
+          method_technique_id: 240,
+          method_response_metric_id: 44,
+          label: 'Technique 4',
+          value: 240
+        },
+        // New (for new site)
+        250: {
+          method_technique_id: 250,
+          method_response_metric_id: 45,
+          label: 'Technique 5',
+          value: 250
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+    });
+  });
+
+  describe('updateCachedSamplingPeriods', () => {
+    it('adds new periods', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      // Assert the initial state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        '11-21': new Set([31])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        36: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 36,
+          value: 36
+        },
+        37: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 37,
+          value: 37
+        }
+      });
+
+      samplingInformationCache.current.updateCachedSamplingPeriods([
+        {
+          // Existing
+          survey_sample_period_id: 31,
+          survey_sample_site_id: 11,
+          method_technique_id: 21,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        {
+          // New (for existing site and technique)
+          survey_sample_period_id: 340,
+          survey_sample_site_id: 11,
+          method_technique_id: 21,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 340
+        },
+        {
+          // New (for existing site and new technique)
+          survey_sample_period_id: 350,
+          survey_sample_site_id: 11,
+          method_technique_id: 240,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 350
+        },
+        {
+          // New (for new site and existing technique)
+          survey_sample_period_id: 360,
+          survey_sample_site_id: 140,
+          method_technique_id: 210,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 360
+        },
+        {
+          // New (for new site and new technique)
+          survey_sample_period_id: 370,
+          survey_sample_site_id: 150,
+          method_technique_id: 25,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 370
+        }
+      ]);
+
+      // Assert updated state
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.sites).toEqual({
+        11: {
+          survey_sample_site_id: 11,
+          label: 'Site 1',
+          value: 11
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniqueIndex).toEqual({
+        '11': new Set([21])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.techniques).toEqual({
+        21: {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periodIndex).toEqual({
+        // Existing + New (for existing site and technique)
+        '11-21': new Set([31, 340]),
+        // New (for existing site and new technique)
+        '11-240': new Set([350]),
+        // New (for new site and existing technique)
+        '140-210': new Set([360]),
+        // New (for new site and new technique)
+        '150-25': new Set([370])
+      });
+
+      expect(samplingInformationCache.current.cachedSamplingInformationRef.current?.periods).toEqual({
+        // Existing
+        31: {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        },
+        32: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 32,
+          value: 32
+        },
+        33: {
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          survey_sample_period_id: 33,
+          value: 33
+        },
+        // New (for existing site and technique)
+        340: {
+          survey_sample_period_id: 340,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 340
+        },
+        // New (for existing site and new technique)
+        350: {
+          survey_sample_period_id: 350,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 350
+        },
+        36: {
+          survey_sample_period_id: 36,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 36
+        },
+        // New (for new site and existing technique)
+        360: {
+          survey_sample_period_id: 360,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 360
+        },
+        37: {
+          survey_sample_period_id: 37,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 37
+        },
+        // New (for new site and new technique)
+        370: {
+          survey_sample_period_id: 370,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 370
+        }
+      });
+    });
+  });
+
+  describe('getCurrentSite', () => {
+    it('returns an existing site', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentSite(11);
+
+      expect(response).toEqual({
+        survey_sample_site_id: 11,
+        label: 'Site 1',
+        value: 11
+      });
+    });
+
+    it('returns null if the site does not exist', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentSite(999);
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('getCurrentTechnique', () => {
+    it('returns an existing technique', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentTechnique(21);
+
+      expect(response).toEqual({
+        method_technique_id: 21,
+        method_response_metric_id: 41,
+        label: 'Technique 1',
+        value: 21
+      });
+    });
+
+    it('returns null if the technique does not exist', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentTechnique(999);
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('getCurrentPeriod', () => {
+    it('returns an existing period', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentPeriod(31);
+
+      expect(response).toEqual({
+        survey_sample_period_id: 31,
+        label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+        value: 31
+      });
+    });
+
+    it('returns null if the period does not exist', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getCurrentPeriod(999);
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('getTechniquesForRow', () => {
+    it('returns an array of matching techniques', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getTechniquesForRow(11);
+
+      expect(response).toEqual([
+        {
+          method_technique_id: 21,
+          method_response_metric_id: 41,
+          label: 'Technique 1',
+          value: 21
+        }
+      ]);
+    });
+
+    it('returns an empty array if no techniques match', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getTechniquesForRow(999);
+
+      expect(response).toEqual([]);
+    });
+  });
+
+  describe('getPeriodsForRow', () => {
+    it('returns an array of matching periods', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getPeriodsForRow(11, 21);
+
+      expect(response).toEqual([
+        {
+          survey_sample_period_id: 31,
+          label: '2021-01-01 08:00:00 - 2022-01-01 12:00:00',
+          value: 31
+        }
+      ]);
+    });
+
+    it('returns an empty array if no periods match', () => {
+      const { result: samplingInformationCache } = renderHook(() => useSamplingInformationCache());
+
+      samplingInformationCache.current.initCachedSamplingInformationRef({ periods: mockBasicPeriods });
+
+      const response = samplingInformationCache.current.getPeriodsForRow(999, 999);
+
+      expect(response).toEqual([]);
+    });
+  });
+});

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
@@ -59,15 +59,22 @@ export type SamplingInformationCache = {
   cachedSamplingInformationRef: MutableRefObject<SamplingInformationCacheRef | undefined>;
   initCachedSamplingInformationRef: (params: { periods?: GetSamplingPeriod[] }) => void;
   updateCachedSamplingSites: (sites: SamplingInformationCachedSite[]) => void;
-  updateCachedMethodTechniques: (techniques: SamplingInformationCachedTechnique[]) => void;
-  updateCachedSamplingPeriods: (periods: SamplingInformationCachedPeriod[]) => void;
+  updateCachedMethodTechniques: (
+    techniques: (SamplingInformationCachedTechnique & { survey_sample_site_id: number | null })[]
+  ) => void;
+  updateCachedSamplingPeriods: (
+    periods: (SamplingInformationCachedPeriod & {
+      survey_sample_site_id: number | null;
+      method_technique_id: number | null;
+    })[]
+  ) => void;
   getCurrentSite: (surveySampleSiteId: number) => SamplingInformationCachedSite | null;
   getCurrentTechnique: (methodTechniqueId: number) => SamplingInformationCachedTechnique | null;
   getCurrentPeriod: (surveySamplePeriodId: number) => SamplingInformationCachedPeriod | null;
-  getTechniquesForRow: (surveySampleSiteId?: number | null) => SamplingInformationCachedTechnique[];
+  getTechniquesForRow: (surveySampleSiteId: number | null) => SamplingInformationCachedTechnique[];
   getPeriodsForRow: (
-    surveySampleSiteId?: number | null,
-    methodTechniqueId?: number | null
+    surveySampleSiteId: number | null,
+    methodTechniqueId: number | null
   ) => SamplingInformationCachedPeriod[];
 };
 
@@ -193,11 +200,11 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
   /**
    * Update the cache with new method techniques. Will ignore techniques that are already in the cache.
    *
-   * @param {SamplingInformationCachedTechnique[]} techniques
+   * @param {((SamplingInformationCachedTechnique & { survey_sample_site_id: number | null })[])} techniques
    * @return {*}
    */
   const updateCachedMethodTechniques = (
-    techniques: (SamplingInformationCachedTechnique & { survey_sample_site_id?: number })[]
+    techniques: (SamplingInformationCachedTechnique & { survey_sample_site_id: number | null })[]
   ) => {
     if (!cachedSamplingInformationRef.current) {
       return;
@@ -209,7 +216,9 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
     for (const technique of techniques) {
       if (!techniquesMap[technique.method_technique_id]) {
         // If the technique is not already in the map, add it
-        techniquesMap[technique.method_technique_id] = technique;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { survey_sample_site_id, ...rest } = technique;
+        techniquesMap[technique.method_technique_id] = rest;
       }
 
       if (technique.survey_sample_site_id) {
@@ -233,11 +242,17 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
   /**
    * Update the cache with new sampling periods. Will ignore periods that are already in the cache.
    *
-   * @param {SamplingInformationCachedPeriod[]} periods
+   * @param {((SamplingInformationCachedPeriod & {
+   *       survey_sample_site_id: number | null;
+   *       method_technique_id: number | null;
+   *     })[])} periods
    * @return {*}
    */
   const updateCachedSamplingPeriods = (
-    periods: (SamplingInformationCachedPeriod & { survey_sample_site_id?: number; method_technique_id?: number })[]
+    periods: (SamplingInformationCachedPeriod & {
+      survey_sample_site_id: number | null;
+      method_technique_id: number | null;
+    })[]
   ) => {
     if (!cachedSamplingInformationRef.current) {
       return;
@@ -249,7 +264,9 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
     for (const period of periods) {
       if (!periodsMap[period.survey_sample_period_id]) {
         // If the period is not already in the map, add it
-        periodsMap[period.survey_sample_period_id] = period;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { survey_sample_site_id, method_technique_id, ...rest } = period;
+        periodsMap[period.survey_sample_period_id] = rest;
       }
 
       if (period.survey_sample_site_id && period.method_technique_id) {
@@ -273,51 +290,49 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
   /**
    * Return the site object for the provided site id.
    *
-   * @param {(number | null)} [siteId]
+   * @param {(number | null)} surveySampleSiteId
    * @return {*}  {(SamplingInformationCachedSite | null)}
    */
-  const findSite = (siteId?: number | null): SamplingInformationCachedSite | null => {
-    if (!siteId) {
+  const findSite = (surveySampleSiteId: number | null): SamplingInformationCachedSite | null => {
+    if (!surveySampleSiteId) {
       return null;
     }
 
-    return cachedSamplingInformationRef.current?.sites[siteId] ?? null;
+    return cachedSamplingInformationRef.current?.sites[surveySampleSiteId] ?? null;
   };
 
   /**
    * Return the technique object for the provided technique id.
    *
-   * @param {(number | null)} [techniqueId]
+   * @param {(number | null)} techniqueId
    * @return {*}  {(SamplingInformationCachedTechnique | null)}
    */
-  const findTechnique = (techniqueId?: number | null): SamplingInformationCachedTechnique | null => {
-    if (!techniqueId) {
+  const findTechnique = (methodTechniqueId: number | null): SamplingInformationCachedTechnique | null => {
+    if (!methodTechniqueId) {
       return null;
     }
 
-    return cachedSamplingInformationRef.current?.techniques[techniqueId] ?? null;
+    return cachedSamplingInformationRef.current?.techniques[methodTechniqueId] ?? null;
   };
 
   /**
    * Return the period object for the provided period id.
    *
-   * @param {(number | null)} [periodId]
+   * @param {(number | null)} surveySamplePeriodId
    * @return {*}  {(SamplingInformationCachedPeriod | null)}
    */
-  const findPeriod = (periodId?: number | null): SamplingInformationCachedPeriod | null => {
-    if (!periodId) {
+  const findPeriod = (surveySamplePeriodId: number | null): SamplingInformationCachedPeriod | null => {
+    if (!surveySamplePeriodId) {
       return null;
     }
 
-    return cachedSamplingInformationRef.current?.periods[periodId] ?? null;
+    return cachedSamplingInformationRef.current?.periods[surveySamplePeriodId] ?? null;
   };
 
   /**
    * Get the currently selected site for the row.
    *
-   * @template DataGridType
-   * @param {GridRenderCellParams<DataGridType>} dataGridProps
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
+   * @param {number} surveySampleSiteId
    * @return {*}  {(SamplingInformationCachedSite | null)}
    */
   const getCurrentSite = (surveySampleSiteId: number): SamplingInformationCachedSite | null => {
@@ -347,10 +362,10 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
   /**
    * Get all valid techniques for the currently selected site.
    *
-   * @param {(number | null)} [surveySampleSiteId]
+   * @param {(number | null)} surveySampleSiteId
    * @return {*}  {SamplingInformationCachedTechnique[]}
    */
-  const getTechniquesForRow = (surveySampleSiteId?: number | null): SamplingInformationCachedTechnique[] => {
+  const getTechniquesForRow = (surveySampleSiteId: number | null): SamplingInformationCachedTechnique[] => {
     if (!surveySampleSiteId) {
       return [];
     }
@@ -363,20 +378,20 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
 
     // Get all techniques for the matching technique ids
     return methodTechniqueIds
-      .map((techniqueId) => cachedSamplingInformationRef.current?.techniques[techniqueId])
+      .map((methodTechniqueId) => cachedSamplingInformationRef.current?.techniques[methodTechniqueId])
       .filter((value): value is SamplingInformationCachedTechnique => value !== undefined);
   };
 
   /**
    * Get all valid periods for the currently selected site and technique.
    *
-   * @param {(number | null)} [surveySampleSiteId]
-   * @param {(number | null)} [methodTechniqueId]
+   * @param {(number | null)} surveySampleSiteId
+   * @param {(number | null)} methodTechniqueId
    * @return {*}  {SamplingInformationCachedPeriod[]}
    */
   const getPeriodsForRow = (
-    surveySampleSiteId?: number | null,
-    methodTechniqueId?: number | null
+    surveySampleSiteId: number | null,
+    methodTechniqueId: number | null
   ): SamplingInformationCachedPeriod[] => {
     if (!surveySampleSiteId || !methodTechniqueId) {
       return [];
@@ -398,21 +413,21 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
   /**
    * Get a key for the site technique index.
    *
-   * @param {(number | null)} [surveySampleSiteId]
+   * @param {(number | null)} surveySampleSiteId
    * @return {*}  {IndexKey}
    */
-  const _getSiteTechniqueKey = (surveySampleSiteId?: number | null): IndexKey => {
+  const _getSiteTechniqueKey = (surveySampleSiteId: number | null): IndexKey => {
     return `${surveySampleSiteId ?? null}`;
   };
 
   /**
    * Get a key for the technique period index.
    *
-   * @param {(number | null)} [surveySampleSiteId]
-   * @param {(number | null)} [methodTechniqueId]
+   * @param {(number | null)} surveySampleSiteId
+   * @param {(number | null)} methodTechniqueId
    * @return {*}  {IndexKey}
    */
-  const _getTechniquePeriodKey = (surveySampleSiteId?: number | null, methodTechniqueId?: number | null): IndexKey => {
+  const _getTechniquePeriodKey = (surveySampleSiteId: number | null, methodTechniqueId: number | null): IndexKey => {
     return `${surveySampleSiteId ?? null}-${methodTechniqueId ?? null}`;
   };
 

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
@@ -1,32 +1,58 @@
-import { GridRenderCellParams, GridValidRowModel } from '@mui/x-data-grid';
-import { IAutocompleteDataGridOption } from 'components/data-grid/autocomplete/AutocompleteDataGrid.interface';
+import { IAutocompleteFieldOption } from 'components/fields/AutocompleteField';
 import { GetSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
 import { MutableRefObject, useRef } from 'react';
 import { getDateTimeLabel } from 'utils/datetime';
 
-export type SamplingInformationCachedSite = IAutocompleteDataGridOption<number> & {
+export type SamplingInformationCachedSite = IAutocompleteFieldOption<number> & {
   survey_sample_site_id: number;
 };
 
-export type SamplingInformationCachedTechnique = IAutocompleteDataGridOption<number> & {
+export type SamplingInformationCachedTechnique = IAutocompleteFieldOption<number> & {
   method_technique_id: number;
-  survey_sample_site_id: number | null;
   method_response_metric_id: number;
 };
 
-export type SamplingInformationCachedPeriod = IAutocompleteDataGridOption<number> & {
+export type SamplingInformationCachedPeriod = IAutocompleteFieldOption<number> & {
   survey_sample_period_id: number;
-  survey_sample_site_id: number | null;
-  method_technique_id: number | null;
 };
 
+export type IndexKey = string;
+
 export type SamplingInformationCacheRef = {
-  // A unique list of sample sites
-  sites: SamplingInformationCachedSite[];
-  // A unique list of techniques
-  techniques: SamplingInformationCachedTechnique[];
-  // A unique list of sampling periods
-  periods: SamplingInformationCachedPeriod[];
+  /**
+   * A unique list of sample sites mapped by survey sample site id.
+   *
+   * @type {Record<number, SamplingInformationCachedSite>}
+   */
+  sites: Record<number, SamplingInformationCachedSite>;
+  /**
+   * A mapping of method technique keys to sample site ids.
+   *
+   * Note: The key is the site id.
+   *
+   * @type {Record<IndexKey, Set<number>>}
+   */
+  techniqueIndex: Record<IndexKey, Set<number>>;
+  /**
+   * A unique list of method techniques mapped by method technique id.
+   *
+   * @type {Record<number, SamplingInformationCachedTechnique>}
+   */
+  techniques: Record<number, SamplingInformationCachedTechnique>;
+  /**
+   * A mapping of method technique keys to sample period ids.
+   *
+   * Note: The key is a combination of the site id and technique id.
+   *
+   * @type {Record<IndexKey, Set<number>>}
+   */
+  periodIndex: Record<IndexKey, Set<number>>;
+  /**
+   * A unique list of sampling periods mapped by survey sample period id.
+   *
+   * @type {Record<number, SamplingInformationCachedPeriod>}
+   */
+  periods: Record<number, SamplingInformationCachedPeriod>;
 };
 
 export type SamplingInformationCache = {
@@ -35,19 +61,13 @@ export type SamplingInformationCache = {
   updateCachedSamplingSites: (sites: SamplingInformationCachedSite[]) => void;
   updateCachedMethodTechniques: (techniques: SamplingInformationCachedTechnique[]) => void;
   updateCachedSamplingPeriods: (periods: SamplingInformationCachedPeriod[]) => void;
-  getCurrentSite: <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ) => SamplingInformationCachedSite | null;
-  getCurrentTechnique: <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ) => SamplingInformationCachedTechnique | null;
-  getCurrentPeriod: <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ) => SamplingInformationCachedPeriod | null;
-  getTechniquesForRow: (survey_sample_site_id: number | undefined) => SamplingInformationCachedTechnique[];
+  getCurrentSite: (surveySampleSiteId: number) => SamplingInformationCachedSite | null;
+  getCurrentTechnique: (methodTechniqueId: number) => SamplingInformationCachedTechnique | null;
+  getCurrentPeriod: (surveySamplePeriodId: number) => SamplingInformationCachedPeriod | null;
+  getTechniquesForRow: (surveySampleSiteId?: number | null) => SamplingInformationCachedTechnique[];
   getPeriodsForRow: (
-    survey_sample_site_id: number | undefined,
-    method_technique_id: number | undefined
+    surveySampleSiteId?: number | null,
+    methodTechniqueId?: number | null
   ) => SamplingInformationCachedPeriod[];
 };
 
@@ -69,68 +89,74 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    */
   const initCachedSamplingInformationRef = (params: { periods?: GetSamplingPeriod[] }) => {
     if (!params.periods?.length) {
-      // No periods to initialize with
+      cachedSamplingInformationRef.current = {
+        sites: {},
+        techniqueIndex: {},
+        techniques: {},
+        periodIndex: {},
+        periods: {}
+      };
+
       return;
     }
 
-    if (cachedSamplingInformationRef.current) {
-      // Already initialized
-      return;
-    }
+    const sitesMap: Record<string, SamplingInformationCachedSite> = {};
+    const techniqueIndex: Record<string, Set<number>> = {};
+    const techniquesMap: Record<string, SamplingInformationCachedTechnique> = {};
+    const periodIndex: Record<string, Set<number>> = {};
+    const periodsMap: Record<string, SamplingInformationCachedPeriod> = {};
 
-    const sitesMap = new Map<number, SamplingInformationCachedSite>();
     params.periods.forEach((period) => {
-      if (!period.survey_sample_site_id || !period.survey_sample_site) {
-        return;
+      if (_isValidSamplingSite(period) && !sitesMap[period.survey_sample_site_id]) {
+        sitesMap[period.survey_sample_site_id] = {
+          survey_sample_site_id: period.survey_sample_site_id,
+          // Satisfy the IAutocompleteDataGridOption interface
+          value: period.survey_sample_site_id,
+          label: period.survey_sample_site.name
+        };
       }
 
-      sitesMap.set(period.survey_sample_site.survey_sample_site_id, {
-        survey_sample_site_id: period.survey_sample_site.survey_sample_site_id,
-        // Satisfy the IAutocompleteDataGridOption interface
-        value: period.survey_sample_site_id,
-        label: period.survey_sample_site.name
-      });
-    });
-    const sites = Array.from(sitesMap.values());
+      if (_isValidMethodTechnique(period) && !techniquesMap[period.method_technique_id]) {
+        techniquesMap[period.method_technique_id] = {
+          method_technique_id: period.method_technique_id,
+          method_response_metric_id: period.method_technique.method_response_metric_id,
+          // Satisfy the IAutocompleteDataGridOption interface
+          value: period.method_technique.method_technique_id,
+          label: period.method_technique.name
+        };
 
-    const techniquesMap = new Map<number, SamplingInformationCachedTechnique>();
-    params.periods.forEach((period) => {
-      if (!period.method_technique_id || !period.method_technique) {
-        return;
+        if (period.survey_sample_site_id) {
+          // If the technique has a parent site, ensure it is indexed
+          techniqueIndex[_getSiteTechniqueKey(period.survey_sample_site_id)] = (
+            techniqueIndex[_getSiteTechniqueKey(period.survey_sample_site_id)] ?? new Set<number>()
+          ).add(period.method_technique.method_technique_id);
+        }
       }
 
-      techniquesMap.set(period.method_technique.method_technique_id, {
-        method_technique_id: period.method_technique.method_technique_id,
-        survey_sample_site_id: period.survey_sample_site?.survey_sample_site_id ?? null, // Default to null if not available
-        method_response_metric_id: period.method_technique.method_response_metric_id,
-        // Satisfy the IAutocompleteDataGridOption interface
-        value: period.method_technique_id,
-        label: period.method_technique.name
-      });
-    });
-    const techniques = Array.from(techniquesMap.values());
+      if (_isValidSamplingPeriod(period) && !periodsMap[period.survey_sample_period_id]) {
+        periodsMap[period.survey_sample_period_id] = {
+          survey_sample_period_id: period.survey_sample_period_id,
+          // Satisfy the IAutocompleteDataGridOption interface
+          value: period.survey_sample_period_id,
+          label: getDateTimeLabel(period.start_date, period.start_time, period.end_date, period.end_time)
+        };
 
-    const periodsMap = new Map<number, SamplingInformationCachedPeriod>();
-    params.periods.forEach((period) => {
-      if (!period.start_date || !period.end_date) {
-        return;
+        if (period.survey_sample_period_id && period.method_technique_id) {
+          // If the period has a parent technique, ensure it is indexed
+          periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] = (
+            periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] ??
+            new Set<number>()
+          ).add(period.survey_sample_period_id);
+        }
       }
-
-      periodsMap.set(period.survey_sample_period_id, {
-        survey_sample_period_id: period.survey_sample_period_id,
-        survey_sample_site_id: period.survey_sample_site?.survey_sample_site_id ?? null,
-        method_technique_id: period.method_technique?.method_technique_id ?? null,
-        // Satisfy the IAutocompleteDataGridOption interface
-        value: period.survey_sample_period_id,
-        label: getDateTimeLabel(period.start_date, period.start_time, period.end_date, period.end_time)
-      });
     });
-    const periods = Array.from(periodsMap.values());
 
     cachedSamplingInformationRef.current = {
-      sites,
-      techniques,
-      periods
+      sites: sitesMap,
+      techniqueIndex: techniqueIndex,
+      techniques: techniquesMap,
+      periodIndex: periodIndex,
+      periods: periodsMap
     };
   };
 
@@ -145,25 +171,21 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
       return;
     }
 
-    const newSites = [];
+    const newSitesMap = cachedSamplingInformationRef.current.sites;
 
-    for (const site of sites ?? []) {
-      if (
-        cachedSamplingInformationRef.current.sites.findIndex(
-          (item) => item.survey_sample_site_id === site.survey_sample_site_id
-        ) !== -1
-      ) {
-        // The site is already in the cache
-        continue;
+    for (const site of sites) {
+      if (!newSitesMap[site.survey_sample_site_id]) {
+        // If the site is not already in the map, add it
+        newSitesMap[site.survey_sample_site_id] = site;
       }
-
-      newSites.push(site);
     }
 
     // Update the cache
     cachedSamplingInformationRef.current = {
-      sites: [...cachedSamplingInformationRef.current.sites, ...newSites],
+      sites: newSitesMap,
+      techniqueIndex: cachedSamplingInformationRef.current.techniqueIndex,
       techniques: cachedSamplingInformationRef.current.techniques,
+      periodIndex: cachedSamplingInformationRef.current.periodIndex,
       periods: cachedSamplingInformationRef.current.periods
     };
   };
@@ -174,30 +196,36 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    * @param {SamplingInformationCachedTechnique[]} techniques
    * @return {*}
    */
-  const updateCachedMethodTechniques = (techniques: SamplingInformationCachedTechnique[]) => {
+  const updateCachedMethodTechniques = (
+    techniques: (SamplingInformationCachedTechnique & { survey_sample_site_id?: number })[]
+  ) => {
     if (!cachedSamplingInformationRef.current) {
       return;
     }
 
-    const newTechniques = [];
+    const techniquesMap = cachedSamplingInformationRef.current.techniques;
+    const techniquesIndex = cachedSamplingInformationRef.current.techniqueIndex;
 
-    for (const technique of techniques ?? []) {
-      if (
-        cachedSamplingInformationRef.current.techniques.findIndex(
-          (item) => item.method_technique_id === technique.method_technique_id
-        ) !== -1
-      ) {
-        // The technique is already in the cache
-        continue;
+    for (const technique of techniques) {
+      if (!techniquesMap[technique.method_technique_id]) {
+        // If the technique is not already in the map, add it
+        techniquesMap[technique.method_technique_id] = technique;
       }
 
-      newTechniques.push(technique);
+      if (technique.survey_sample_site_id) {
+        // If the technique has a parent site, ensure it is indexed
+        techniquesIndex[_getSiteTechniqueKey(technique.survey_sample_site_id)] = (
+          techniquesIndex[_getSiteTechniqueKey(technique.survey_sample_site_id)] ?? new Set()
+        ).add(technique.method_technique_id);
+      }
     }
 
     // Update the cache
     cachedSamplingInformationRef.current = {
       sites: cachedSamplingInformationRef.current.sites,
-      techniques: [...cachedSamplingInformationRef.current.techniques, ...newTechniques],
+      techniqueIndex: techniquesIndex,
+      techniques: techniquesMap,
+      periodIndex: cachedSamplingInformationRef.current.periodIndex,
       periods: cachedSamplingInformationRef.current.periods
     };
   };
@@ -208,60 +236,81 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    * @param {SamplingInformationCachedPeriod[]} periods
    * @return {*}
    */
-  const updateCachedSamplingPeriods = (periods: SamplingInformationCachedPeriod[]) => {
+  const updateCachedSamplingPeriods = (
+    periods: (SamplingInformationCachedPeriod & { survey_sample_site_id?: number; method_technique_id?: number })[]
+  ) => {
     if (!cachedSamplingInformationRef.current) {
       return;
     }
 
-    const newPeriods = [];
+    const periodsMap = cachedSamplingInformationRef.current.periods;
+    const periodIndex = cachedSamplingInformationRef.current.periodIndex;
 
-    for (const period of periods ?? []) {
-      if (
-        cachedSamplingInformationRef.current.periods.findIndex(
-          (item) => item.survey_sample_period_id === period.survey_sample_period_id
-        ) !== -1
-      ) {
-        // The period is already in the cache
-        continue;
+    for (const period of periods) {
+      if (!periodsMap[period.survey_sample_period_id]) {
+        // If the period is not already in the map, add it
+        periodsMap[period.survey_sample_period_id] = period;
       }
 
-      newPeriods.push(period);
+      if (period.survey_sample_site_id && period.method_technique_id) {
+        // If the technique has a parent site, ensure it is indexed
+        periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] = (
+          periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] ?? new Set()
+        ).add(period.survey_sample_period_id);
+      }
     }
 
     // Update the cache
     cachedSamplingInformationRef.current = {
       sites: cachedSamplingInformationRef.current.sites,
+      techniqueIndex: cachedSamplingInformationRef.current.techniqueIndex,
       techniques: cachedSamplingInformationRef.current.techniques,
-      periods: [...cachedSamplingInformationRef.current.periods, ...newPeriods]
+      periodIndex: periodIndex,
+      periods: periodsMap
     };
   };
 
   /**
    * Return the site object for the provided site id.
    *
-   * @param {(number | undefined)} siteId
-   * @param {(SamplingInformationCacheRef | undefined)} cache
+   * @param {(number | null)} [siteId]
+   * @return {*}  {(SamplingInformationCachedSite | null)}
    */
-  const findSite = (siteId: number | undefined) =>
-    cachedSamplingInformationRef.current?.sites.find((site) => site.survey_sample_site_id === siteId);
+  const findSite = (siteId?: number | null): SamplingInformationCachedSite | null => {
+    if (!siteId) {
+      return null;
+    }
+
+    return cachedSamplingInformationRef.current?.sites[siteId] ?? null;
+  };
 
   /**
    * Return the technique object for the provided technique id.
    *
-   * @param {(number | undefined)} techniqueId
-   * @param {(SamplingInformationCacheRef | undefined)} cache
+   * @param {(number | null)} [techniqueId]
+   * @return {*}  {(SamplingInformationCachedTechnique | null)}
    */
-  const findTechnique = (techniqueId: number | undefined) =>
-    cachedSamplingInformationRef.current?.techniques.find((technique) => technique.method_technique_id === techniqueId);
+  const findTechnique = (techniqueId?: number | null): SamplingInformationCachedTechnique | null => {
+    if (!techniqueId) {
+      return null;
+    }
+
+    return cachedSamplingInformationRef.current?.techniques[techniqueId] ?? null;
+  };
 
   /**
    * Return the period object for the provided period id.
    *
-   * @param {(number | undefined)} periodId
-   * @param {(SamplingInformationCacheRef | undefined)} cache
+   * @param {(number | null)} [periodId]
+   * @return {*}  {(SamplingInformationCachedPeriod | null)}
    */
-  const findPeriod = (periodId: number | undefined) =>
-    cachedSamplingInformationRef.current?.periods.find((period) => period.survey_sample_period_id === periodId);
+  const findPeriod = (periodId?: number | null): SamplingInformationCachedPeriod | null => {
+    if (!periodId) {
+      return null;
+    }
+
+    return cachedSamplingInformationRef.current?.periods[periodId] ?? null;
+  };
 
   /**
    * Get the currently selected site for the row.
@@ -271,88 +320,154 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
    * @return {*}  {(SamplingInformationCachedSite | null)}
    */
-  const getCurrentSite = <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ): SamplingInformationCachedSite | null => {
-    return findSite(dataGridProps.value as number) ?? null;
+  const getCurrentSite = (surveySampleSiteId: number): SamplingInformationCachedSite | null => {
+    return findSite(surveySampleSiteId) ?? null;
   };
 
   /**
    * Get the currently selected method technique for the row.
    *
-   * @template DataGridType
-   * @param {GridRenderCellParams<DataGridType>} dataGridProps
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
+   * @param {number} methodTechniqueId
    * @return {*}  {(SamplingInformationCachedTechnique | null)}
    */
-  const getCurrentTechnique = <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ): SamplingInformationCachedTechnique | null => {
-    return findTechnique(dataGridProps.value as number) ?? null;
+  const getCurrentTechnique = (methodTechniqueId: number): SamplingInformationCachedTechnique | null => {
+    return findTechnique(methodTechniqueId) ?? null;
   };
 
   /**
    * Get the currently selected period for the row.
    *
-   * @template DataGridType
-   * @param {GridRenderCellParams<DataGridType>} dataGridProps
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
+   * @param {number} surveySamplePeriodId
    * @return {*}  {(SamplingInformationCachedPeriod | null)}
    */
-  const getCurrentPeriod = <DataGridType extends GridValidRowModel>(
-    dataGridProps: GridRenderCellParams<DataGridType>
-  ): SamplingInformationCachedPeriod | null => {
-    return findPeriod(dataGridProps.value as number) ?? null;
+  const getCurrentPeriod = (surveySamplePeriodId: number): SamplingInformationCachedPeriod | null => {
+    return findPeriod(surveySamplePeriodId) ?? null;
   };
 
   /**
    * Get all valid techniques for the currently selected site.
    *
-   * @param {(number | undefined)} survey_sample_site_id
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
+   * @param {(number | null)} [surveySampleSiteId]
    * @return {*}  {SamplingInformationCachedTechnique[]}
    */
-  const getTechniquesForRow = (survey_sample_site_id: number | undefined): SamplingInformationCachedTechnique[] => {
-    const site = findSite(survey_sample_site_id);
-
-    if (!site) {
+  const getTechniquesForRow = (surveySampleSiteId?: number | null): SamplingInformationCachedTechnique[] => {
+    if (!surveySampleSiteId) {
       return [];
     }
 
-    const matchingTechniques = cachedSamplingInformationRef.current?.techniques.filter((technique) => {
-      return technique.survey_sample_site_id === site.survey_sample_site_id;
-    });
+    // Get all technique ids for the provided site id
+    const methodTechniqueIds: number[] = Array.from(
+      cachedSamplingInformationRef.current?.techniqueIndex[_getSiteTechniqueKey(surveySampleSiteId)] ??
+        new Set<number>()
+    );
 
-    return matchingTechniques ?? [];
+    // Get all techniques for the matching technique ids
+    return methodTechniqueIds
+      .map((techniqueId) => cachedSamplingInformationRef.current?.techniques[techniqueId])
+      .filter((value): value is SamplingInformationCachedTechnique => value !== undefined);
   };
 
   /**
    * Get all valid periods for the currently selected site and technique.
    *
-   * @param {(number | undefined)} survey_sample_site_id
-   * @param {(number | undefined)} method_technique_id
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
+   * @param {(number | null)} [surveySampleSiteId]
+   * @param {(number | null)} [methodTechniqueId]
    * @return {*}  {SamplingInformationCachedPeriod[]}
    */
   const getPeriodsForRow = (
-    survey_sample_site_id: number | undefined,
-    method_technique_id: number | undefined
+    surveySampleSiteId?: number | null,
+    methodTechniqueId?: number | null
   ): SamplingInformationCachedPeriod[] => {
-    const site = findSite(survey_sample_site_id);
-    const technique = findTechnique(method_technique_id);
-
-    if (!site || !technique) {
+    if (!surveySampleSiteId || !methodTechniqueId) {
       return [];
     }
 
-    const matchingPeriods = cachedSamplingInformationRef.current?.periods.filter((period) => {
-      return (
-        period.survey_sample_site_id === site.survey_sample_site_id &&
-        period.method_technique_id === technique.method_technique_id
-      );
-    });
+    // Get all period ids for the provided technique id
+    const samplePeriodIds: number[] = Array.from(
+      cachedSamplingInformationRef.current?.periodIndex[
+        _getTechniquePeriodKey(surveySampleSiteId, methodTechniqueId)
+      ] ?? new Set<number>()
+    );
 
-    return matchingPeriods ?? [];
+    // Get all periods for the matching period ids
+    return samplePeriodIds
+      .map((samplePeriodId) => cachedSamplingInformationRef.current?.periods[samplePeriodId])
+      .filter((value): value is SamplingInformationCachedPeriod => value !== undefined);
+  };
+
+  /**
+   * Get a key for the site technique index.
+   *
+   * @param {(number | null)} [surveySampleSiteId]
+   * @return {*}  {IndexKey}
+   */
+  const _getSiteTechniqueKey = (surveySampleSiteId?: number | null): IndexKey => {
+    return `${surveySampleSiteId ?? null}`;
+  };
+
+  /**
+   * Get a key for the technique period index.
+   *
+   * @param {(number | null)} [surveySampleSiteId]
+   * @param {(number | null)} [methodTechniqueId]
+   * @return {*}  {IndexKey}
+   */
+  const _getTechniquePeriodKey = (surveySampleSiteId?: number | null, methodTechniqueId?: number | null): IndexKey => {
+    return `${surveySampleSiteId ?? null}-${methodTechniqueId ?? null}`;
+  };
+
+  /**
+   * Type guard to check if the provided sampling period has valid sample site data.
+   *
+   * @param {GetSamplingPeriod} period
+   * @return {*}  {(period is GetSamplingPeriod & {
+   *     survey_sample_site_id: NonNullable<GetSamplingPeriod['survey_sample_site_id']>;
+   *     survey_sample_site: NonNullable<GetSamplingPeriod['survey_sample_site']>;
+   *   })}
+   */
+  const _isValidSamplingSite = (
+    period: GetSamplingPeriod
+  ): period is GetSamplingPeriod & {
+    survey_sample_site_id: NonNullable<GetSamplingPeriod['survey_sample_site_id']>;
+    survey_sample_site: NonNullable<GetSamplingPeriod['survey_sample_site']>;
+  } => {
+    return period.survey_sample_site_id !== null && period.survey_sample_site !== null;
+  };
+
+  /**
+   * Type guard to check if the provided sampling period has valid method technique data.
+   *
+   * @param {GetSamplingPeriod} period
+   * @return {*}  {(period is GetSamplingPeriod & {
+   *     method_technique_id: NonNullable<GetSamplingPeriod['method_technique_id']>;
+   *     method_technique: NonNullable<GetSamplingPeriod['method_technique']>;
+   *   })}
+   */
+  const _isValidMethodTechnique = (
+    period: GetSamplingPeriod
+  ): period is GetSamplingPeriod & {
+    method_technique_id: NonNullable<GetSamplingPeriod['method_technique_id']>;
+    method_technique: NonNullable<GetSamplingPeriod['method_technique']>;
+  } => {
+    return period.method_technique_id !== null && period.method_technique !== null;
+  };
+
+  /**
+   * Type guard to check if the provided sampling period has valid sample period data.
+   *
+   * @param {GetSamplingPeriod} period
+   * @return {*}  {(period is GetSamplingPeriod & {
+   *     start_date: NonNullable<GetSamplingPeriod['start_date']>;
+   *     end_date: NonNullable<GetSamplingPeriod['end_date']>;
+   *   })}
+   */
+  const _isValidSamplingPeriod = (
+    period: GetSamplingPeriod
+  ): period is GetSamplingPeriod & {
+    start_date: NonNullable<GetSamplingPeriod['start_date']>;
+    end_date: NonNullable<GetSamplingPeriod['end_date']>;
+  } => {
+    return period.start_date !== null && period.end_date !== null;
   };
 
   return {

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/sampling-information/useSamplingInformationCache.tsx
@@ -148,7 +148,7 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
           label: getDateTimeLabel(period.start_date, period.start_time, period.end_date, period.end_time)
         };
 
-        if (period.survey_sample_period_id && period.method_technique_id) {
+        if (period.survey_sample_site_id && period.method_technique_id) {
           // If the period has a parent technique, ensure it is indexed
           periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] = (
             periodIndex[_getTechniquePeriodKey(period.survey_sample_site_id, period.method_technique_id)] ??
@@ -416,8 +416,8 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    * @param {(number | null)} surveySampleSiteId
    * @return {*}  {IndexKey}
    */
-  const _getSiteTechniqueKey = (surveySampleSiteId: number | null): IndexKey => {
-    return `${surveySampleSiteId ?? null}`;
+  const _getSiteTechniqueKey = (surveySampleSiteId: number): IndexKey => {
+    return `${surveySampleSiteId}`;
   };
 
   /**
@@ -427,8 +427,8 @@ export const useSamplingInformationCache = (): SamplingInformationCache => {
    * @param {(number | null)} methodTechniqueId
    * @return {*}  {IndexKey}
    */
-  const _getTechniquePeriodKey = (surveySampleSiteId: number | null, methodTechniqueId: number | null): IndexKey => {
-    return `${surveySampleSiteId ?? null}-${methodTechniqueId ?? null}`;
+  const _getTechniquePeriodKey = (surveySampleSiteId: number, methodTechniqueId: number): IndexKey => {
+    return `${surveySampleSiteId}-${methodTechniqueId}`;
   };
 
   /**


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Fixes the sampling information cache.

The sampling site, technique, and period columns in the observations data grid should now load records as expected, based on the correct site -> technique -> period record relationships.

Typing in the sites drop-down should filter the results as expected (fixed in previous PR).
- Note: The technique search always returns all results regardless of what you enter. The findTechnique backend service/repo receives the keyword, it just doesn't do anything with it currently.
- Note: The period search always returns all results regardless of what you enter. The keyword isn't even sent to the backend currently.

## Dev Notes

The cache works by tracking 3 objects (for site, technique, period). Where the key is the primary ID, and the value is the respective autocomplete option.

There are 2 new index objects, which tracks a key against an array of ids.
- site id -> technique id
- site id + technique id -> period id

This way, the technique edit component can filter its drop-down options based on the site value provided (from the site datagrid value).
And the period edit component can filter its drop-down options based on both the site and technique values provided (based on their respective values in the datagrid state).

## Testing Notes

Site column should search and filter as expected from an autocomplete field.

Technique column should show all valid techniques for the chosen site, or nothing if no site value has been selected.
If the site value changes, the technique value will be cleared.

Period column should show all valid periods for the chosen site + technique, or nothing if no site or technique values have been selected.
If the site or technique value changes, the period value will be cleared.