### PR TITLE
Add Map to Summary Page

### DIFF
--- a/api/src/models/survey-view.ts
+++ b/api/src/models/survey-view.ts
@@ -81,6 +81,8 @@ export type FindSurveysResponse = z.infer<typeof FindSurveysResponse>;
 export const FindSurveysSpatialResponse = z.object({
   project_id: z.number(),
   survey_id: z.number(),
+  project_name: z.string(),
+  survey_name: z.string(),
   survey_location_id: z.number(),
   geojson: z.any()
 });

--- a/api/src/models/survey-view.ts
+++ b/api/src/models/survey-view.ts
@@ -18,13 +18,6 @@ export interface ISurveyAdvancedFilters {
    */
   keyword?: string;
   /**
-   * Filter results by ITIS TSN.
-   *
-   * @type {number}
-   * @memberof ISurveyAdvancedFilters
-   */
-  itis_tsn?: number;
-  /**
    * Filter results by ITIS TSNs.
    *
    * @type {number[]}
@@ -52,6 +45,14 @@ export interface ISurveyAdvancedFilters {
    * @memberof ISurveyAdvancedFilters
    */
   survey_name?: string;
+
+  /**
+   * Filter results by project name.
+   *
+   * @type {string}
+   * @memberof ISurveyAdvancedFilters
+   */
+  project_name?: string;
   /**
    * Filter results by system user id.
    *
@@ -76,6 +77,15 @@ export const FindSurveysResponse = z.object({
 });
 
 export type FindSurveysResponse = z.infer<typeof FindSurveysResponse>;
+
+export const FindSurveysSpatialResponse = z.object({
+  project_id: z.number(),
+  survey_id: z.number(),
+  survey_location_id: z.number(),
+  geojson: z.any()
+});
+
+export type FindSurveysSpatialResponse = z.infer<typeof FindSurveysSpatialResponse>;
 
 export type SurveyObject = {
   survey_details: GetSurveyData;

--- a/api/src/paths/survey/spatial/index.test.ts
+++ b/api/src/paths/survey/spatial/index.test.ts
@@ -1,0 +1,165 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { findSurveysSpatial } from '.';
+import { SYSTEM_ROLE } from '../../../constants/roles';
+import * as db from '../../../database/db';
+import { HTTPError } from '../../../errors/http-error';
+import { FindSurveysSpatialResponse } from '../../../models/survey-view';
+import { SurveyService } from '../../../services/survey-service';
+import { KeycloakUserInformation } from '../../../utils/keycloak-utils';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
+
+chai.use(sinonChai);
+
+describe('findSurveysSpatial', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('finds and returns projects', async () => {
+    const mockFindSurveysSpatialResponse: FindSurveysSpatialResponse[] = [
+      {
+        survey_id: 1,
+        project_id: 1,
+        survey_location_id: 1,
+        geojson: []
+      }
+    ];
+
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      systemUserId: () => 20
+    });
+
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+    const findSurveysSpatialStub = sinon
+      .stub(SurveyService.prototype, 'findSurveysSpatial')
+      .resolves(mockFindSurveysSpatialResponse);
+
+    const findSurveysSpatialCountStub = sinon.stub(SurveyService.prototype, 'findSurveysCount').resolves(50);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.query = {
+      keyword: 'keyword',
+      itis_tsns: ['123456'],
+      system_user_id: '11',
+      survey_name: 'survey name',
+      sproject_name: 'project name',
+      page: '2',
+      limit: '10',
+      sort: undefined,
+      order: undefined
+    };
+    mockReq.keycloak_token = {} as KeycloakUserInformation;
+    mockReq.system_user = {
+      system_user_id: 20,
+      user_guid: '123-456-789',
+      user_identifier: 'test-identifier',
+      identity_source: 'IDIR',
+      display_name: 'test-user',
+      given_name: 'test-given',
+      family_name: 'test-family',
+      email: 'test-email',
+      agency: 'test-agency',
+      record_end_date: null,
+      role_ids: [1],
+      role_names: [SYSTEM_ROLE.SYSTEM_ADMIN]
+    };
+
+    const requestHandler = findSurveysSpatial();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+
+    expect(findSurveysSpatialStub).to.have.been.calledOnceWith(true, 20, sinon.match.object, sinon.match.object);
+    expect(findSurveysSpatialCountStub).to.have.been.calledOnceWith(true, 20, sinon.match.object);
+
+    expect(mockRes.jsonValue.surveys).to.eql(mockFindSurveysSpatialResponse);
+    expect(mockRes.jsonValue.pagination).not.to.be.null;
+
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('catches and re-throws error', async () => {
+    const mockFindSurveysSpatialResponse: FindSurveysSpatialResponse[] = [
+      {
+        survey_id: 1,
+        project_id: 1,
+        survey_location_id: 1,
+        geojson: []
+      }
+    ];
+
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub(),
+      systemUserId: () => 20
+    });
+
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+    const findSurveysSpatialStub = sinon
+      .stub(SurveyService.prototype, 'findSurveysSpatial')
+      .resolves(mockFindSurveysSpatialResponse);
+
+    const findSurveysSpatialCountStub = sinon
+      .stub(SurveyService.prototype, 'findSurveysCount')
+      .rejects(new Error('a test error'));
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.query = {
+      keyword: 'keyword',
+      itis_tsns: ['123456'],
+      system_user_id: '11',
+      project_name: 'project name',
+      survey_name: 'survey name',
+      page: '2',
+      limit: '10',
+      sort: undefined,
+      order: undefined
+    };
+    mockReq.keycloak_token = {} as KeycloakUserInformation;
+    mockReq.system_user = {
+      system_user_id: 20,
+      user_guid: '123-456-789',
+      user_identifier: 'test-identifier',
+      identity_source: 'IDIR',
+      display_name: 'test-user',
+      given_name: 'test-given',
+      family_name: 'test-family',
+      email: 'test-email',
+      agency: 'test-agency',
+      record_end_date: null,
+      role_ids: [3],
+      role_names: [SYSTEM_ROLE.PROJECT_CREATOR]
+    };
+
+    const requestHandler = findSurveysSpatial();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+
+      expect(findSurveysSpatialStub).to.have.been.calledOnceWith(false, 20, sinon.match.object, sinon.match.object);
+      expect(findSurveysSpatialCountStub).to.have.been.calledOnceWith(false, 20, sinon.match.object);
+
+      expect(mockDBConnection.rollback).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+
+      expect((actualError as HTTPError).message).to.equal('a test error');
+    }
+  });
+});

--- a/api/src/paths/survey/spatial/index.test.ts
+++ b/api/src/paths/survey/spatial/index.test.ts
@@ -18,7 +18,7 @@ describe('findSurveysSpatial', () => {
     sinon.restore();
   });
 
-  it('finds and returns projects', async () => {
+  it('finds and returns survey spatial geometries', async () => {
     const mockFindSurveysSpatialResponse: FindSurveysSpatialResponse[] = [
       {
         survey_id: 1,
@@ -45,12 +45,16 @@ describe('findSurveysSpatial', () => {
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
-    mockReq.query = {
+    const mockFilters = {
       keyword: 'keyword',
       itis_tsns: ['123456'],
       system_user_id: '11',
       survey_name: 'survey name',
-      sproject_name: 'project name',
+      project_name: 'project name'
+    };
+
+    mockReq.query = {
+      ...mockFilters,
       page: '2',
       limit: '10',
       sort: undefined,
@@ -79,7 +83,12 @@ describe('findSurveysSpatial', () => {
     expect(mockDBConnection.open).to.have.been.calledOnce;
     expect(mockDBConnection.commit).to.have.been.calledOnce;
 
-    expect(findSurveysSpatialStub).to.have.been.calledOnceWith(true, 20, sinon.match.object, sinon.match.object);
+    expect(findSurveysSpatialStub).to.have.been.calledOnceWith(
+      true,
+      20,
+      { ...mockFilters, system_user_id: Number(mockFilters.system_user_id) },
+      sinon.match.object
+    );
     expect(findSurveysSpatialCountStub).to.have.been.calledOnceWith(true, 20, sinon.match.object);
 
     expect(mockRes.jsonValue.surveys).to.eql(mockFindSurveysSpatialResponse);
@@ -118,17 +127,15 @@ describe('findSurveysSpatial', () => {
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
-    mockReq.query = {
+    const mockFilters = {
       keyword: 'keyword',
       itis_tsns: ['123456'],
       system_user_id: '11',
       project_name: 'project name',
-      survey_name: 'survey name',
-      page: '2',
-      limit: '10',
-      sort: undefined,
-      order: undefined
+      survey_name: 'survey name'
     };
+
+    mockReq.query = { ...mockFilters, page: '2', limit: '10', sort: undefined, order: undefined };
     mockReq.keycloak_token = {} as KeycloakUserInformation;
     mockReq.system_user = {
       system_user_id: 20,
@@ -153,7 +160,12 @@ describe('findSurveysSpatial', () => {
     } catch (actualError) {
       expect(mockDBConnection.open).to.have.been.calledOnce;
 
-      expect(findSurveysSpatialStub).to.have.been.calledOnceWith(false, 20, sinon.match.object, sinon.match.object);
+      expect(findSurveysSpatialStub).to.have.been.calledOnceWith(
+        false,
+        20,
+        { ...mockFilters, system_user_id: Number(mockFilters.system_user_id) },
+        sinon.match.object
+      );
       expect(findSurveysSpatialCountStub).to.have.been.calledOnceWith(false, 20, sinon.match.object);
 
       expect(mockDBConnection.rollback).to.have.been.calledOnce;

--- a/api/src/paths/survey/spatial/index.test.ts
+++ b/api/src/paths/survey/spatial/index.test.ts
@@ -23,6 +23,8 @@ describe('findSurveysSpatial', () => {
       {
         survey_id: 1,
         project_id: 1,
+        project_name: 'name',
+        survey_name: 'name',
         survey_location_id: 1,
         geojson: []
       }
@@ -102,6 +104,8 @@ describe('findSurveysSpatial', () => {
       {
         survey_id: 1,
         project_id: 1,
+        project_name: 'name',
+        survey_name: 'name',
         survey_location_id: 1,
         geojson: []
       }

--- a/api/src/paths/survey/spatial/index.ts
+++ b/api/src/paths/survey/spatial/index.ts
@@ -118,6 +118,12 @@ GET.apiDoc = {
                       type: 'integer',
                       minimum: 1
                     },
+                    survey_name: {
+                      type: 'string',
+                    },
+                    project_name: {
+                      type: 'string',
+                    },
                     survey_location_id: {
                       type: 'integer',
                       minimum: 1

--- a/api/src/paths/survey/spatial/index.ts
+++ b/api/src/paths/survey/spatial/index.ts
@@ -151,7 +151,7 @@ GET.apiDoc = {
 };
 
 /**
- * Get all project geometries (potentially based on filter criteria).
+ * Get all survey spatial geometries (potentially based on filter criteria).
  *
  * @returns {RequestHandler}
  */
@@ -196,7 +196,7 @@ export function findSurveysSpatial(): RequestHandler {
         pagination: makePaginationResponse(surveysTotalCount, paginationOptions)
       };
 
-      // Allow browsers to cache this response for 30 seconds
+      // Allow browsers to cache this response for 5 seconds
       res.setHeader('Cache-Control', 'private, max-age=5');
 
       return res.status(200).json(response);

--- a/api/src/paths/survey/spatial/index.ts
+++ b/api/src/paths/survey/spatial/index.ts
@@ -119,10 +119,10 @@ GET.apiDoc = {
                       minimum: 1
                     },
                     survey_name: {
-                      type: 'string',
+                      type: 'string'
                     },
                     project_name: {
-                      type: 'string',
+                      type: 'string'
                     },
                     survey_location_id: {
                       type: 'integer',

--- a/api/src/paths/survey/spatial/index.ts
+++ b/api/src/paths/survey/spatial/index.ts
@@ -1,37 +1,39 @@
 import { Request, RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { SYSTEM_ROLE } from '../../constants/roles';
-import { getDBConnection } from '../../database/db';
-import { ISurveyAdvancedFilters } from '../../models/survey-view';
-import { paginationRequestQueryParamSchema, paginationResponseSchema } from '../../openapi/schemas/pagination';
-import { authorizeRequestHandler, userHasValidRole } from '../../request-handlers/security/authorization';
-import { SurveyService } from '../../services/survey-service';
-import { getLogger } from '../../utils/logger';
+import { SYSTEM_ROLE } from '../../../constants/roles';
+import { getDBConnection } from '../../../database/db';
+import { ISurveyAdvancedFilters } from '../../../models/survey-view';
+import { GeoJSONFeature } from '../../../openapi/schemas/geoJson';
+import { paginationRequestQueryParamSchema, paginationResponseSchema } from '../../../openapi/schemas/pagination';
+import { authorizeRequestHandler, userHasValidRole } from '../../../request-handlers/security/authorization';
+import { SurveyService } from '../../../services/survey-service';
+import { getLogger } from '../../../utils/logger';
 import {
   ensureCompletePaginationOptions,
   makePaginationOptionsFromRequest,
   makePaginationResponse
-} from '../../utils/pagination';
-import { getSystemUserFromRequest } from '../../utils/request';
+} from '../../../utils/pagination';
+import { getSystemUserFromRequest } from '../../../utils/request';
 
-const defaultLog = getLogger('paths/survey/index');
+const defaultLog = getLogger('paths/survey/spatial');
 
 export const GET: Operation = [
   authorizeRequestHandler(() => {
     return {
       and: [
         {
-          discriminator: 'SystemUser'
+          validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
         }
       ]
     };
   }),
-  findSurveys()
+  findSurveysSpatial()
 ];
 
 GET.apiDoc = {
-  description: "Gets a list of surveys based on the user's permissions and filter criteria.",
-  tags: ['surveys'],
+  description: 'Get survey spatial for a user id.',
+  tags: ['survey'],
   security: [
     {
       Bearer: []
@@ -62,27 +64,16 @@ GET.apiDoc = {
     },
     {
       in: 'query',
-      name: 'start_date',
-      description: 'ISO 8601 datetime string',
-      required: false,
-      schema: {
-        type: 'string',
-        nullable: true
-      }
-    },
-    {
-      in: 'query',
-      name: 'end_date',
-      description: 'ISO 8601 datetime string',
-      required: false,
-      schema: {
-        type: 'string',
-        nullable: true
-      }
-    },
-    {
-      in: 'query',
       name: 'survey_name',
+      required: false,
+      schema: {
+        type: 'string',
+        nullable: true
+      }
+    },
+    {
+      in: 'query',
+      name: 'project_name',
       required: false,
       schema: {
         type: 'string',
@@ -103,7 +94,7 @@ GET.apiDoc = {
   ],
   responses: {
     200: {
-      description: 'Survey response object.',
+      description: 'Surveys spatial response object for given user.',
       content: {
         'application/json': {
           schema: {
@@ -114,19 +105,10 @@ GET.apiDoc = {
               surveys: {
                 type: 'array',
                 items: {
+                  title: 'Survey Get Spatial Response Object',
                   type: 'object',
                   additionalProperties: false,
-                  required: [
-                    'project_id',
-                    'survey_id',
-                    'name',
-                    'progress_id',
-                    'start_date',
-                    'end_date',
-                    'regions',
-                    'focal_species',
-                    'types'
-                  ],
+                  required: ['project_id', 'survey_id', 'survey_location_id', 'geojson'],
                   properties: {
                     project_id: {
                       type: 'integer',
@@ -136,44 +118,11 @@ GET.apiDoc = {
                       type: 'integer',
                       minimum: 1
                     },
-                    name: {
-                      type: 'string'
-                    },
-                    progress_id: {
+                    survey_location_id: {
                       type: 'integer',
                       minimum: 1
                     },
-                    start_date: {
-                      type: 'string',
-                      description: 'ISO 8601 datetime string',
-                      nullable: true
-                    },
-                    end_date: {
-                      type: 'string',
-                      description: 'ISO 8601 datetime string',
-                      nullable: true
-                    },
-                    regions: {
-                      type: 'array',
-                      items: {
-                        type: 'string'
-                      },
-                      nullable: true
-                    },
-                    focal_species: {
-                      type: 'array',
-                      items: {
-                        type: 'integer'
-                      },
-                      nullable: true
-                    },
-                    types: {
-                      type: 'array',
-                      items: {
-                        type: 'integer',
-                        nullable: true
-                      }
-                    }
+                    geojson: { type: 'array', items: { ...(GeoJSONFeature as object) } }
                   }
                 }
               },
@@ -202,13 +151,13 @@ GET.apiDoc = {
 };
 
 /**
- * Get surveys for the current user, based on their permissions and filter criteria.
+ * Get all project geometries (potentially based on filter criteria).
  *
  * @returns {RequestHandler}
  */
-export function findSurveys(): RequestHandler {
+export function findSurveysSpatial(): RequestHandler {
   return async (req, res) => {
-    defaultLog.debug({ label: 'findSurveys' });
+    defaultLog.debug({ label: 'findSurveysSpatial' });
 
     const connection = getDBConnection(req.keycloak_token);
 
@@ -224,14 +173,14 @@ export function findSurveys(): RequestHandler {
         systemUser.role_names
       );
 
-      const filterFields = parseQueryParams(req);
-
       const paginationOptions = makePaginationOptionsFromRequest(req);
+
+      const filterFields = parseQueryParams(req);
 
       const surveyService = new SurveyService(connection);
 
-      const [surveys, surveysTotalCount] = await Promise.all([
-        surveyService.findSurveys(
+      const [surveySpatial, surveysTotalCount] = await Promise.all([
+        surveyService.findSurveysSpatial(
           isUserAdmin,
           systemUserId,
           filterFields,
@@ -243,16 +192,16 @@ export function findSurveys(): RequestHandler {
       await connection.commit();
 
       const response = {
-        surveys,
+        surveys: surveySpatial,
         pagination: makePaginationResponse(surveysTotalCount, paginationOptions)
       };
 
       // Allow browsers to cache this response for 30 seconds
-      res.setHeader('Cache-Control', 'private, max-age=30');
+      res.setHeader('Cache-Control', 'private, max-age=5');
 
       return res.status(200).json(response);
     } catch (error) {
-      defaultLog.error({ label: 'findSurveys', message: 'error', error });
+      defaultLog.error({ label: 'findSurveysSpatial', message: 'error', error });
       await connection.rollback();
       throw error;
     } finally {
@@ -271,9 +220,8 @@ function parseQueryParams(req: Request<unknown, unknown, unknown, ISurveyAdvance
   return {
     keyword: req.query.keyword ?? undefined,
     itis_tsns: req.query.itis_tsns ?? undefined,
-    start_date: req.query.start_date ?? undefined,
-    end_date: req.query.end_date ?? undefined,
     survey_name: req.query.survey_name ?? undefined,
+    project_name: req.query.project_name ?? undefined,
     system_user_id: (req.query.system_user_id && Number(req.query.system_user_id)) ?? undefined
   };
 }

--- a/api/src/repositories/project-repository.ts
+++ b/api/src/repositories/project-repository.ts
@@ -139,8 +139,12 @@ export class ProjectRepository extends BaseRepository {
     if (pagination) {
       query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
 
-      if (pagination.sort && pagination.order) {
+      if (pagination.sort && pagination.order && pagination.sort !== 'project_name') {
         query.orderBy(pagination.sort, pagination.order);
+      }
+
+      if (pagination.sort === 'project_name') {
+        query.orderBy('p.name', pagination.order);
       }
     }
 

--- a/api/src/repositories/survey-repository.test.ts
+++ b/api/src/repositories/survey-repository.test.ts
@@ -215,6 +215,131 @@ describe('SurveyRepository', () => {
     });
   });
 
+  describe('findSurveys', () => {
+    it('should return a list of projects', async () => {
+      const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        project_name: 'string',
+        keyword: 'string'
+      };
+
+      const response = await repository.findSurveys(false, 1, input);
+
+      expect(response).to.eql([{ id: 1 }]);
+    });
+
+    it('should return a list of projects using different filter fields', async () => {
+      const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        project_name: 'string',
+        keyword: 'string'
+      };
+
+      const response = await repository.findSurveys(true, 1, input);
+
+      expect(response).to.eql([{ id: 1 }]);
+    });
+
+    it('should return result with both data fields', async () => {
+      const mockResponse = { rows: [], rowCount: 0 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        keyword: 'a'
+      };
+
+      const response = await repository.findSurveys(true, 1, input);
+
+      expect(response).to.eql([]);
+    });
+  });
+
+  describe('findSurveysSpatial', () => {
+    it('should return list of survey geometries', async () => {
+      const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        project_name: 'string',
+        keyword: 'string'
+      };
+
+      const response = await repository.findSurveysSpatial(false, 1, input);
+
+      expect(response).to.eql([{ id: 1 }]);
+    });
+
+    it('should return a list of survey geometries using different filter fields', async () => {
+      const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        project_name: 'string',
+        keyword: 'string'
+      };
+
+      const response = await repository.findSurveysSpatial(true, 1, input);
+
+      expect(response).to.eql([{ id: 1 }]);
+    });
+
+    it('should return result with both data fields', async () => {
+      const mockResponse = { rows: [], rowCount: 0 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const input = {
+        keyword: 'a'
+      };
+
+      const response = await repository.findSurveysSpatial(true, 1, input);
+
+      expect(response).to.eql([]);
+    });
+  });
+
+  describe('findSurveysCount', () => {
+    it('should return a survey count', async () => {
+      const mockResponse = { rows: [{ count: 10 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      const response = await repository.findSurveysCount(false, 1001, {});
+
+      expect(response).to.eql(10);
+    });
+
+    it('should throw an error', async () => {
+      const mockResponse = { rows: [], rowCount: 0 } as any as Promise<QueryResult<any>>;
+      const dbConnection = getMockDBConnection({ knex: () => mockResponse });
+
+      const repository = new SurveyRepository(dbConnection);
+
+      try {
+        await repository.findSurveysCount(true, 1001, {});
+        expect.fail();
+      } catch (error) {
+        expect((error as Error).message).to.equal('Failed to get survey count');
+      }
+    });
+  });
+
   describe('getSurveyProprietorDataForView', () => {
     it('should return result', async () => {
       const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;

--- a/api/src/repositories/survey-repository.test.ts
+++ b/api/src/repositories/survey-repository.test.ts
@@ -216,7 +216,7 @@ describe('SurveyRepository', () => {
   });
 
   describe('findSurveys', () => {
-    it('should return a list of projects', async () => {
+    it('should return a list of surveys', async () => {
       const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
       const dbConnection = getMockDBConnection({ knex: () => mockResponse });
 

--- a/api/src/repositories/survey-repository.ts
+++ b/api/src/repositories/survey-repository.ts
@@ -7,6 +7,7 @@ import { PostProprietorData, PostSurveyObject } from '../models/survey-create';
 import { PutSurveyObject } from '../models/survey-update';
 import {
   FindSurveysResponse,
+  FindSurveysSpatialResponse,
   GetAttachmentsData,
   GetReportAttachmentsData,
   GetSurveyProprietorData,
@@ -215,9 +216,94 @@ export class SurveyRepository extends BaseRepository {
     if (filterFields.itis_tsns?.length) {
       // multiple
       query.whereIn('sp.itis_tsn', filterFields.itis_tsns);
-    } else if (filterFields.itis_tsn) {
-      // single
-      query.where('sp.itis_tsn', filterFields.itis_tsn);
+    }
+
+    // Keyword Search filter
+    if (filterFields.keyword) {
+      const keywordMatch = `%${filterFields.keyword}%`;
+      query.where((subQueryBuilder) => {
+        subQueryBuilder
+          .where('s.name', 'ilike', keywordMatch)
+          .orWhere('s.additional_details', 'ilike', keywordMatch)
+          .orWhere('s.comments', 'ilike', keywordMatch);
+
+        // If the keyword is a number, also match on survey Id
+        if (!isNaN(Number(filterFields.keyword))) {
+          subQueryBuilder.orWhere('s.survey_id', Number(filterFields.keyword));
+        }
+      });
+    }
+
+    return query;
+  }
+
+  /**
+   * Constructs a non-paginated query used to get the geometries of all surveys based on the user's permissions and filter criteria.
+   *
+   * @param {boolean} isUserAdmin
+   * @param {(number | null)} systemUserId The system user id of the user making the request
+   * @param {ISurveyAdvancedFilters} filterFields
+   * @return {*}  Promise<Knex.QueryBuilder>
+   * @memberof SurveyRepository
+   */
+  _makeFindSurveySpatialQuery(
+    isUserAdmin: boolean,
+    systemUserId: number | null,
+    filterFields: ISurveyAdvancedFilters
+  ): Knex.QueryBuilder {
+    const knex = getKnex();
+
+    const query = knex
+      .distinct('s.survey_id', 's.project_id', 'sl.survey_location_id', 'sl.geojson')
+      .from('survey_location as sl')
+      .join('survey as s', 'sl.survey_id', 's.survey_id')
+      .leftJoin('project as p', 'p.project_id', 's.project_id')
+      .leftJoin('study_species as sp', 'sp.survey_id', 's.survey_id')
+      .leftJoin('survey_type as st', 'st.survey_id', 's.survey_id')
+      .leftJoin('survey_region as sr', 'sr.survey_id', 's.survey_id')
+      .leftJoin('region_lookup as rl', 'rl.region_id', 'sr.region_id')
+      .leftJoin('project_participation as ppa', 'ppa.project_id', 's.project_id');
+
+    // Ensure that users can only see surveys that they are participating in, unless they are an administrator.
+    if (!isUserAdmin) {
+      query.whereIn('p.project_id', (subQueryBuilder) => {
+        subQueryBuilder.select('project_id').from('project_participation').where('system_user_id', systemUserId);
+      });
+    }
+
+    if (filterFields.system_user_id) {
+      query.whereIn('p.project_id', (subQueryBuilder) => {
+        subQueryBuilder
+          .select('project_id')
+          .from('project_participation')
+          .where('system_user_id', filterFields.system_user_id);
+      });
+    }
+
+    // Start Date filter
+    if (filterFields.start_date) {
+      query.andWhere('s.start_date', '>=', filterFields.start_date);
+    }
+
+    // End Date filter
+    if (filterFields.end_date) {
+      query.andWhere('s.end_date', '<=', filterFields.end_date);
+    }
+
+    // Project Name filter (like match)
+    if (filterFields.survey_name) {
+      query.andWhere('s.name', 'ilike', `%${filterFields.survey_name}%`);
+    }
+
+    // Project Name filter (like match)
+    if (filterFields.project_name) {
+      query.andWhere('p.name', 'ilike', `%${filterFields.project_name}%`);
+    }
+
+    // Focal Species filter
+    if (filterFields.itis_tsns?.length) {
+      // multiple
+      query.whereIn('sp.itis_tsn', filterFields.itis_tsns);
     }
 
     // Keyword Search filter
@@ -267,6 +353,38 @@ export class SurveyRepository extends BaseRepository {
     }
 
     const response = await this.connection.knex(query, FindSurveysResponse);
+
+    return response.rows;
+  }
+
+  /**
+   * Retrieves the paginated list of survey geometries that are available to the user.
+   *
+   * @param {boolean} isUserAdmin
+   * @param {(number | null)} systemUserId The system user id of the user making the request
+   * @param {ISurveyAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindSurveysSpatialResponse[]>}
+   * @memberof SurveyRepository
+   */
+  async findSurveysSpatial(
+    isUserAdmin: boolean,
+    systemUserId: number | null,
+    filterFields: ISurveyAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindSurveysSpatialResponse[]> {
+    const query = this._makeFindSurveySpatialQuery(isUserAdmin, systemUserId, filterFields);
+
+    // Pagination
+    if (pagination) {
+      query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
+
+      if (pagination.sort && pagination.order) {
+        query.orderBy(pagination.sort, pagination.order);
+      }
+    }
+
+    const response = await this.connection.knex(query, FindSurveysSpatialResponse);
 
     return response.rows;
   }

--- a/api/src/repositories/survey-repository.ts
+++ b/api/src/repositories/survey-repository.ts
@@ -254,7 +254,14 @@ export class SurveyRepository extends BaseRepository {
     const knex = getKnex();
 
     const query = knex
-      .distinct('s.survey_id', 's.project_id', 'sl.survey_location_id', 'sl.geojson')
+      .distinct(
+        's.survey_id',
+        's.project_id',
+        's.name as survey_name',
+        'p.name as project_name',
+        'sl.survey_location_id',
+        'sl.geojson'
+      )
       .from('survey_location as sl')
       .join('survey as s', 'sl.survey_id', 's.survey_id')
       .leftJoin('project as p', 'p.project_id', 's.project_id')

--- a/api/src/repositories/survey-repository.ts
+++ b/api/src/repositories/survey-repository.ts
@@ -354,8 +354,16 @@ export class SurveyRepository extends BaseRepository {
     if (pagination) {
       query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
 
-      if (pagination.sort && pagination.order) {
+      if (pagination.sort && pagination.order && !['survey_name', 'project_name'].includes(pagination.sort)) {
         query.orderBy(pagination.sort, pagination.order);
+      }
+
+      if (pagination.sort === 'survey_name') {
+        query.orderBy('s.name', pagination.order);
+      }
+
+      if (pagination.sort === 'project_name') {
+        query.orderBy('p.name', pagination.order);
       }
     }
 
@@ -386,8 +394,16 @@ export class SurveyRepository extends BaseRepository {
     if (pagination) {
       query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
 
-      if (pagination.sort && pagination.order) {
+      if (pagination.sort && pagination.order && !['survey_name', 'project_name'].includes(pagination.sort)) {
         query.orderBy(pagination.sort, pagination.order);
+      }
+
+      if (pagination.sort === 'survey_name') {
+        query.orderBy('s.name', pagination.order);
+      }
+
+      if (pagination.sort === 'project_name') {
+        query.orderBy('p.name', pagination.order);
       }
     }
 

--- a/api/src/services/survey-service.test.ts
+++ b/api/src/services/survey-service.test.ts
@@ -10,6 +10,8 @@ import { GetReportAttachmentsData } from '../models/project-view';
 import { PostProprietorData, PostSurveyObject } from '../models/survey-create';
 import { PostSurveyLocationData, PutSurveyObject, PutSurveyPermitData } from '../models/survey-update';
 import {
+  FindSurveysResponse,
+  FindSurveysSpatialResponse,
   GetAttachmentsData,
   GetFocalSpeciesData,
   GetSurveyData,
@@ -725,6 +727,93 @@ describe('SurveyService', () => {
 
       expect(deleteSurveyTypesDataStub).to.have.been.calledOnceWith(surveyId);
       expect(insertSurveyTypeStub).to.have.been.calledOnceWith([22, 33, 44]);
+    });
+  });
+
+  describe('findSurveys', () => {
+    it('returns rows on success', async () => {
+      const dbConnection = getMockDBConnection();
+      const service = new SurveyService(dbConnection);
+
+      const data: FindSurveysResponse[] = [
+        {
+          project_id: 1,
+          survey_id: 1,
+          name: 'Survey 1',
+          progress_id: 1,
+          regions: [],
+          start_date: '2020-01-01',
+          end_date: '2020-02-01',
+          focal_species: [],
+          types: []
+        },
+        {
+          project_id: 2,
+          survey_id: 2,
+          name: 'Survey 2',
+          progress_id: 1,
+          regions: [],
+          start_date: '2020-01-01',
+          end_date: '2020-02-01',
+          focal_species: [],
+          types: []
+        }
+      ];
+
+      const repoStub = sinon.stub(SurveyRepository.prototype, 'findSurveys').resolves(data);
+
+      const response = await service.findSurveys(true, 1, {});
+
+      expect(repoStub).to.be.calledOnce;
+      expect(response[0].survey_id).to.equal(1);
+      expect(response[0].name).to.equal('Survey 1');
+
+      expect(response[1].survey_id).to.equal(2);
+      expect(response[1].name).to.equal('Survey 2');
+    });
+  });
+
+  describe('findSurveysSpatial', () => {
+    it('returns rows on success', async () => {
+      const dbConnection = getMockDBConnection();
+      const service = new SurveyService(dbConnection);
+
+      const data: FindSurveysSpatialResponse[] = [
+        {
+          project_id: 1,
+          survey_id: 1,
+          survey_location_id: 1,
+          geojson: []
+        },
+        {
+          project_id: 2,
+          survey_id: 2,
+          survey_location_id: 2,
+          geojson: []
+        }
+      ];
+
+      const repoStub = sinon.stub(SurveyRepository.prototype, 'findSurveysSpatial').resolves(data);
+
+      const response = await service.findSurveysSpatial(true, 1, {});
+
+      expect(repoStub).to.be.calledOnce;
+      expect(response[0].survey_id).to.equal(1);
+      expect(response[1].survey_id).to.equal(2);
+    });
+  });
+
+  describe('findSurveysCount', () => {
+    it('returns the total survey count', async () => {
+      const dbConnection = getMockDBConnection();
+      const service = new SurveyService(dbConnection);
+
+      const repoStub = sinon.stub(SurveyRepository.prototype, 'findSurveysCount').resolves(10);
+
+      const response = await service.findSurveysCount(false, 1001, {});
+
+      expect(repoStub).to.be.calledOnce;
+      expect(response).to.eql(10);
     });
   });
 

--- a/api/src/services/survey-service.test.ts
+++ b/api/src/services/survey-service.test.ts
@@ -782,12 +782,16 @@ describe('SurveyService', () => {
         {
           project_id: 1,
           survey_id: 1,
+          project_name: 'name',
+          survey_name: 'name',
           survey_location_id: 1,
           geojson: []
         },
         {
           project_id: 2,
           survey_id: 2,
+          project_name: 'name',
+          survey_name: 'name',
           survey_location_id: 2,
           geojson: []
         }

--- a/api/src/services/survey-service.ts
+++ b/api/src/services/survey-service.ts
@@ -329,7 +329,7 @@ export class SurveyService extends DBService {
    * @param {(number | null)} systemUserId The system user id of the user making the request
    * @param {ISurveyAdvancedFilters} filterFields
    * @param {ApiPaginationOptions} [pagination]
-   * @returns {*} {Promise<{id: number}[]>}
+   * @returns {*} {Promise<FindSurveysResponse[]>}
    * @memberof SurveyRepository
    */
   async findSurveys(
@@ -349,7 +349,7 @@ export class SurveyService extends DBService {
    * @param {(number | null)} systemUserId The system user id of the user making the request
    * @param {ISurveyAdvancedFilters} filterFields
    * @param {ApiPaginationOptions} [pagination]
-   * @returns {*} {Promise<{id: number}[]>}
+   * @returns {*} {Promise<FindSurveysSpatialResponse[]>}
    * @memberof SurveyRepository
    */
   async findSurveysSpatial(

--- a/api/src/services/survey-service.ts
+++ b/api/src/services/survey-service.ts
@@ -4,6 +4,7 @@ import { PostProprietorData, PostSurveyObject } from '../models/survey-create';
 import { PostSurveyLocationData, PutPartnershipsData, PutSurveyObject } from '../models/survey-update';
 import {
   FindSurveysResponse,
+  FindSurveysSpatialResponse,
   GetAttachmentsData,
   GetFocalSpeciesData,
   GetPermitData,
@@ -338,6 +339,26 @@ export class SurveyService extends DBService {
     pagination?: ApiPaginationOptions
   ): Promise<FindSurveysResponse[]> {
     return this.surveyRepository.findSurveys(isUserAdmin, systemUserId, filterFields, pagination);
+  }
+
+  /**
+   * Retrieves the geometries of all surveys that are available to the user, based on their permissions and provided
+   * filter criteria.
+   *
+   * @param {boolean} isUserAdmin
+   * @param {(number | null)} systemUserId The system user id of the user making the request
+   * @param {ISurveyAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @returns {*} {Promise<{id: number}[]>}
+   * @memberof SurveyRepository
+   */
+  async findSurveysSpatial(
+    isUserAdmin: boolean,
+    systemUserId: number | null,
+    filterFields: ISurveyAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindSurveysSpatialResponse[]> {
+    return this.surveyRepository.findSurveysSpatial(isUserAdmin, systemUserId, filterFields, pagination);
   }
 
   /**

--- a/app/src/AppRouter.tsx
+++ b/app/src/AppRouter.tsx
@@ -59,7 +59,7 @@ const AppRouter: React.FC = () => {
 
       <Redirect exact from="/admin" to="/admin/summary" />
 
-      <RouteWithTitle path="/admin/summary" title={getTitle('Summary')}>
+      <RouteWithTitle path="/admin/summary" title={getTitle('Overview')}>
         <BaseLayout>
           <AuthenticatedRouteGuard>
             <CodesContextProvider>

--- a/app/src/components/layout/PageHeader.tsx
+++ b/app/src/components/layout/PageHeader.tsx
@@ -1,5 +1,4 @@
 import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -27,7 +26,7 @@ const PageHeader = (props: IPageHeader) => {
         top: 0,
         zIndex: 1002
       }}>
-      <Container maxWidth={'xl'} sx={{ py: { xs: 2, sm: 3 } }}>
+      <Box sx={{ px: 3, py: { xs: 2, sm: 3 } }}>
         {breadCrumbJSX}
         <Stack
           flexDirection={{ xs: 'column', md: 'row' }}
@@ -48,7 +47,7 @@ const PageHeader = (props: IPageHeader) => {
             </Stack>
           )}
         </Stack>
-      </Container>
+      </Box>
     </Paper>
   );
 };

--- a/app/src/features/alert/banner/SystemAlertBanner.tsx
+++ b/app/src/features/alert/banner/SystemAlertBanner.tsx
@@ -1,9 +1,9 @@
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js';
 import Icon from '@mdi/react';
+import { AlertProps } from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
-import grey from '@mui/material/colors/grey';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import AlertBar from 'components/alert/AlertBar';
@@ -13,7 +13,7 @@ import useDataLoader from 'hooks/useDataLoader';
 import { IAlert, SystemAlertBannerEnum } from 'interfaces/useAlertApi.interface';
 import { useEffect, useState } from 'react';
 
-interface ISystemAlertBannerProps {
+interface ISystemAlertBannerProps extends AlertProps {
   alertTypes?: SystemAlertBannerEnum[];
 }
 
@@ -27,7 +27,7 @@ const NumberOfAlertsShownInitially = 2;
  * @returns
  */
 export const SystemAlertBanner = (props: ISystemAlertBannerProps) => {
-  const { alertTypes } = props;
+  const { alertTypes, ...alertProps } = props;
 
   const biohubApi = useBiohubApi();
 
@@ -59,6 +59,7 @@ export const SystemAlertBanner = (props: ISystemAlertBannerProps) => {
           title={alert.name}
           key={alert.alert_id}
           variant="outlined"
+          {...alertProps}
         />
       );
 
@@ -89,21 +90,21 @@ export const SystemAlertBanner = (props: ISystemAlertBannerProps) => {
   }
 
   return (
-    <Box mb={3}>
+    <Box>
       {renderAlerts(alerts)}
       {numberOfAlerts > NumberOfAlertsShownInitially && (
         <Button
           variant="text"
           onClick={() => setIsExpanded((prev) => !prev)}
-          sx={{ color: grey[700] }}
+          color="primary"
           startIcon={<Icon path={(isExpanded && mdiChevronUp) || mdiChevronDown} size={0.8} />}>
-          <Typography variant="body2">
+          <Typography variant="body2" fontWeight={700} color="primary">
             {isExpanded ? (
               <>{'See fewer alerts'}</>
             ) : (
               <>
                 {'See more alerts'} &zwnj;
-                <Typography component="span" variant="inherit" color="textSecondary">
+                <Typography component="span" variant="inherit">
                   ({numberOfAlerts - NumberOfAlertsShownInitially})
                 </Typography>
               </>

--- a/app/src/features/summary/SummaryPage.tsx
+++ b/app/src/features/summary/SummaryPage.tsx
@@ -1,14 +1,12 @@
 import { mdiPlus } from '@mdi/js';
 import Icon from '@mdi/react';
 import Button from '@mui/material/Button';
-import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import PageHeader from 'components/layout/PageHeader';
 import { SystemRoleGuard } from 'components/security/Guards';
 import { SYSTEM_ROLE } from 'constants/roles';
 import { SystemAlertBanner } from 'features/alert/banner/SystemAlertBanner';
 import { ListDataTableContainer } from 'features/summary/list-data/ListDataTableContainer';
-import { TabularDataTableContainer } from 'features/summary/tabular-data/TabularDataTableContainer';
 import { SystemAlertBannerEnum } from 'interfaces/useAlertApi.interface';
 import { Link as RouterLink } from 'react-router-dom';
 
@@ -21,7 +19,7 @@ const SummaryPage = () => {
   return (
     <>
       <PageHeader
-        title="Summary"
+        title="Overview"
         buttonJSX={
           <SystemRoleGuard
             validSystemRoles={[SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.PROJECT_CREATOR, SYSTEM_ROLE.DATA_ADMINISTRATOR]}>
@@ -37,16 +35,10 @@ const SummaryPage = () => {
         }
       />
 
-      <Container maxWidth="xl" sx={{ py: 3 }}>
-        <SystemAlertBanner alertTypes={[SystemAlertBannerEnum.SUMMARY]} />
-
-        <Paper>
-          <ListDataTableContainer />
-        </Paper>
-        <Paper sx={{ mt: 3 }}>
-          <TabularDataTableContainer />
-        </Paper>
-      </Container>
+      <Paper>
+        <SystemAlertBanner alertTypes={[SystemAlertBannerEnum.SUMMARY]} sx={{ mx: 2, mt: 2 }} />
+        <ListDataTableContainer />
+      </Paper>
     </>
   );
 };

--- a/app/src/features/summary/list-data/ListDataTableContainer.tsx
+++ b/app/src/features/summary/list-data/ListDataTableContainer.tsx
@@ -1,4 +1,4 @@
-import { mdiFolder, mdiListBoxOutline, mdiMagnify } from '@mdi/js';
+import { mdiDatabaseSearch, mdiFolder, mdiListBoxOutline, mdiMagnify } from '@mdi/js';
 import Icon from '@mdi/react';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
@@ -11,11 +11,13 @@ import SurveysListContainer from 'features/summary/list-data/survey/SurveysListC
 import { useSearchParams } from 'hooks/useSearchParams';
 import { MarkdownTypeNameEnum } from 'interfaces/useMarkdownApi.interface';
 import { useState } from 'react';
+import { TabularDataTableContainer } from '../tabular-data/TabularDataTableContainer';
 
 export const ACTIVE_VIEW_KEY = 'lvk';
 export enum ACTIVE_VIEW_VALUE {
   projects = 'pv',
-  surveys = 'sv'
+  surveys = 'sv',
+  data = 'dv'
 }
 
 export const SHOW_SEARCH_KEY = 'lvsk';
@@ -45,7 +47,8 @@ export const ListDataTableContainer = () => {
 
   const views = [
     { value: ACTIVE_VIEW_VALUE.projects, label: 'projects', icon: mdiFolder },
-    { value: ACTIVE_VIEW_VALUE.surveys, label: 'surveys', icon: mdiListBoxOutline }
+    { value: ACTIVE_VIEW_VALUE.surveys, label: 'surveys', icon: mdiListBoxOutline },
+    { value: ACTIVE_VIEW_VALUE.data, label: 'data', icon: mdiDatabaseSearch }
   ];
 
   return (
@@ -80,6 +83,7 @@ export const ListDataTableContainer = () => {
       <Divider />
       {activeView === ACTIVE_VIEW_VALUE.projects && <ProjectsListContainer showSearch={showSearch} />}
       {activeView === ACTIVE_VIEW_VALUE.surveys && <SurveysListContainer showSearch={showSearch} />}
+      {activeView === ACTIVE_VIEW_VALUE.data && <TabularDataTableContainer />}
     </>
   );
 };

--- a/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
@@ -136,7 +136,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
             }
           ]
         : [],
-    [geometryDataLoader.data?.surveys]
+    [geometryDataLoader.data]
   );
 
   // Define the columns for the DataGrid

--- a/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
@@ -17,6 +17,7 @@ import { getNrmRegionColour, NrmRegionKeys } from 'constants/colours';
 import { NRM_REGION_APPENDED_TEXT } from 'constants/regions';
 import { TeamMemberAvatar } from 'features/projects/view/components/TeamMemberAvatar';
 import SurveyMap from 'features/surveys/view/SurveyMap';
+import SurveyMapTooltip from 'features/surveys/view/SurveyMapTooltip';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
@@ -26,6 +27,7 @@ import { useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
 import { firstOrNull, getRandomHexColor } from 'utils/Utils';
+import { ProjectSpatialStudyAreaPopup } from './map-popup/ProjectSpatialStudyAreaPopup';
 import ProjectsListFilterForm, {
   IProjectAdvancedFilters,
   ProjectAdvancedFiltersInitialValues
@@ -54,7 +56,7 @@ interface IProjectsListContainerProps {
 // Default pagination parameters
 const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
   page: 0,
-  limit: 10,
+  limit: 25,
   sort: 'project_id',
   order: 'desc'
 };
@@ -131,8 +133,27 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
               features: geometryDataLoader.data?.surveys.map((survey) => ({
                 id: survey.survey_location_id,
                 key: survey.survey_location_id,
-                geoJSON: survey.geojson[0]
-              }))
+                geoJSON: {
+                  ...survey.geojson[0],
+                  properties: {
+                    survey_id: survey.survey_id,
+                    project_id: survey.project_id,
+                    survey_name: survey.survey_name,
+                    project_name: survey.project_name
+                  }
+                }
+              })),
+              popup: (feature) => (
+                <ProjectSpatialStudyAreaPopup
+                  projectId={feature.geoJSON.properties?.project_id}
+                />
+              ),
+              tooltip: (feature) => (
+                <SurveyMapTooltip
+                  title={feature.geoJSON.properties?.project_name}
+                  key={feature.id}
+                />
+              )
             }
           ]
         : [],

--- a/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
@@ -56,7 +56,7 @@ interface IProjectsListContainerProps {
 // Default pagination parameters
 const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
   page: 0,
-  limit: 25,
+  limit: 10,
   sort: 'project_id',
   order: 'desc'
 };
@@ -143,16 +143,9 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
                   }
                 }
               })),
-              popup: (feature) => (
-                <ProjectSpatialStudyAreaPopup
-                  projectId={feature.geoJSON.properties?.project_id}
-                />
-              ),
+              popup: (feature) => <ProjectSpatialStudyAreaPopup projectId={feature.geoJSON.properties?.project_id} />,
               tooltip: (feature) => (
-                <SurveyMapTooltip
-                  title={feature.geoJSON.properties?.project_name}
-                  key={feature.id}
-                />
+                <SurveyMapTooltip title={feature.geoJSON.properties?.project_name} key={feature.id} />
               )
             }
           ]
@@ -179,7 +172,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
       )
     },
     {
-      field: 'name',
+      field: 'project_name',
       headerName: 'Name',
       flex: 1,
       disableColumnMenu: true,
@@ -202,6 +195,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
     {
       field: 'members',
       headerName: 'Members',
+      sortable: false,
       flex: 0.4,
       renderCell: (params) => (
         <Stack direction="row" gap={0.5} flexWrap="wrap">
@@ -223,6 +217,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
     {
       field: 'regions',
       headerName: 'Region',
+      sortable: false,
       type: 'string',
       flex: 0.5,
       renderCell: (params) => (

--- a/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListContainer.tsx
@@ -11,10 +11,12 @@ import ColouredRectangleChip from 'components/chips/ColouredRectangleChip';
 import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
 import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { SkeletonTable } from 'components/loading/SkeletonLoaders';
+import { IStaticLayer } from 'components/map/components/StaticLayers';
 import { NoDataOverlay } from 'components/overlay/NoDataOverlay';
 import { getNrmRegionColour, NrmRegionKeys } from 'constants/colours';
 import { NRM_REGION_APPENDED_TEXT } from 'constants/regions';
 import { TeamMemberAvatar } from 'features/projects/view/components/TeamMemberAvatar';
+import SurveyMap from 'features/surveys/view/SurveyMap';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
@@ -86,7 +88,9 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
     itis_tsn: searchParams.get('p_itis_tsn')
       ? Number(searchParams.get('p_itis_tsn'))
       : ProjectAdvancedFiltersInitialValues.itis_tsn,
-    system_user_id: searchParams.get('p_system_user_id') ?? ProjectAdvancedFiltersInitialValues.system_user_id
+    system_user_id: searchParams.get('p_system_user_id')
+      ? Number(searchParams.get('p_system_user_id'))
+      : ProjectAdvancedFiltersInitialValues.system_user_id
   });
 
   const sort = firstOrNull(sortModel);
@@ -105,12 +109,35 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
       biohubApi.project.findProjects(pagination, filter)
   );
 
+  const geometryDataLoader = useDataLoader(
+    (pagination: ApiPaginationRequestOptions, filter?: IProjectAdvancedFilters) =>
+      biohubApi.survey.findSurveysSpatial(pagination, filter)
+  );
+
   // Fetch projects when either the pagination, sort, or advanced filters change
   useDeepCompareEffect(() => {
     projectsDataLoader.refresh(paginationSort, advancedFiltersModel);
+    geometryDataLoader.refresh(paginationSort, advancedFiltersModel);
   }, [advancedFiltersModel, paginationSort]);
 
   const rows = projectsDataLoader.data?.projects ?? [];
+
+  const geometries: IStaticLayer[] = useMemo(
+    () =>
+      geometryDataLoader.data
+        ? [
+            {
+              layerName: 'Surveys',
+              features: geometryDataLoader.data?.surveys.map((survey) => ({
+                id: survey.survey_location_id,
+                key: survey.survey_location_id,
+                geoJSON: survey.geojson[0]
+              }))
+            }
+          ]
+        : [],
+    [geometryDataLoader.data?.surveys]
+  );
 
   // Define the columns for the DataGrid
   const columns: GridColDef<IProjectsListItemData>[] = [
@@ -210,7 +237,11 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
         <Divider />
       </Collapse>
 
-      <Box height="90vh" maxHeight="700px">
+      <Box height="50vh" position="relative">
+        <SurveyMap staticLayers={geometries} isLoading={geometryDataLoader.isLoading} />
+      </Box>
+
+      <Box height="70vh" maxHeight="700px">
         <LoadingGuard
           isLoading={!rows.length && (projectsDataLoader.isLoading || !projectsDataLoader.isReady)}
           isLoadingFallback={<SkeletonTable />}
@@ -218,7 +249,7 @@ const ProjectsListContainer = (props: IProjectsListContainerProps) => {
           hasNoData={!rows.length}
           hasNoDataFallback={
             <NoDataOverlay
-              height="400px"
+              height="100%"
               title="Create or Join Projects"
               subtitle="You currently have no projects. Once you create or get invited to projects, they will be displayed here"
               icon={mdiArrowTopRight}

--- a/app/src/features/summary/list-data/project/ProjectsListFilterForm.tsx
+++ b/app/src/features/summary/list-data/project/ProjectsListFilterForm.tsx
@@ -8,7 +8,7 @@ import { useTaxonomyContext } from 'hooks/useContext';
 export type IProjectAdvancedFilters = {
   keyword?: string;
   itis_tsn?: number;
-  system_user_id?: string;
+  system_user_id?: number;
 };
 
 export const ProjectAdvancedFiltersInitialValues: IProjectAdvancedFilters = {

--- a/app/src/features/summary/list-data/project/map-popup/ProjectSpatialStudyAreaPopup.tsx
+++ b/app/src/features/summary/list-data/project/map-popup/ProjectSpatialStudyAreaPopup.tsx
@@ -33,16 +33,21 @@ export const ProjectSpatialStudyAreaPopup = (props: IProjectSpatialStudyAreaPopu
 
     return [
       { label: 'Project', value: projectDataLoader.data.projectData.project.project_name },
-      { label: 'Members', value: projectDataLoader.data.projectData.participants.map((participant) => <TeamMemberAvatar
-                    key={participant.system_user_id}
-                    tooltip={participant.display_name}
-                    label={participant.display_name
-                      .split(',')
-                      .map((name) => name.trim().slice(0, 1).toUpperCase())
-                      .reverse()
-                      .join('')}
-                    color={getRandomHexColor(participant.system_user_id)}
-                  />)}
+      {
+        label: 'Members',
+        value: projectDataLoader.data.projectData.participants.map((participant) => (
+          <TeamMemberAvatar
+            key={participant.system_user_id}
+            tooltip={participant.display_name}
+            label={participant.display_name
+              .split(',')
+              .map((name) => name.trim().slice(0, 1).toUpperCase())
+              .reverse()
+              .join('')}
+            color={getRandomHexColor(participant.system_user_id)}
+          />
+        ))
+      }
     ];
   }, [projectDataLoader.data]);
 

--- a/app/src/features/summary/list-data/project/map-popup/ProjectSpatialStudyAreaPopup.tsx
+++ b/app/src/features/summary/list-data/project/map-popup/ProjectSpatialStudyAreaPopup.tsx
@@ -1,0 +1,70 @@
+import { TeamMemberAvatar } from 'features/projects/view/components/TeamMemberAvatar';
+import { SurveyMapPopup } from 'features/surveys/view/SurveyMapPopup';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import useDataLoader from 'hooks/useDataLoader';
+import { useMemo } from 'react';
+import { Popup } from 'react-leaflet';
+
+import { useHistory } from 'react-router';
+import { getRandomHexColor } from 'utils/Utils';
+
+interface IProjectSpatialStudyAreaPopupProps {
+  projectId: number;
+}
+
+/**
+ * Returns information about a project with an action button for opening the project
+ *
+ * @param {IProjectSpatialStudyAreaPopupProps} props
+ * @returns {*}
+ */
+export const ProjectSpatialStudyAreaPopup = (props: IProjectSpatialStudyAreaPopupProps) => {
+  const { projectId } = props;
+
+  const biohubApi = useBiohubApi();
+  const history = useHistory();
+
+  const projectDataLoader = useDataLoader(() => biohubApi.project.getProjectForView(projectId));
+
+  const popupMetadata = useMemo(() => {
+    if (!projectDataLoader.data) {
+      return [];
+    }
+
+    return [
+      { label: 'Project', value: projectDataLoader.data.projectData.project.project_name },
+      { label: 'Members', value: projectDataLoader.data.projectData.participants.map((participant) => <TeamMemberAvatar
+                    key={participant.system_user_id}
+                    tooltip={participant.display_name}
+                    label={participant.display_name
+                      .split(',')
+                      .map((name) => name.trim().slice(0, 1).toUpperCase())
+                      .reverse()
+                      .join('')}
+                    color={getRandomHexColor(participant.system_user_id)}
+                  />)}
+    ];
+  }, [projectDataLoader.data]);
+
+  return (
+    <Popup
+      keepInView={false}
+      closeButton={true}
+      autoPan={true}
+      maxWidth={450}
+      eventHandlers={{
+        add: async () => {
+          projectDataLoader.load();
+        }
+      }}>
+      <SurveyMapPopup
+        isLoading={projectDataLoader.isLoading}
+        title="Project Details"
+        metadata={popupMetadata}
+        key={`project-popup-${projectId}`}
+        actionButtonLabel="Open Project"
+        handleActionButtonClick={() => history.push(`/admin/projects/${projectId}/details`)}
+      />
+    </Popup>
+  );
+};

--- a/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
+++ b/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
@@ -59,7 +59,7 @@ interface ISurveysListContainerProps {
 // Default pagination parameters
 const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
   page: 0,
-  limit: 25,
+  limit: 10,
   sort: 'survey_id',
   order: 'desc'
 };
@@ -149,10 +149,7 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
                 />
               ),
               tooltip: (feature) => (
-                <SurveyMapTooltip
-                  title={feature.geoJSON.properties?.survey_name}
-                  key={feature.id}
-                />
+                <SurveyMapTooltip title={feature.geoJSON.properties?.survey_name} key={feature.id} />
               )
             }
           ]
@@ -183,7 +180,7 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
       )
     },
     {
-      field: 'name',
+      field: 'survey_name',
       headerName: 'Name',
       flex: 1,
       disableColumnMenu: true,

--- a/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
+++ b/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
@@ -11,21 +11,24 @@ import ColouredRectangleChip from 'components/chips/ColouredRectangleChip';
 import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
 import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { SkeletonTable } from 'components/loading/SkeletonLoaders';
+import { IStaticLayer } from 'components/map/components/StaticLayers';
 import { NoDataOverlay } from 'components/overlay/NoDataOverlay';
 import { getNrmRegionColour, NrmRegionKeys } from 'constants/colours';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { NRM_REGION_APPENDED_TEXT } from 'constants/regions';
 import dayjs from 'dayjs';
 import { SurveyProgressChip } from 'features/surveys/components/SurveyProgressChip';
+import SurveyMap from 'features/surveys/view/SurveyMap';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
 import { useSearchParams } from 'hooks/useSearchParams';
 import { SurveyBasicFieldsObject } from 'interfaces/useSurveyApi.interface';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
 import { firstOrNull } from 'utils/Utils';
+import { IProjectAdvancedFilters } from '../project/ProjectsListFilterForm';
 import SurveysListFilterForm, {
   ISurveyAdvancedFilters,
   SurveyAdvancedFiltersInitialValues
@@ -88,7 +91,9 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
     itis_tsn: searchParams.get('s_itis_tsn')
       ? Number(searchParams.get('s_itis_tsn'))
       : SurveyAdvancedFiltersInitialValues.itis_tsn,
-    system_user_id: searchParams.get('s_system_user_id') ?? SurveyAdvancedFiltersInitialValues.system_user_id
+    system_user_id: searchParams.get('s_system_user_id')
+      ? Number(searchParams.get('s_system_user_id'))
+      : SurveyAdvancedFiltersInitialValues.system_user_id
   });
 
   const sort = firstOrNull(sortModel);
@@ -103,12 +108,40 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
     biohubApi.survey.findSurveys(pagination, filter)
   );
 
+  const geometryDataLoader = useDataLoader(
+    (pagination: ApiPaginationRequestOptions, filter?: IProjectAdvancedFilters) =>
+      biohubApi.survey.findSurveysSpatial(pagination, filter)
+  );
+
+  // Fetch projects when either the pagination, sort, or advanced filters change
+  useDeepCompareEffect(() => {
+    surveysDataLoader.refresh(paginationSort, advancedFiltersModel);
+    geometryDataLoader.refresh(paginationSort, advancedFiltersModel);
+  }, [advancedFiltersModel, paginationSort]);
+
+  const rows = surveysDataLoader.data?.surveys ?? [];
+
+  const geometries: IStaticLayer[] = useMemo(
+    () =>
+      geometryDataLoader.data
+        ? [
+            {
+              layerName: 'Surveys',
+              features: geometryDataLoader.data?.surveys.map((survey) => ({
+                id: survey.survey_location_id,
+                key: survey.survey_location_id,
+                geoJSON: survey.geojson[0]
+              }))
+            }
+          ]
+        : [],
+    [geometryDataLoader.data?.surveys]
+  );
+
   // Fetch projects when either the pagination, sort, or advanced filters change
   useDeepCompareEffect(() => {
     surveysDataLoader.refresh(paginationSort, advancedFiltersModel);
   }, [advancedFiltersModel, paginationSort]);
-
-  const rows = surveysDataLoader.data?.surveys ?? [];
 
   const columns: GridColDef<SurveyBasicFieldsObject>[] = [
     {
@@ -217,7 +250,11 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
         <Divider />
       </Collapse>
 
-      <Box height="90vh" maxHeight="700px">
+      <Box height="50vh" position="relative">
+        <SurveyMap staticLayers={geometries} isLoading={geometryDataLoader.isLoading} />
+      </Box>
+
+      <Box height="70vh" maxHeight="700px">
         <LoadingGuard
           isLoading={!rows.length && (surveysDataLoader.isLoading || !surveysDataLoader.isReady)}
           isLoadingFallback={<SkeletonTable />}
@@ -225,7 +262,7 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
           hasNoData={!rows.length}
           hasNoDataFallback={
             <NoDataOverlay
-              height="400px"
+              height="100%"
               title="Create Surveys in Projects"
               subtitle="You currently have no surveys. Once you create or get invited to projects with surveys, they will be displayed here"
               icon={mdiArrowTopRight}

--- a/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
+++ b/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
@@ -19,6 +19,7 @@ import { NRM_REGION_APPENDED_TEXT } from 'constants/regions';
 import dayjs from 'dayjs';
 import { SurveyProgressChip } from 'features/surveys/components/SurveyProgressChip';
 import SurveyMap from 'features/surveys/view/SurveyMap';
+import SurveyMapTooltip from 'features/surveys/view/SurveyMapTooltip';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
@@ -29,6 +30,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
 import { firstOrNull } from 'utils/Utils';
 import { IProjectAdvancedFilters } from '../project/ProjectsListFilterForm';
+import { SurveySpatialStudyAreaPopup } from './map-popup/SurveySpatialStudyAreaPopup';
 import SurveysListFilterForm, {
   ISurveyAdvancedFilters,
   SurveyAdvancedFiltersInitialValues
@@ -57,7 +59,7 @@ interface ISurveysListContainerProps {
 // Default pagination parameters
 const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
   page: 0,
-  limit: 10,
+  limit: 25,
   sort: 'survey_id',
   order: 'desc'
 };
@@ -130,8 +132,28 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
               features: geometryDataLoader.data?.surveys.map((survey) => ({
                 id: survey.survey_location_id,
                 key: survey.survey_location_id,
-                geoJSON: survey.geojson[0]
-              }))
+                geoJSON: {
+                  ...survey.geojson[0],
+                  properties: {
+                    survey_id: survey.survey_id,
+                    project_id: survey.project_id,
+                    survey_name: survey.survey_name,
+                    project_name: survey.project_name
+                  }
+                }
+              })),
+              popup: (feature) => (
+                <SurveySpatialStudyAreaPopup
+                  surveyId={feature.geoJSON.properties?.survey_id}
+                  projectId={feature.geoJSON.properties?.project_id}
+                />
+              ),
+              tooltip: (feature) => (
+                <SurveyMapTooltip
+                  title={feature.geoJSON.properties?.survey_name}
+                  key={feature.id}
+                />
+              )
             }
           ]
         : [],

--- a/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
+++ b/app/src/features/summary/list-data/survey/SurveysListContainer.tsx
@@ -135,7 +135,7 @@ const SurveysListContainer = (props: ISurveysListContainerProps) => {
             }
           ]
         : [],
-    [geometryDataLoader.data?.surveys]
+    [geometryDataLoader.data]
   );
 
   // Fetch projects when either the pagination, sort, or advanced filters change

--- a/app/src/features/summary/list-data/survey/SurveysListFilterForm.tsx
+++ b/app/src/features/summary/list-data/survey/SurveysListFilterForm.tsx
@@ -8,7 +8,7 @@ import { useTaxonomyContext } from 'hooks/useContext';
 export type ISurveyAdvancedFilters = {
   keyword?: string;
   itis_tsn?: number;
-  system_user_id?: string;
+  system_user_id?: number;
 };
 
 export const SurveyAdvancedFiltersInitialValues: ISurveyAdvancedFilters = {

--- a/app/src/features/summary/list-data/survey/map-popup/SurveySpatialStudyAreaPopup.tsx
+++ b/app/src/features/summary/list-data/survey/map-popup/SurveySpatialStudyAreaPopup.tsx
@@ -1,0 +1,72 @@
+import { DATE_FORMAT } from 'constants/dateTimeFormats';
+import dayjs from 'dayjs';
+import { SurveyMapPopup } from 'features/surveys/view/SurveyMapPopup';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import useDataLoader from 'hooks/useDataLoader';
+import { useMemo } from 'react';
+import { Popup } from 'react-leaflet';
+
+import { useHistory } from 'react-router';
+
+interface ISurveySpatialStudyAreaPopupProps {
+  surveyId: number;
+  projectId: number;
+}
+
+/**
+ * Returns information about a survey with an action button for opening the survey
+ *
+ * @param {ISurveySpatialStudyAreaPopupProps} props
+ * @returns {*}
+ */
+export const SurveySpatialStudyAreaPopup = (props: ISurveySpatialStudyAreaPopupProps) => {
+  const { projectId, surveyId } = props;
+
+  const biohubApi = useBiohubApi();
+  const history = useHistory();
+
+  const projectDataLoader = useDataLoader(() => biohubApi.project.getProjectForView(projectId));
+  const surveyDataLoader = useDataLoader(() => biohubApi.survey.getSurveyForView(projectId, surveyId));
+
+  const popupMetadata = useMemo(() => {
+    if (!surveyDataLoader.data || !projectDataLoader.data) {
+      return [];
+    }
+
+    return [
+      { label: 'Project', value: projectDataLoader.data.projectData.project.project_name },
+      { label: 'Survey', value: surveyDataLoader.data.surveyData.survey_details.survey_name },
+      {
+        label: 'Start Date',
+        value: dayjs(surveyDataLoader.data.surveyData.survey_details.start_date).format(DATE_FORMAT.LongDateTimeFormat)
+      },
+      {
+        label: 'End Date',
+        value: dayjs(surveyDataLoader.data.surveyData.survey_details.end_date).format(DATE_FORMAT.LongDateTimeFormat)
+      }
+    ];
+  }, [surveyDataLoader.data, projectDataLoader.data]);
+
+  return (
+    <Popup
+      keepInView={false}
+      closeButton={true}
+      autoPan={true}
+      maxWidth={450}
+      eventHandlers={{
+        add: async () => {
+          projectDataLoader.load();
+          surveyDataLoader.load();
+        }
+      }}>
+      <SurveyMapPopup
+        isLoading={surveyDataLoader.isLoading || projectDataLoader.isLoading}
+        title="Survey Details"
+        metadata={popupMetadata}
+        key={`survey-popup-${surveyId}`}
+        actionButtonLabel="Open Survey"
+        handleActionButtonClick={() => history.push(`/admin/projects/${projectId}/surveys/${surveyId}/details`)}
+      />
+    </Popup>
+  );
+};

--- a/app/src/features/surveys/view/SurveyMapPopup.tsx
+++ b/app/src/features/surveys/view/SurveyMapPopup.tsx
@@ -1,15 +1,19 @@
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { ReactNode } from 'react';
 
 export interface ISurveyMapPopupProps {
   isLoading: boolean;
   title: string;
   metadata: {
     label: string;
-    value: string | number | null;
+    value: string | number | null | ReactNode;
   }[];
+  actionButtonLabel?: string;
+  handleActionButtonClick?: () => void;
 }
 
 /**
@@ -19,7 +23,7 @@ export interface ISurveyMapPopupProps {
  * @return {*}
  */
 export const SurveyMapPopup = (props: ISurveyMapPopupProps) => {
-  const { isLoading, title, metadata } = props;
+  const { isLoading, title, metadata, actionButtonLabel, handleActionButtonClick } = props;
 
   return (
     <Box>
@@ -64,7 +68,7 @@ export const SurveyMapPopup = (props: ISurveyMapPopupProps) => {
             }}>
             {title}
           </Typography>
-          <Box component="dl" mt={1} mb={0}>
+          <Stack gap={1} component="dl" mt={1} mb={0}>
             {metadata.map((metadata) => (
               <Stack
                 key={`${metadata.label}-${metadata.value}`}
@@ -80,7 +84,12 @@ export const SurveyMapPopup = (props: ISurveyMapPopupProps) => {
                 </Box>
               </Stack>
             ))}
-          </Box>
+          </Stack>
+          {handleActionButtonClick && (
+            <Box mt={2}>
+              <Button fullWidth onClick={handleActionButtonClick} variant='contained'>{actionButtonLabel}</Button>
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/app/src/features/surveys/view/SurveyMapPopup.tsx
+++ b/app/src/features/surveys/view/SurveyMapPopup.tsx
@@ -87,7 +87,9 @@ export const SurveyMapPopup = (props: ISurveyMapPopupProps) => {
           </Stack>
           {handleActionButtonClick && (
             <Box mt={2}>
-              <Button fullWidth onClick={handleActionButtonClick} variant='contained'>{actionButtonLabel}</Button>
+              <Button fullWidth onClick={handleActionButtonClick} variant="contained">
+                {actionButtonLabel}
+              </Button>
             </Box>
           )}
         </Box>

--- a/app/src/features/surveys/view/SurveyPage.tsx
+++ b/app/src/features/surveys/view/SurveyPage.tsx
@@ -39,13 +39,13 @@ const SurveyPage: React.FC = () => {
         <SystemAlertBanner alertTypes={[SystemAlertBannerEnum.SURVEYS]} />
         <Stack gap={3}>
           <Paper>
-            <SurveySamplingTableContainer />
-          </Paper>
-
-          <Paper>
             <TaxonomyContextProvider>
               <SurveySpatialContainer />
             </TaxonomyContextProvider>
+          </Paper>
+
+          <Paper>
+            <SurveySamplingTableContainer />
           </Paper>
 
           <Paper>

--- a/app/src/features/surveys/view/SurveyPage.tsx
+++ b/app/src/features/surveys/view/SurveyPage.tsx
@@ -39,13 +39,13 @@ const SurveyPage: React.FC = () => {
         <SystemAlertBanner alertTypes={[SystemAlertBannerEnum.SURVEYS]} />
         <Stack gap={3}>
           <Paper>
-            <TaxonomyContextProvider>
-              <SurveySpatialContainer />
-            </TaxonomyContextProvider>
+            <SurveySamplingTableContainer />
           </Paper>
 
           <Paper>
-            <SurveySamplingTableContainer />
+            <TaxonomyContextProvider>
+              <SurveySpatialContainer />
+            </TaxonomyContextProvider>
           </Paper>
 
           <Paper>

--- a/app/src/hooks/api/useSurveyApi.ts
+++ b/app/src/hooks/api/useSurveyApi.ts
@@ -88,11 +88,11 @@ const useSurveyApi = (axios: AxiosInstance) => {
   };
 
   /**
-   * Get survey geometries for a system user id.
+   * Get survey spatial geometries for a system user id.
    *
    * @param {ApiPaginationRequestOptions} [pagination]
    * @param {ISurveyAdvancedFilters} filterFieldData
-   * @return {*} {Promise<IFindProjectsResponse[]>}
+   * @return {*} {Promise<IFindSurveysSpatialResponse>}
    */
   const findSurveysSpatial = async (
     pagination?: ApiPaginationRequestOptions,

--- a/app/src/hooks/api/useSurveyApi.ts
+++ b/app/src/hooks/api/useSurveyApi.ts
@@ -11,6 +11,7 @@ import {
   ICreateSurveyRequest,
   ICreateSurveyResponse,
   IFindSurveysResponse,
+  IFindSurveysSpatialResponse,
   IGetSurveyAttachmentsResponse,
   IGetSurveyForUpdateResponse,
   IGetSurveyForViewResponse,
@@ -82,6 +83,30 @@ const useSurveyApi = (axios: AxiosInstance) => {
     };
 
     const { data } = await axios.get('/api/survey', { params, paramsSerializer: (params) => qs.stringify(params) });
+
+    return data;
+  };
+
+  /**
+   * Get survey geometries for a system user id.
+   *
+   * @param {ApiPaginationRequestOptions} [pagination]
+   * @param {ISurveyAdvancedFilters} filterFieldData
+   * @return {*} {Promise<IFindProjectsResponse[]>}
+   */
+  const findSurveysSpatial = async (
+    pagination?: ApiPaginationRequestOptions,
+    filterFieldData?: ISurveyAdvancedFilters
+  ): Promise<IFindSurveysSpatialResponse> => {
+    const params = {
+      ...pagination,
+      ...filterFieldData
+    };
+
+    const { data } = await axios.get('/api/survey/spatial', {
+      params,
+      paramsSerializer: (params) => qs.stringify(params)
+    });
 
     return data;
   };
@@ -612,6 +637,7 @@ const useSurveyApi = (axios: AxiosInstance) => {
     getSurveysBasicFieldsByProjectId,
     getSurveyForUpdate,
     findSurveys,
+    findSurveysSpatial,
     updateSurvey,
     uploadSurveyAttachments,
     uploadSurveyReports,

--- a/app/src/interfaces/useProjectApi.interface.ts
+++ b/app/src/interfaces/useProjectApi.interface.ts
@@ -3,7 +3,6 @@ import { PROJECT_PERMISSION, PROJECT_ROLE } from 'constants/roles';
 import { IProjectDetailsForm } from 'features/projects/components/ProjectDetailsForm';
 import { IProjectIUCNForm } from 'features/projects/components/ProjectIUCNForm';
 import { IProjectObjectivesForm } from 'features/projects/components/ProjectObjectivesForm';
-import { Feature, FeatureCollection } from 'geojson';
 import { ApiPaginationResponseParams } from 'types/misc';
 
 export interface IGetProjectAttachment {
@@ -67,19 +66,6 @@ export interface IGetUserProjectsListResponse {
   project_role_ids: number[];
   project_role_names: string[];
   project_role_permissions: string[];
-}
-
-/**
- * Get project geometriesresponse object.
- *
- * @export
- * @interface IGetUserProjectGeometriesResponse
- */
-export interface IGetUserProjectGeometriesResponse {
-  project_participation_id: number;
-  project_id: number;
-  survey_id: string;
-  geometry: FeatureCollection;
 }
 
 /**
@@ -147,18 +133,6 @@ export interface IProjectsListItemData {
    * Members of the project
    */
   members: { system_user_id: number; display_name: string }[];
-}
-
-export interface IProjectGeometryItem {
-  project_id: number;
-  /**
-   * The survey that the geometry comes from
-   */
-  survey_id: string;
-  /**
-   * Feature collection for the potentially many geometry in a Survey
-   */
-  geojson: Feature;
 }
 
 export interface IProjectUserRoles {

--- a/app/src/interfaces/useProjectApi.interface.ts
+++ b/app/src/interfaces/useProjectApi.interface.ts
@@ -3,6 +3,7 @@ import { PROJECT_PERMISSION, PROJECT_ROLE } from 'constants/roles';
 import { IProjectDetailsForm } from 'features/projects/components/ProjectDetailsForm';
 import { IProjectIUCNForm } from 'features/projects/components/ProjectIUCNForm';
 import { IProjectObjectivesForm } from 'features/projects/components/ProjectObjectivesForm';
+import { Feature, FeatureCollection } from 'geojson';
 import { ApiPaginationResponseParams } from 'types/misc';
 
 export interface IGetProjectAttachment {
@@ -69,6 +70,19 @@ export interface IGetUserProjectsListResponse {
 }
 
 /**
+ * Get project geometriesresponse object.
+ *
+ * @export
+ * @interface IGetUserProjectGeometriesResponse
+ */
+export interface IGetUserProjectGeometriesResponse {
+  project_participation_id: number;
+  project_id: number;
+  survey_id: string;
+  geometry: FeatureCollection;
+}
+
+/**
  * Get surveys list response object.
  *
  * @export
@@ -103,7 +117,6 @@ export interface IFindProjectsResponse {
   projects: IProjectsListItemData[];
   pagination: ApiPaginationResponseParams;
 }
-
 export interface IProjectsListItemData {
   project_id: number;
   /**
@@ -134,6 +147,18 @@ export interface IProjectsListItemData {
    * Members of the project
    */
   members: { system_user_id: number; display_name: string }[];
+}
+
+export interface IProjectGeometryItem {
+  project_id: number;
+  /**
+   * The survey that the geometry comes from
+   */
+  survey_id: string;
+  /**
+   * Feature collection for the potentially many geometry in a Survey
+   */
+  geojson: Feature;
 }
 
 export interface IProjectUserRoles {

--- a/app/src/interfaces/useSurveyApi.interface.ts
+++ b/app/src/interfaces/useSurveyApi.interface.ts
@@ -292,6 +292,14 @@ export interface ISurveySpatialItem {
    */
   survey_id: string;
   /**
+   * The name of the survey
+   */
+  survey_name: string;
+  /**
+   * The name of the project
+   */
+  project_name: string;
+  /**
    * The survey location id of the geometry
    */
   survey_location_id: string;

--- a/app/src/interfaces/useSurveyApi.interface.ts
+++ b/app/src/interfaces/useSurveyApi.interface.ts
@@ -272,6 +272,36 @@ export interface IFindSurveysResponse {
 }
 
 /**
+ * Find surveys spatial response object.
+ *
+ * @export
+ * @interface IFindSurveysSpatialResponse
+ */
+export interface IFindSurveysSpatialResponse {
+  surveys: ISurveySpatialItem[];
+  pagination: ApiPaginationResponseParams;
+}
+
+export interface ISurveySpatialItem {
+  /**
+   * The project that the geometry comes from
+   */
+  project_id: number;
+  /**
+   * The survey that the geometry comes from
+   */
+  survey_id: string;
+  /**
+   * The survey location id of the geometry
+   */
+  survey_location_id: string;
+  /**
+   * Feature collection for the potentially many geometry in a Survey
+   */
+  geojson: Feature[];
+}
+
+/**
  * An interface for a single instance of survey metadata, for view-only use cases.
  *
  * @export

--- a/app/src/interfaces/useSurveyApi.interface.ts
+++ b/app/src/interfaces/useSurveyApi.interface.ts
@@ -284,11 +284,11 @@ export interface IFindSurveysSpatialResponse {
 
 export interface ISurveySpatialItem {
   /**
-   * The project that the geometry comes from
+   * The project of the geometry
    */
   project_id: number;
   /**
-   * The survey that the geometry comes from
+   * The survey of the geometry
    */
   survey_id: string;
   /**
@@ -296,7 +296,7 @@ export interface ISurveySpatialItem {
    */
   survey_location_id: string;
   /**
-   * Feature collection for the potentially many geometry in a Survey
+   * GeoJSON of the feature
    */
   geojson: Feature[];
 }


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Adds a map of survey boundaries to the Summary page
- Adds endpoints for querying survey boundaries, matching the query params of the findSurveys request to populate the table
- Adds missing tests to findSurveys back

## Testing Notes

- Map and table should be in sync: same response from the survey/index and survey/spatial endpoints
