### PR TITLE
Observations Table - Environment Columns to display units associated with that variable/column

### DIFF
--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/GridColumnDefinitionsUtils.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/GridColumnDefinitionsUtils.tsx
@@ -104,7 +104,13 @@ export const getEnvironmentColumnDefinitions = (
   for (const environment of environments.quantitative_environments) {
     colDefs.push(
       ObservationQuantitativeEnvironmentColDef({
-        environment: environment,
+        environment: {
+          ...environment,
+          name: environment.unit
+            ? `${environment.name} (${environment.unit}${environment.unit.endsWith('er') ? 's' : ''})`
+            : environment.name,
+          description: environment.description
+        },
         hasError: hasError
       })
     );

--- a/app/src/features/surveys/observations/observations-table/grid-column-definitions/GridColumnDefinitionsUtils.tsx
+++ b/app/src/features/surveys/observations/observations-table/grid-column-definitions/GridColumnDefinitionsUtils.tsx
@@ -96,21 +96,35 @@ export const getMeasurementColumnDefinitions = (
   return colDefs;
 };
 
+const getQuantitativeEnvironmentHeaderName = (name: string, unit?: string): string => {
+  if (!unit) {
+    return name;
+  }
+
+  const unitSuffix = unit.endsWith('er') ? 's' : '';
+  return `${name} (${unit}${unitSuffix})`;
+};
+
+const formatQuantitativeEnvironment = (environment: EnvironmentQuantitativeTypeDefinition) => {
+  return {
+    ...environment,
+    name: getQuantitativeEnvironmentHeaderName(environment.name, environment.unit ?? undefined),
+    description: environment.description
+  };
+};
+
 export const getEnvironmentColumnDefinitions = (
   environments: EnvironmentType,
   hasError: (params: GridCellParams) => boolean
 ): GridColDef<IObservationTableRow>[] => {
   const colDefs: GridColDef<IObservationTableRow>[] = [];
+
   for (const environment of environments.quantitative_environments) {
+    const formattedEnvironment = formatQuantitativeEnvironment(environment);
+
     colDefs.push(
       ObservationQuantitativeEnvironmentColDef({
-        environment: {
-          ...environment,
-          name: environment.unit
-            ? `${environment.name} (${environment.unit}${environment.unit.endsWith('er') ? 's' : ''})`
-            : environment.name,
-          description: environment.description
-        },
+        environment: formattedEnvironment,
         hasError: hasError
       })
     );


### PR DESCRIPTION
## Links to Jira Tickets
NA

## Description of Changes

Updates the environment column definitions to include units in the column header names for environment measurements.
Also adds 's' in the context that the unit ends with 'er'
