### PR TITLE
BugFix: Fix Device Edits Not Updating Deployment 'device_key'

### DIFF
--- a/app/src/features/surveys/telemetry/list/SurveyDeploymentListItem.tsx
+++ b/app/src/features/surveys/telemetry/list/SurveyDeploymentListItem.tsx
@@ -108,7 +108,7 @@ export const SurveyDeploymentListItem = (props: ISurveyDeploymentListItemProps) 
                 </Typography>
               </Stack>
               <Typography variant="body2" color="textSecondary" title="Animal">
-                {`${deployment.deployment_id}: ${animal?.animal_id || 'Unknown'}`}
+                {`${deployment.deployment_id}: ${animal?.animal_id || deployment.critter_id}`}
               </Typography>
             </Box>
           </Stack>

--- a/app/src/features/surveys/telemetry/table/TelemetryTable.tsx
+++ b/app/src/features/surveys/telemetry/table/TelemetryTable.tsx
@@ -63,19 +63,24 @@ export const TelemetryTable = (props: IManualTelemetryTableProps) => {
     return critterDeployments;
   }, [critterDataLoader.data, deploymentDataLoader.data]);
 
-  const columns: GridColDef<IManualTelemetryTableRow>[] = useMemo(
-    () => [
-      DeploymentColDef({ critterDeployments, hasError: telemetryTableContext.hasError }),
+  const columns: GridColDef<IManualTelemetryTableRow>[] = useMemo(() => {
+    const deployments = deploymentDataLoader.data?.deployments ?? [];
+
+    return [
+      DeploymentColDef({
+        critterDeployments,
+        deployments,
+        hasError: telemetryTableContext.hasError
+      }),
       // TODO: Show animal nickname as a column
-      DeviceColDef({ critterDeployments }),
+      DeviceColDef(),
       GenericDateColDef({ field: 'date', headerName: 'Date', hasError: telemetryTableContext.hasError }),
       GenericTimeColDef({ field: 'time', headerName: 'Time', hasError: telemetryTableContext.hasError }),
       GenericLatitudeColDef({ field: 'latitude', headerName: 'Latitude', hasError: telemetryTableContext.hasError }),
       GenericLongitudeColDef({ field: 'longitude', headerName: 'Longitude', hasError: telemetryTableContext.hasError }),
       TelemetryTypeColDef()
-    ],
-    [critterDeployments, telemetryTableContext.hasError]
-  );
+    ];
+  }, [critterDeployments, deploymentDataLoader.data, telemetryTableContext.hasError]);
 
   return (
     <DataGrid

--- a/app/src/features/surveys/telemetry/table/utils/GridColumnDefinitions.tsx
+++ b/app/src/features/surveys/telemetry/table/utils/GridColumnDefinitions.tsx
@@ -1,9 +1,11 @@
 import { Typography } from '@mui/material';
 import { GridCellParams, GridColDef } from '@mui/x-data-grid';
+import { IAutocompleteDataGridOption } from 'components/data-grid/autocomplete/AutocompleteDataGrid.interface';
 import AutocompleteDataGridEditCell from 'components/data-grid/autocomplete/AutocompleteDataGridEditCell';
 import AutocompleteDataGridViewCell from 'components/data-grid/autocomplete/AutocompleteDataGridViewCell';
 import { IManualTelemetryTableRow } from 'contexts/telemetryTableContext';
 import { IAnimalDeploymentWithCritter } from 'interfaces/useSurveyApi.interface';
+import { TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
 import { capitalize } from 'lodash-es';
 
 export const TelemetryTypeColDef = (): GridColDef<IManualTelemetryTableRow> => {
@@ -23,8 +25,33 @@ export const TelemetryTypeColDef = (): GridColDef<IManualTelemetryTableRow> => {
 
 export const DeploymentColDef = (props: {
   critterDeployments: IAnimalDeploymentWithCritter[];
+  deployments: TelemetryDeployment[];
   hasError: (params: GridCellParams) => boolean;
 }): GridColDef<IManualTelemetryTableRow> => {
+  const optionsMap: Map<number, IAutocompleteDataGridOption<number>> = new Map();
+
+  // Add deployments to the options map.
+  props.deployments.forEach((item) => {
+    optionsMap.set(item.deployment_id, {
+      label: `${item.deployment_id}: ${item.critter_id}`,
+      value: item.deployment_id
+    });
+  });
+
+  // Add critter deployments to the options map, overriding any deployments with matching id.
+  // This will ideally override all of the items from the previous forEach loop, unless we fail to find a matching
+  // critter, in which case the above forEach loop will fill in that missing deployment so the column is not empty.
+  if (props.critterDeployments.length) {
+    props.critterDeployments.forEach((item) =>
+      optionsMap.set(item.deployment.deployment_id, {
+        label: `${item.deployment.deployment_id}: ${item.critter.animal_id}`,
+        value: item.deployment.deployment_id
+      })
+    );
+  }
+
+  const options = Array.from(optionsMap.values());
+
   return {
     field: 'deployment_id',
     headerName: 'Deployment',
@@ -40,12 +67,7 @@ export const DeploymentColDef = (props: {
       return (
         <AutocompleteDataGridViewCell<IManualTelemetryTableRow, number>
           dataGridProps={params}
-          options={props.critterDeployments.map((item) => {
-            return {
-              label: `${item.deployment.deployment_id}: ${item.critter.animal_id}`,
-              value: item.deployment.deployment_id
-            };
-          })}
+          options={options}
           error={error}
         />
       );
@@ -56,10 +78,7 @@ export const DeploymentColDef = (props: {
       return (
         <AutocompleteDataGridEditCell<IManualTelemetryTableRow, number>
           dataGridProps={params}
-          options={props.critterDeployments.map((item) => ({
-            label: `${item.deployment.deployment_id}: ${item.critter.animal_id}`,
-            value: item.deployment.deployment_id
-          }))}
+          options={options}
           error={error}
         />
       );
@@ -67,9 +86,7 @@ export const DeploymentColDef = (props: {
   };
 };
 
-export const DeviceColDef = (props: {
-  critterDeployments: IAnimalDeploymentWithCritter[];
-}): GridColDef<IManualTelemetryTableRow> => {
+export const DeviceColDef = (): GridColDef<IManualTelemetryTableRow> => {
   return {
     field: 'serial',
     headerName: 'Device',
@@ -78,14 +95,6 @@ export const DeviceColDef = (props: {
     disableColumnMenu: true,
     headerAlign: 'left',
     align: 'left',
-    renderCell: (params) => (
-      <Typography>
-        {
-          props.critterDeployments.find(
-            (deployment) => deployment.deployment.deployment_id === params.row.deployment_id
-          )?.deployment.serial
-        }
-      </Typography>
-    )
+    renderCell: (params) => <Typography>{params.value}</Typography>
   };
 };

--- a/database/src/migrations/20250221000000_device_deployment_constraints.ts
+++ b/database/src/migrations/20250221000000_device_deployment_constraints.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+/**
+ * Update tables:
+ *
+ * device
+ * - Add unique constraint on (survey_id, device_key), as required by deployment foreign key constraint.
+ *
+ * deployment
+ * - Add foreign key constraint, with update on cascade, on device(survey_id, device_key).
+ * - Add matching index.
+ *
+ * This prevents the following scenario: a `device.serial` column is updated, the `device.device_key` is auto
+ * re-generated, but now the `deployment.device_key` for that `device` is out of sync.
+ *
+ * @param {Knex} knex
+ * @returns {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH=biohub;
+
+    ----------------------------------------------------------------------------------------
+    -- device
+    ----------------------------------------------------------------------------------------
+
+    -- Add unique constraint
+    ALTER TABLE device ADD CONSTRAINT device_uk2 UNIQUE (survey_id, device_key);
+
+    ----------------------------------------------------------------------------------------
+    -- deployment
+    ----------------------------------------------------------------------------------------
+
+    -- Add foreign key constraint on deployment.device_key, which should automatically update when device.device_key is
+    -- updated. This is to ensure that deployment.device_key stays in sync with its related device.device_key.
+    ALTER TABLE deployment
+      ADD CONSTRAINT deployment_fk6
+      FOREIGN KEY (survey_id, device_key)
+      REFERENCES device(survey_id, device_key) ON UPDATE CASCADE;
+
+    -- Add index for foreign key
+    CREATE INDEX deployment_idx6 ON device(survey_id, device_key);
+
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

### Database changes
Update device/deployment tables. Add foreign key between device and deployment on device_key, with cascade update.

### Manage telemetry UI changes
Update telemetry table to ensure the deployment and device columns always have some values populated, even if the critter request fails, or there is no critter in sims.

## Testing Notes

### Database changes
Previously: If you edited a device's serial number, the deployment would not be updated, and the `device_key` column would be out of sync between the 2 records.

Now: You should be able to edit a device's serial number, and the matching deployment record(s) should have their `device_key` column updated automatically to match.

### Manage telemetry UI changes
Previously: on the manage telemetry page, if a critterbase record is found for a deployment, the deployment column would show the deployment id and critter alias (ex: `'14: Big Tom'`). If no critterbase record was found, it would be empty.

Now: It will show the deployment_id and critter_id as a fallback (ex: `'14: 23'`)

## Regrading the bulk create/update manual telemetry changes
@MacQSL I think there may be a way to combine the security checks into the sql itself, so it doesn't have to be done in the service. But it was getting a bit ugly and needed more testing and I didn't want to delay the rest of these changes any longer.
