### PR TITLE
BugFix: Add Company to OpenAPI Spec for BCeID Access Requests

### DIFF
--- a/api/src/paths/administrative-activity.ts
+++ b/api/src/paths/administrative-activity.ts
@@ -37,6 +37,7 @@ POST.apiDoc = {
             username: { type: 'string' },
             email: { type: 'string' },
             identitySource: { type: 'string', description: 'Whether the account is an IDIR or BCeID.' },
+            company: { type: 'string', description: 'The company that the user belongs to.', nullable: true },
             displayName: { type: 'string' }
           }
         }


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Allows the "company" property to be included in access requests from BCeID users (the frontend was including it, the backend was rejecting it)
