### PR TITLE
Initial Survey Habitat Feature API Models, Services, Repos.

### DIFF
--- a/api/src/database-models/habitat-feature-type.ts
+++ b/api/src/database-models/habitat-feature-type.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Type Model.
+ *
+ * @description Data model for `habitat_feature_type`.
+ */
+export const HabitatFeatureTypeModel = z.object({
+  habitat_feature_type_id: z.number(),
+  name: z.string(),
+  description: z.string().nullable(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureTypeModel = z.infer<typeof HabitatFeatureTypeModel>;
+
+/**
+ * Habitat Feature Type Record.
+ *
+ * @description Data record for `habitat_feature_type`.
+ */
+export const HabitatFeatureTypeRecord = HabitatFeatureTypeModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureTypeRecord = z.infer<typeof HabitatFeatureTypeRecord>;

--- a/api/src/database-models/habitat_feature_qualitative_definition.ts
+++ b/api/src/database-models/habitat_feature_qualitative_definition.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Qualitative Definition Model.
+ *
+ * @description Data model for `habitat_feature_qualitative_definition`.
+ */
+export const HabitatFeatureQualitativeDefinitionModel = z.object({
+  habitat_feature_qualitative_definition_id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureQualitativeDefinitionModel = z.infer<typeof HabitatFeatureQualitativeDefinitionModel>;
+
+/**
+ * Habitat Feature Qualitative Definition Record.
+ *
+ * @description Data record for `habitat_feature_qualitative_definition`.
+ */
+export const HabitatFeatureQualitativeDefinitionRecord = HabitatFeatureQualitativeDefinitionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureQualitativeDefinitionRecord = z.infer<typeof HabitatFeatureQualitativeDefinitionRecord>;

--- a/api/src/database-models/habitat_feature_qualitative_definition_option.ts
+++ b/api/src/database-models/habitat_feature_qualitative_definition_option.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Qualitative Definition Option Model.
+ *
+ * @description Data model for `habitat_feature_qualitative_definition_option`.
+ */
+export const HabitatFeatureQualitativeDefinitionOptionModel = z.object({
+  habitat_feature_qualitative_definition_option_id: z.string().uuid(),
+  habitat_feature_qualitative_definition_id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureQualitativeDefinitionOptionModel = z.infer<
+  typeof HabitatFeatureQualitativeDefinitionOptionModel
+>;
+
+/**
+ * Habitat Feature Qualitative Definition Option Record.
+ *
+ * @description Data record for `habitat_feature_qualitative_definition_option`.
+ */
+export const HabitatFeatureQualitativeDefinitionOptionRecord = HabitatFeatureQualitativeDefinitionOptionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureQualitativeDefinitionOptionRecord = z.infer<
+  typeof HabitatFeatureQualitativeDefinitionOptionRecord
+>;

--- a/api/src/database-models/habitat_feature_quantitative_definition.ts
+++ b/api/src/database-models/habitat_feature_quantitative_definition.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { QuantitativeUnitType } from '../database-units/quantitative_unit';
+
+/**
+ * Habitat Feature Quantitative Definition Model.
+ *
+ * @description Data model for `habitat_feature_quantitative_definition`.
+ */
+export const HabitatFeatureQuantitativeDefinitionModel = z.object({
+  habitat_feature_quantitative_definition_id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  min: z.number().nullable(),
+  max: z.number().nullable(),
+  unit: QuantitativeUnitType,
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureQuantitativeDefinitionModel = z.infer<typeof HabitatFeatureQuantitativeDefinitionModel>;
+
+/**
+ * Habitat Feature Quantitative Definition Record.
+ *
+ * @description Data record for `habitat_feature_quantitative_definition`.
+ */
+export const HabitatFeatureQuantitativeDefinitionRecord = HabitatFeatureQuantitativeDefinitionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureQuantitativeDefinitionRecord = z.infer<typeof HabitatFeatureQuantitativeDefinitionRecord>;

--- a/api/src/database-models/habitat_feature_type_qualitative_option.ts
+++ b/api/src/database-models/habitat_feature_type_qualitative_option.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Type Qualitative Option Model.
+ *
+ * @description Data model for `habitat_feature_type_qualitative_option`.
+ */
+export const HabitatFeatureTypeQualitativeOptionModel = z.object({
+  habitat_feature_type_qualitative_option_id: z.number(),
+  habitat_feature_qualitative_definition_id: z.string().uuid(),
+  habitat_feature_type_id: z.number(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureTypeQualitativeOptionModel = z.infer<typeof HabitatFeatureTypeQualitativeOptionModel>;
+
+/**
+ * Habitat Feature Type Qualitative Option Record.
+ *
+ * @description Data record for `habitat_feature_type_qualitative_option`.
+ */
+export const HabitatFeatureTypeQualitativeOptionRecord = HabitatFeatureTypeQualitativeOptionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureTypeQualitativeOptionRecord = z.infer<typeof HabitatFeatureTypeQualitativeOptionRecord>;

--- a/api/src/database-models/habitat_feature_type_quantitative_option.ts
+++ b/api/src/database-models/habitat_feature_type_quantitative_option.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Type Quantitative Option Model.
+ *
+ * @description Data model for `habitat_feature_type_quantitative_option`.
+ */
+export const HabitatFeatureTypeQuantitativeOptionModel = z.object({
+  habitat_feature_type_quantitative_option_id: z.number(),
+  habitat_feature_quantitative_definition_id: z.string().uuid(),
+  habitat_feature_type_id: z.number(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureTypeQuantitativeOptionModel = z.infer<typeof HabitatFeatureTypeQuantitativeOptionModel>;
+
+/**
+ * Habitat Feature Type Quantitative Option Record.
+ *
+ * @description Data record for `habitat_feature_type_quantitative_option`.
+ */
+export const HabitatFeatureTypeQuantitativeOptionRecord = HabitatFeatureTypeQuantitativeOptionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureTypeQuantitativeOptionRecord = z.infer<typeof HabitatFeatureTypeQuantitativeOptionRecord>;

--- a/api/src/database-models/survey_habitat_feature.ts
+++ b/api/src/database-models/survey_habitat_feature.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+/**
+ * Survey Habitat Feature Model.
+ *
+ * @description Data model for `survey_habitat_feature`.
+ */
+export const SurveyHabitatFeatureModel = z.object({
+  survey_habitat_feature_id: z.number(),
+  survey_id: z.number(),
+  habitat_feature_type_id: z.number(),
+  count: z.number(),
+  latitude: z.number(),
+  longitude: z.number(),
+  observed_date: z.string(),
+  observed_time: z.string(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type SurveyHabitatFeatureModel = z.infer<typeof SurveyHabitatFeatureModel>;
+
+/**
+ * Survey Habitat Feature Record.
+ *
+ * @description Data record for `survey_habitat_feature`.
+ */
+export const SurveyHabitatFeatureRecord = SurveyHabitatFeatureModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type SurveyHabitatFeatureRecord = z.infer<typeof SurveyHabitatFeatureRecord>;

--- a/api/src/database-models/survey_habitat_feature_qualitative_value.ts
+++ b/api/src/database-models/survey_habitat_feature_qualitative_value.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Type Qualitative Option Model.
+ *
+ * @description Data model for `habitat_feature_type_qualitative_option`.
+ */
+export const HabitatFeatureTypeQualitativeOptionModel = z.object({
+  habitat_feature_type_qualitative_option_id: z.number(),
+  habitat_feature_qualitative_definition_id: z.string().uuid(),
+  habitat_feature_type_id: z.number(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureTypeQualitativeOptionModel = z.infer<typeof HabitatFeatureTypeQualitativeOptionModel>;
+
+/**
+ * Habitat Feature Type Qualitative Option Record.
+ *
+ * @description Data record for `habitat_feature_type_qualitative_option`.
+ */
+export const HabitatFeatureTypeQualitativeOptionRecord = HabitatFeatureTypeQualitativeOptionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureTypeQualitativeOptionRecord = z.infer<typeof HabitatFeatureTypeQualitativeOptionRecord>;

--- a/api/src/database-models/survey_habitat_feature_quantitative_value.ts
+++ b/api/src/database-models/survey_habitat_feature_quantitative_value.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Habitat Feature Type Quantitative Option Model.
+ *
+ * @description Data model for `habitat_feature_type_quantitative_option`.
+ */
+export const HabitatFeatureTypeQuantitativeOptionModel = z.object({
+  habitat_feature_type_quantitative_option_id: z.number(),
+  habitat_feature_quantitative_definition_id: z.string().uuid(),
+  habitat_feature_type_id: z.number(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type HabitatFeatureTypeQuantitativeOptionModel = z.infer<typeof HabitatFeatureTypeQuantitativeOptionModel>;
+
+/**
+ * Habitat Feature Type Quantitative Option Record.
+ *
+ * @description Data record for `habitat_feature_type_quantitative_option`.
+ */
+export const HabitatFeatureTypeQuantitativeOptionRecord = HabitatFeatureTypeQuantitativeOptionModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type HabitatFeatureTypeQuantitativeOptionRecord = z.infer<typeof HabitatFeatureTypeQuantitativeOptionRecord>;

--- a/api/src/database-models/survey_habitat_feature_taxon.ts
+++ b/api/src/database-models/survey_habitat_feature_taxon.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Survey Habitat Feature Taxon Model.
+ *
+ * @description Data model for `survey_habitat_feature_taxon`.
+ */
+export const SurveyHabitatFeatureTaxonModel = z.object({
+  survey_habitat_feature_taxon_id: z.number(),
+  survey_habitat_feature_id: z.number(),
+  itis_tsn: z.number(),
+  itis_scientific_name: z.string(),
+  comment: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type SurveyHabitatFeatureTaxonModel = z.infer<typeof SurveyHabitatFeatureTaxonModel>;
+
+/**
+ * Survey Habitat Feature Taxon Record.
+ *
+ * @description Data record for `survey_habitat_feature_taxon`.
+ */
+export const SurveyHabitatFeatureTaxonRecord = SurveyHabitatFeatureTaxonModel.omit({
+  create_date: true,
+  create_user: true,
+  update_date: true,
+  update_user: true,
+  revision_count: true
+});
+
+export type SurveyHabitatFeatureTaxonRecord = z.infer<typeof SurveyHabitatFeatureTaxonRecord>;

--- a/api/src/openapi/schemas/survey-habitat-feature.ts
+++ b/api/src/openapi/schemas/survey-habitat-feature.ts
@@ -1,0 +1,282 @@
+import { OpenAPIV3 } from 'openapi-types';
+
+/**
+ * Defines the schema for a survey habitat feature object, used for inserting a new survey habitat feature record.
+ */
+export const insertHabitatFeatureSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'survey_id',
+    'itis_tsn',
+    'itis_scientific_name',
+    'latitude',
+    'longitude',
+    'count',
+    'observed_date',
+    'observed_time'
+  ],
+  properties: {
+    survey_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    itis_tsn: {
+      type: 'integer'
+    },
+    itis_scientific_name: {
+      type: 'string',
+      nullable: true
+    },
+    latitude: {
+      type: 'number',
+      nullable: true,
+      minimum: -90,
+      maximum: 90
+    },
+    longitude: {
+      type: 'number',
+      nullable: true,
+      minimum: -180,
+      maximum: 180
+    },
+    count: {
+      type: 'integer'
+    },
+    observed_date: {
+      type: 'string',
+      nullable: true
+    },
+    observed_time: {
+      type: 'string',
+      nullable: true
+    }
+  }
+};
+
+/**
+ * A single survey habitat feature taxon object.
+ */
+export const surveyHabitatFeatureTaxonSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'survey_habitat_feature_taxon_id',
+    'survey_habitat_feature_id',
+    'itis_tsn',
+    'itis_scientific_name',
+    'comment'
+  ],
+  properties: {
+    survey_habitat_feature_taxon_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    survey_habitat_feature_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    itis_tsn: {
+      type: 'integer'
+    },
+    itis_scientific_name: {
+      type: 'string'
+    },
+    comment: {
+      type: 'string',
+      nullable: true
+    }
+  }
+};
+
+/**
+ * A single survey habitat feature object, with an array of survey habitat feature taxons.
+ */
+export const surveyHabitatFeatureWithTaxonsSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'survey_habitat_feature_id',
+    'survey_id',
+    'habitat_feature_type_id',
+    'count',
+    'latitude',
+    'longitude',
+    'observed_date',
+    'observed_time'
+  ],
+  properties: {
+    survey_habitat_feature_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    survey_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    habitat_feature_type_id: {
+      type: 'integer',
+      minimum: 1
+    },
+    count: {
+      type: 'integer'
+    },
+    latitude: {
+      type: 'number',
+      nullable: true,
+      minimum: -90,
+      maximum: 90
+    },
+    longitude: {
+      type: 'number',
+      nullable: true,
+      minimum: -180,
+      maximum: 180
+    },
+    observed_date: {
+      type: 'string',
+      nullable: true
+    },
+    observed_time: {
+      type: 'string',
+      nullable: true
+    },
+    survey_habitat_feature_taxons: {
+      type: 'array',
+      items: surveyHabitatFeatureTaxonSchema
+    }
+  }
+};
+
+/**
+ * An array of survey habitat feature objects.
+ */
+export const SurveyHabitatFeaturesWithTaxonsSchema: OpenAPIV3.SchemaObject = {
+  type: 'array',
+  items: surveyHabitatFeatureWithTaxonsSchema
+};
+
+/**
+ * Supplementary data for survey habitat feature objects.
+ */
+export const surveyHabitatFeaturesSupplementaryDataSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['count', 'habitatFeatureQuantitativeDefinition', 'habitatFeatureQualitativeDefinition'],
+  properties: {
+    count: {
+      description: 'The total count of survey habitat features for the survey.',
+      type: 'integer',
+      minimum: 0
+    },
+    habitatFeatureQuantitativeDefinition: {
+      description: 'All quantitative habitat feature definitions for the survey habitat features.',
+      type: 'array',
+      items: {
+        description: 'A quantitative habitat feature definition, with possible min/max constraints.',
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'habitat_feature_quantitative_definition_id',
+          'name',
+          'description',
+          'min',
+          'max',
+          'unit',
+          'record_end_date'
+        ],
+        properties: {
+          habitat_feature_quantitative_definition_id: {
+            type: 'string',
+            format: 'uuid'
+          },
+          name: {
+            type: 'string'
+          },
+          description: {
+            type: 'string',
+            nullable: true
+          },
+          min: {
+            type: 'number',
+            nullable: true
+          },
+          max: {
+            type: 'number',
+            nullable: true
+          },
+          unit: {
+            type: 'string',
+            nullable: true
+          },
+          record_end_date: {
+            type: 'string',
+            nullable: true
+          }
+        }
+      }
+    },
+    habitatFeatureQualitativeDefinition: {
+      description: 'All qualitative habitat feature definitions for the survey habitat features.',
+      type: 'array',
+      items: {
+        description: 'A qualitative habitat feature definition, with array of valid options',
+        type: 'object',
+        additionalProperties: false,
+        required: ['environment_qualitative_id', 'name', 'description', 'record_end_date', 'options'],
+        properties: {
+          habitat_feature_qualitative_definition_id: {
+            type: 'string',
+            format: 'uuid'
+          },
+          name: {
+            type: 'string'
+          },
+          description: {
+            type: 'string',
+            nullable: true
+          },
+          record_end_date: {
+            type: 'string',
+            nullable: true
+          },
+          options: {
+            description: 'Valid options for the qualitative habitat feature definition.',
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: [
+                'habitat_feature_qualitative_definition_option_id',
+                'habitat_feature_qualitative_definition_id',
+                'name',
+                'description'
+              ],
+              properties: {
+                habitat_feature_qualitative_definition_option_id: {
+                  type: 'string',
+                  format: 'uuid'
+                },
+                habitat_feature_qualitative_definition_id: {
+                  type: 'string',
+                  format: 'uuid'
+                },
+                name: {
+                  type: 'string'
+                },
+                description: {
+                  type: 'string',
+                  nullable: true
+                },
+                record_end_date: {
+                  type: 'string',
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/api/src/paths/codes.ts
+++ b/api/src/paths/codes.ts
@@ -44,7 +44,8 @@ GET.apiDoc = {
               'telemetry_device_makes',
               'frequency_units',
               'alert_types',
-              'vantages'
+              'vantages',
+              'habitat_feature_types'
             ],
             properties: {
               management_action_type: {
@@ -468,6 +469,27 @@ GET.apiDoc = {
               vantages: {
                 type: 'array',
                 description: 'Vantages that vantages belong to.',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['id', 'name', 'description'],
+                  properties: {
+                    id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    name: {
+                      type: 'string'
+                    },
+                    description: {
+                      type: 'string'
+                    }
+                  }
+                }
+              },
+              habitat_feature_types: {
+                type: 'array',
+                description: 'Habitat feature type codes.',
                 items: {
                   type: 'object',
                   additionalProperties: false,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.ts
@@ -1,0 +1,157 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../database/db';
+import {
+  paginationRequestQueryParamSchema,
+  paginationResponseSchema
+} from '../../../../../../openapi/schemas/pagination';
+import {
+  surveyHabitatFeaturesSupplementaryDataSchema,
+  SurveyHabitatFeaturesWithTaxonsSchema
+} from '../../../../../../openapi/schemas/survey-habitat-feature';
+import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
+
+import { SurveyHabitatFeatureService } from '../../../../../../services/habitat-feature-services/survey-habitat-feature-service';
+import { getLogger } from '../../../../../../utils/logger';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../../../../../utils/pagination';
+
+const defaultLog = getLogger('/api/project/{projectId}/survey/{surveyId}/observation');
+
+export const GET: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      or: [
+        {
+          validProjectPermissions: [
+            PROJECT_PERMISSION.COORDINATOR,
+            PROJECT_PERMISSION.COLLABORATOR,
+            PROJECT_PERMISSION.OBSERVER
+          ],
+          surveyId: Number(req.params.surveyId),
+          discriminator: 'ProjectPermission'
+        },
+        {
+          validSystemRoles: [SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  getSurveyHabitatFeatures()
+];
+
+GET.apiDoc = {
+  description: 'Get paginated survey habitat feature records for a survey.',
+  tags: ['habitat-feature'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  parameters: [
+    {
+      in: 'path',
+      name: 'projectId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    },
+    {
+      in: 'path',
+      name: 'surveyId',
+      schema: {
+        type: 'integer',
+        minimum: 1
+      },
+      required: true
+    },
+    ...paginationRequestQueryParamSchema
+  ],
+  responses: {
+    200: {
+      description: 'Survey habitat features get response.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['surveyHabitatFeatures', 'supplementaryData', 'pagination'],
+            properties: {
+              surveyHabitatFeatures: SurveyHabitatFeaturesWithTaxonsSchema,
+              supplementaryData: surveyHabitatFeaturesSupplementaryDataSchema,
+              pagination: paginationResponseSchema
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Get paginated survey habitat feature records for a survey.
+ *
+ * @export
+ * @return {*}  {RequestHandler}
+ */
+export function getSurveyHabitatFeatures(): RequestHandler {
+  return async (req, res) => {
+    const surveyId = Number(req.params.surveyId);
+
+    defaultLog.debug({ label: 'getSurveyHabitatFeatures', surveyId });
+
+    const paginationOptions = makePaginationOptionsFromRequest(req);
+
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const surveyHabitatFeatureService = new SurveyHabitatFeatureService(connection);
+
+      const surveyHabitatFeaturesResponse =
+        await surveyHabitatFeatureService.getSurveyHabitatFeaturesWithSupplementaryData(
+          surveyId,
+          ensureCompletePaginationOptions(paginationOptions)
+        );
+
+      await connection.commit();
+
+      const response = {
+        surveyHabitatFeatures: surveyHabitatFeaturesResponse.surveyHabitatFeatures,
+        supplementaryData: surveyHabitatFeaturesResponse.supplementaryData,
+        pagination: makePaginationResponse(surveyHabitatFeaturesResponse.supplementaryData.count, paginationOptions)
+      };
+
+      return res.status(200).json(response);
+    } catch (error) {
+      defaultLog.error({ label: 'getSurveyHabitatFeatures', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/repositories/code-repository.ts
+++ b/api/src/repositories/code-repository.ts
@@ -44,7 +44,8 @@ export const IAllCodeSets = z.object({
   telemetry_device_makes: CodeDescription.array(),
   frequency_units: CodeDescription.array(),
   alert_types: CodeDescription.array(),
-  vantages: CodeDescription.array()
+  vantages: CodeDescription.array(),
+  habitat_feature_types: CodeDescription.array()
 });
 
 export class CodeRepository extends BaseRepository {
@@ -555,6 +556,27 @@ export class CodeRepository extends BaseRepository {
       FROM vantage
       WHERE record_end_date IS null;
     `;
+
+    const response = await this.connection.sql(sqlStatement, CodeDescription);
+
+    return response.rows;
+  }
+
+  /**
+   * Fetch habitat feature type codes.
+   *
+   * @return {*} {Promise<ICodeDescription[]>}
+   * @memberof CodeRepository
+   */
+  async getHabitatFeatureTypes(): Promise<ICodeDescription[]> {
+    const sqlStatement = SQL`
+          SELECT
+            habitat_feature_type_id AS id,
+            name,
+            description
+          FROM habitat_feature_type
+          WHERE record_end_date IS null;
+        `;
 
     const response = await this.connection.sql(sqlStatement, CodeDescription);
 

--- a/api/src/repositories/habitat-feature-repository/habitat-feature-repository.interface.ts
+++ b/api/src/repositories/habitat-feature-repository/habitat-feature-repository.interface.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { HabitatFeatureQualitativeDefinitionRecord } from '../../database-models/habitat_feature_qualitative_definition';
+import { HabitatFeatureQualitativeDefinitionOptionRecord } from '../../database-models/habitat_feature_qualitative_definition_option';
+import { HabitatFeatureQuantitativeDefinitionRecord } from '../../database-models/habitat_feature_quantitative_definition';
+
+export type FindHabitatFeatureDefinitionAdvancedFilters = {
+  /**
+   * Filter results by keyword.
+   *
+   * @type {string}
+   */
+  keyword?: string;
+  /**
+   * Filter results by survey ID.
+   *
+   * @type {number}
+   */
+  survey_id: number;
+  /**
+   * Filter results by ITIS TSNs.
+   *
+   * @type {number[]}
+   */
+  itis_tsns?: number[];
+};
+
+export const FindHabitatFeatureQuantitativeDefinition = HabitatFeatureQuantitativeDefinitionRecord;
+export type FindHabitatFeatureQuantitativeDefinition = z.infer<typeof FindHabitatFeatureQuantitativeDefinition>;
+
+export const FindHabitatFeatureQualitativeDefinition = HabitatFeatureQualitativeDefinitionRecord.extend({
+  options: z.array(HabitatFeatureQualitativeDefinitionOptionRecord)
+});
+export type FindHabitatFeatureQualitativeDefinition = z.infer<typeof FindHabitatFeatureQualitativeDefinition>;
+
+export const FindHabitatFeatureDefinitions = z.object({
+  habitatFeatureQuantitativeDefinition: z.array(HabitatFeatureQuantitativeDefinitionRecord),
+  habitatFeatureQualitativeDefinition: z.array(FindHabitatFeatureQualitativeDefinition)
+});
+export type FindHabitatFeatureDefinitions = z.infer<typeof FindHabitatFeatureDefinitions>;

--- a/api/src/repositories/habitat-feature-repository/habitat-feature-repository.ts
+++ b/api/src/repositories/habitat-feature-repository/habitat-feature-repository.ts
@@ -1,0 +1,206 @@
+import { getKnex } from '../../database/db';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
+import { BaseRepository } from '../base-repository';
+import {
+  FindHabitatFeatureDefinitionAdvancedFilters,
+  FindHabitatFeatureDefinitions,
+  FindHabitatFeatureQualitativeDefinition,
+  FindHabitatFeatureQuantitativeDefinition
+} from './habitat-feature-repository.interface';
+
+export class HabitatFeatureRepository extends BaseRepository {
+  /**
+   * Find habitat feature quantitative definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindHabitatFeatureQuantitativeDefinition[]>}
+   * @memberof HabitatFeatureRepository
+   */
+  async findHabitatFeatureQuantitativeDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindHabitatFeatureQuantitativeDefinition[]> {
+    const knex = getKnex();
+
+    const query = knex.queryBuilder();
+
+    query
+      .select([
+        'habitat_feature_quantitative_definition.habitat_feature_quantitative_definition_id',
+        'habitat_feature_quantitative_definition.name',
+        'habitat_feature_quantitative_definition.description',
+        'habitat_feature_quantitative_definition.min',
+        'habitat_feature_quantitative_definition.max',
+        'habitat_feature_quantitative_definition.unit',
+        'habitat_feature_quantitative_definition.record_end_date'
+      ])
+      .from('habitat_feature_quantitative_definition');
+
+    if (filterFields.keyword) {
+      query
+        .where('habitat_feature_quantitative_definition.name', 'ilike', `%${filterFields.keyword}%`)
+        .orWhere('habitat_feature_quantitative_definition.description', 'ilike', `%${filterFields.keyword}%`);
+    }
+
+    if (filterFields.survey_id || filterFields.itis_tsns?.length) {
+      query
+        .innerJoin(
+          'survey_habitat_feature_quantitative_value',
+          'survey_habitat_feature_quantitative_value.habitat_feature_quantitative_definition_id',
+          'habitat_feature_quantitative_definition.habitat_feature_quantitative_definition_id'
+        )
+        .innerJoin(
+          'survey_habitat_feature',
+          'survey_habitat_feature.survey_habitat_feature_id',
+          'survey_habitat_feature_quantitative_value.survey_habitat_feature_id'
+        );
+
+      if (filterFields.survey_id) {
+        query.where('survey_habitat_feature.survey_id', filterFields.survey_id);
+      }
+
+      if (filterFields.itis_tsns) {
+        query
+          .innerJoin(
+            'survey_habitat_feature_taxon',
+            'survey_habitat_feature_taxon.survey_habitat_feature_id',
+            'survey_habitat_feature.survey_habitat_feature_id'
+          )
+          .whereIn('survey_habitat_feature_taxon.itis_tsn', filterFields.itis_tsns);
+      }
+    }
+
+    if (pagination) {
+      query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
+
+      if (pagination.sort && pagination.order) {
+        query.orderBy(pagination.sort, pagination.order);
+      }
+    }
+
+    const response = await this.connection.knex(query, FindHabitatFeatureQuantitativeDefinition);
+
+    return response.rows;
+  }
+
+  /**
+   * Find habitat feature qualitative definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindHabitatFeatureQualitativeDefinition[]>}
+   * @memberof HabitatFeatureRepository
+   */
+  async findHabitatFeatureQualitativeDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindHabitatFeatureQualitativeDefinition[]> {
+    const knex = getKnex();
+
+    const query = knex.queryBuilder();
+
+    query
+      .select(
+        knex.raw(`
+          habitat_feature_qualitative_definition.habitat_feature_qualitative_definition_id,
+          habitat_feature_qualitative_definition.name,
+          habitat_feature_qualitative_definition.description,
+          habitat_feature_qualitative_definition.record_end_date,
+          coalesce(
+            json_agg(
+              json_build_object(
+                'habitat_feature_qualitative_definition_id', habitat_feature_qualitative_definition_option.habitat_feature_qualitative_definition_id,
+                'habitat_feature_qualitative_definition_option_id', habitat_feature_qualitative_definition_option.habitat_feature_qualitative_definition_option_id,
+                'name', habitat_feature_qualitative_definition_option.name,
+                'description', habitat_feature_qualitative_definition_option.description,
+                'record_end_date', habitat_feature_qualitative_definition_option.record_end_date
+              )
+            ), 
+            '[]'::json
+          ) as options
+        `)
+      )
+      .from('habitat_feature_qualitative_definition')
+      .join(
+        'habitat_feature_qualitative_definition_option',
+        'habitat_feature_qualitative_definition.habitat_feature_qualitative_definition_id',
+        'habitat_feature_qualitative_definition_option.habitat_feature_qualitative_definition_id'
+      )
+      .groupBy([
+        'habitat_feature_qualitative_definition.habitat_feature_qualitative_definition_id',
+        'habitat_feature_qualitative_definition.name',
+        'habitat_feature_qualitative_definition.description',
+        'habitat_feature_qualitative_definition.record_end_date'
+      ]);
+
+    if (filterFields.keyword) {
+      query
+        .where('habitat_feature_qualitative_definition.name', 'ilike', `%${filterFields.keyword}%`)
+        .orWhere('habitat_feature_qualitative_definition.description', 'ilike', `%${filterFields.keyword}%`);
+    }
+
+    if (filterFields.survey_id || filterFields.itis_tsns?.length) {
+      query
+        .innerJoin(
+          'survey_habitat_feature_qualitative_value',
+          'survey_habitat_feature_qualitative_value.habitat_feature_qualitative_definition_id',
+          'habitat_feature_qualitative_definition.habitat_feature_qualitative_definition_id'
+        )
+        .innerJoin(
+          'survey_habitat_feature',
+          'survey_habitat_feature.survey_habitat_feature_id',
+          'survey_habitat_feature_qualitative_value.survey_habitat_feature_id'
+        );
+
+      if (filterFields.survey_id) {
+        query.where('survey_habitat_feature.survey_id', filterFields.survey_id);
+      }
+
+      if (filterFields.itis_tsns) {
+        query
+          .innerJoin(
+            'survey_habitat_feature_taxon',
+            'survey_habitat_feature_taxon.survey_habitat_feature_id',
+            'survey_habitat_feature.survey_habitat_feature_id'
+          )
+          .whereIn('survey_habitat_feature_taxon.itis_tsn', filterFields.itis_tsns);
+      }
+    }
+
+    if (pagination) {
+      query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
+
+      if (pagination.sort && pagination.order) {
+        query.orderBy(pagination.sort, pagination.order);
+      }
+    }
+
+    const response = await this.connection.knex(query, FindHabitatFeatureQualitativeDefinition);
+
+    return response.rows;
+  }
+
+  /**
+   * Find habitat feature quantitative and qualitative definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindHabitatFeatureDefinitions>}
+   * @memberof HabitatFeatureRepository
+   */
+  async findHabitatFeatureDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindHabitatFeatureDefinitions> {
+    const [quantitativeDefinitions, qualitativeDefinitions] = await Promise.all([
+      this.findHabitatFeatureQuantitativeDefinitions(filterFields, pagination),
+      this.findHabitatFeatureQualitativeDefinitions(filterFields, pagination)
+    ]);
+
+    return {
+      habitatFeatureQuantitativeDefinition: quantitativeDefinitions,
+      habitatFeatureQualitativeDefinition: qualitativeDefinitions
+    };
+  }
+}

--- a/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
+++ b/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { SurveyHabitatFeatureRecord } from '../../database-models/survey_habitat_feature';
+import { SurveyHabitatFeatureTaxonRecord } from '../../database-models/survey_habitat_feature_taxon';
+import { FindHabitatFeatureDefinitions } from './habitat-feature-repository.interface';
+
+export type InsertSurveyHabitatFeature = Pick<
+  SurveyHabitatFeatureRecord,
+  | 'survey_habitat_feature_id'
+  | 'habitat_feature_type_id'
+  | 'count'
+  | 'latitude'
+  | 'longitude'
+  | 'observed_date'
+  | 'observed_time'
+>;
+
+export const SurveyHabitatFeatureCount = z.object({
+  count: z.number()
+});
+export type SurveyHabitatFeatureCount = z.infer<typeof SurveyHabitatFeatureCount>;
+
+export type SurveyHabitatFeaturesSupplementaryData = SurveyHabitatFeatureCount & FindHabitatFeatureDefinitions;
+
+export type SurveyHabitatFeaturesWithSupplementaryData = {
+  surveyHabitatFeatures: SurveyHabitatFeatureWithTaxons[];
+  supplementaryData: SurveyHabitatFeaturesSupplementaryData;
+};
+
+export const SurveyHabitatFeatureWithTaxons = SurveyHabitatFeatureRecord.extend({
+  survey_habitat_feature_taxons: z.array(SurveyHabitatFeatureTaxonRecord)
+});
+export type SurveyHabitatFeatureWithTaxons = z.infer<typeof SurveyHabitatFeatureWithTaxons>;

--- a/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.ts
+++ b/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.ts
@@ -1,0 +1,187 @@
+import SQL from 'sql-template-strings';
+import { getKnex } from '../../database/db';
+import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
+import { BaseRepository } from '../base-repository';
+import {
+  InsertSurveyHabitatFeature,
+  SurveyHabitatFeatureCount,
+  SurveyHabitatFeatureWithTaxons
+} from './survey-habitat-feature-repository.interface';
+
+export class SurveyHabitatFeatureRepository extends BaseRepository {
+  /**
+   * Insert survey habitat feature records for the provided survey id.
+   *
+   * @param {number} surveyId The ID of the survey under which the habitat features are being inserted.
+   * @param {InsertSurveyHabitatFeature[]} habitatFeatures The habitat features to insert.
+   * @memberof SurveyHabitatFeatureRepository
+   */
+  async insertSurveyHabitatFeatures(surveyId: number, habitatFeatures: InsertSurveyHabitatFeature[]) {
+    const knex = getKnex();
+
+    const query = knex.queryBuilder();
+
+    query
+      .insert(
+        habitatFeatures.map((habitatFeature) => ({
+          survey_id: surveyId,
+          ...habitatFeature
+        }))
+      )
+      .into('survey_habitat_feature');
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== habitatFeatures.length) {
+      throw new ApiExecuteSQLError('Failed to insert survey habitat feature records', [
+        'SurveyHabitatFeatureRepository->insertSurveyHabitatFeatures',
+        `rowCount was ${response.rowCount}, expected rowCount = ${habitatFeatures.length}`
+      ]);
+    }
+  }
+
+  /**
+   * Get a single survey habitat feature record.
+   *
+   * @param {number} surveyId
+   * @param {number} surveyHabitatFeatureId
+   * @return {*}  {Promise<SurveyHabitatFeatureWithTaxons>}
+   * @memberof SurveyHabitatFeatureRepository
+   */
+  async getSurveyHabitatFeature(
+    surveyId: number,
+    surveyHabitatFeatureId: number
+  ): Promise<SurveyHabitatFeatureWithTaxons> {
+    const knex = getKnex();
+
+    const query = knex.queryBuilder();
+
+    query
+      .select([
+        'survey_habitat_feature_id',
+        'survey_id',
+        'habitat_feature_type_id',
+        'count',
+        'latitude',
+        'longitude',
+        'observed_date',
+        'observed_time',
+        knex.raw(`
+          COALESCE(
+            (
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'survey_habitat_feature_taxon_id', survey_habitat_feature_taxon.survey_habitat_feature_taxon_id,
+                  'survey_habitat_feature_id', survey_habitat_feature_taxon.survey_habitat_feature_id,
+                  'itis_tsn', survey_habitat_feature_taxon.itis_tsn,
+                  'itis_scientific_name', survey_habitat_feature_taxon.itis_scientific_name,
+                  'comment', survey_habitat_feature_taxon.comment
+                )
+              )
+              FROM survey_habitat_feature_taxon
+              WHERE survey_habitat_feature_taxon.survey_habitat_feature_id = survey_habitat_feature.survey_habitat_feature_id
+            ),
+            '[]'::jsonb
+          ) AS survey_habitat_feature_taxons
+        `)
+      ])
+      .from('survey_habitat_feature')
+      .where('survey_habitat_feature.survey_habitat_feature_id', surveyHabitatFeatureId)
+      .andWhere('survey_id', surveyId);
+
+    const response = await this.connection.knex(query, SurveyHabitatFeatureWithTaxons);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to get survey habitat feature', [
+        'SurveyHabitatFeatureRepository->getSurveyHabitatFeature',
+        `rowCount was ${response.rowCount}, expected rowCount = 1`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get paginated habitat features for a survey.
+   *
+   * @param {number} surveyId
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<SurveyHabitatFeatureWithTaxons[]>}
+   * @memberof SurveyHabitatFeatureRepository
+   */
+  async getSurveyHabitatFeatures(
+    surveyId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<SurveyHabitatFeatureWithTaxons[]> {
+    const knex = getKnex();
+
+    const query = knex.queryBuilder();
+
+    query
+      .select([
+        'survey_habitat_feature_id',
+        'survey_id',
+        'habitat_feature_type_id',
+        'count',
+        'latitude',
+        'longitude',
+        'observed_date',
+        'observed_time',
+        knex.raw(`
+          COALESCE(
+            (
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'survey_habitat_feature_taxon_id', survey_habitat_feature_taxon.survey_habitat_feature_taxon_id,
+                  'survey_habitat_feature_id', survey_habitat_feature_taxon.survey_habitat_feature_id,
+                  'itis_tsn', survey_habitat_feature_taxon.itis_tsn,
+                  'itis_scientific_name', survey_habitat_feature_taxon.itis_scientific_name,
+                  'comment', survey_habitat_feature_taxon.comment
+                )
+              )
+              FROM survey_habitat_feature_taxon
+              WHERE survey_habitat_feature_taxon.survey_habitat_feature_id = survey_habitat_feature.survey_habitat_feature_id
+            ),
+            '[]'::jsonb
+          ) AS survey_habitat_feature_taxons
+        `)
+      ])
+      .from('survey_habitat_feature')
+      .where('survey_id', surveyId);
+
+    if (pagination) {
+      query.limit(pagination.limit).offset((pagination.page - 1) * pagination.limit);
+
+      if (pagination.sort && pagination.order) {
+        query.orderBy(pagination.sort, pagination.order);
+      }
+    }
+
+    const response = await this.connection.knex(query, SurveyHabitatFeatureWithTaxons);
+
+    return response.rows;
+  }
+
+  /**
+   * Get the total count of habitat features for a survey.
+   *
+   * @param {number} surveyId
+   * @return {*}  {Promise<number>}
+   * @memberof SurveyHabitatFeatureRepository
+   */
+  async getSurveyHabitatFeaturesCount(surveyId: number): Promise<number> {
+    const sqlStatement = SQL`
+      SELECT
+        count(*)::integer as count
+      FROM
+        survey_habitat_feature
+      WHERE
+        survey_id = ${surveyId};
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SurveyHabitatFeatureCount);
+
+    return response.rows[0].count;
+  }
+}

--- a/api/src/repositories/habitat-feature-repository/utils.ts
+++ b/api/src/repositories/habitat-feature-repository/utils.ts
@@ -1,0 +1,308 @@
+import { Knex } from 'knex';
+import { getKnex } from '../../database/db';
+import { IObservationAdvancedFilters } from '../../models/observation-view';
+
+/**
+ * Generate the observation list query based on user access and filters.
+ *
+ * @param {boolean} isUserAdmin
+ * @param {number | null} systemUserId The system user id of the user making the request
+ * @param {IObservationAdvancedFilters} filterFields
+ * @return {*}  {Knex.QueryBuilder}
+ */
+export function makeFindSurveyHabitatFeaturesQuery(
+  isUserAdmin: boolean,
+  systemUserId: number | null,
+  filterFields?: IObservationAdvancedFilters
+): Knex.QueryBuilder {
+  const knex = getKnex();
+
+  const getSurveyIdsQuery = knex.select<any, { survey_id: number }>(['survey_id']).from('survey');
+
+  // Ensure that users can only see observations that they are participating in, unless they are an administrator.
+  if (!isUserAdmin) {
+    getSurveyIdsQuery.whereIn('survey.project_id', (subqueryBuilder) =>
+      subqueryBuilder
+        .select('project.project_id')
+        .from('project')
+        .leftJoin('project_participation', 'project_participation.project_id', 'project.project_id')
+        .where('project_participation.system_user_id', systemUserId)
+    );
+  }
+
+  if (filterFields?.system_user_id) {
+    getSurveyIdsQuery.whereIn('p.project_id', (subQueryBuilder) => {
+      subQueryBuilder
+        .select('project_id')
+        .from('project_participation')
+        .where('system_user_id', filterFields.system_user_id);
+    });
+  }
+
+  const getObservationsQuery = getSurveyObservationsBaseQuery(knex, getSurveyIdsQuery);
+
+  if (filterFields?.min_count) {
+    getObservationsQuery.andWhere('subcount', '>=', filterFields.min_count);
+  }
+
+  if (filterFields?.start_date) {
+    getObservationsQuery.andWhere('observation_date', '>=', filterFields.start_date);
+  }
+
+  if (filterFields?.end_date) {
+    getObservationsQuery.andWhere('observation_date', '<=', filterFields.end_date);
+  }
+
+  if (filterFields?.keyword) {
+    getObservationsQuery.where((subqueryBuilder) => {
+      subqueryBuilder.where('itis_scientific_name', 'ilike', `%${filterFields.keyword}%`);
+      if (!isNaN(Number(filterFields.keyword))) {
+        subqueryBuilder.orWhere('survey_observation.survey_observation_id', Number(filterFields.keyword));
+      }
+    });
+  }
+
+  if (filterFields?.start_time) {
+    getObservationsQuery.andWhere('time', '>=', filterFields.start_time);
+  }
+
+  if (filterFields?.end_time) {
+    getObservationsQuery.andWhere('time', '<=', filterFields.end_time);
+  }
+
+  // Focal Species filter
+  if (filterFields?.itis_tsns?.length) {
+    // multiple
+    getObservationsQuery.whereIn('itis_tsn', filterFields.itis_tsns);
+  } else if (filterFields?.itis_tsn) {
+    // single
+    getObservationsQuery.where('itis_tsn', filterFields.itis_tsn);
+  }
+
+  return getObservationsQuery;
+}
+
+/**
+ * Get the base query for retrieving survey observations with sampling data.
+ *
+ * @param {Knex} knex The Knex instance.
+ * @param {Knex.QueryBuilder} getSurveyIdsQuery A knex query builder that returns a list of survey IDs, which will be
+ * used to filter the observations.
+ * @return {*}  {Knex.QueryBuilder} The base query for retrieving survey observations, filtered by survey IDs returned by
+ * the getSurveyIdsQuery.
+ */
+export function getSurveyObservationsBaseQuery(
+  knex: Knex,
+  getSurveyIdsQuery: Knex.QueryBuilder<any, { survey_id: number }>
+): Knex.QueryBuilder {
+  return (
+    knex
+      // Get all sampling information (sites, periods, techniques) for the matching observations
+      .with(
+        'w_sampling_data',
+        knex
+          .select(
+            // Period data
+            'survey_sample_period.survey_sample_period_id',
+            knex.raw(
+              `(survey_sample_period.start_date::date + COALESCE(survey_sample_period.start_time, '00:00:00')::time)::timestamp as survey_sample_period_start_datetime`
+            ),
+            // Site data
+            'survey_sample_period.survey_sample_site_id',
+            'survey_sample_site.name as survey_sample_site_name',
+            // Technique data
+            'survey_sample_period.method_technique_id',
+            'method_technique.name as method_technique_name'
+          )
+          .from('survey_sample_period')
+          .leftJoin(
+            'survey_sample_site',
+            'survey_sample_site.survey_sample_site_id',
+            'survey_sample_period.survey_sample_site_id'
+          )
+          .leftJoin(
+            'method_technique',
+            'method_technique.method_technique_id',
+            'survey_sample_period.method_technique_id'
+          )
+          .whereIn('survey_sample_period.survey_id', getSurveyIdsQuery)
+      )
+      // Get all qualitative measurements for all subcounts associated to all observations for the survey
+      .with(
+        'w_qualitative_measurements',
+        knex
+          .select(
+            'observation_subcount_id',
+            knex.raw(`
+              json_agg(json_build_object(
+                'critterbase_taxon_measurement_id', critterbase_taxon_measurement_id,
+                'critterbase_measurement_qualitative_option_id', critterbase_measurement_qualitative_option_id
+              )) as qualitative_measurements
+            `)
+          )
+          .from('observation_subcount_qualitative_measurement')
+          .whereIn('observation_subcount_id', (qb1) => {
+            qb1
+              .select('observation_subcount_id')
+              .from('observation_subcount')
+              .whereIn('survey_observation_id', (qb2) => {
+                qb2.select('survey_observation_id').from('survey_observation').whereIn('survey_id', getSurveyIdsQuery);
+              });
+          })
+          .groupBy('observation_subcount_id')
+      )
+      // Get all quantitative measurements for all subcounts associated to all observations for the survey
+      .with(
+        'w_quantitative_measurements',
+        knex
+          .select(
+            'observation_subcount_id',
+            knex.raw(`
+              json_agg(json_build_object(
+                'critterbase_taxon_measurement_id', critterbase_taxon_measurement_id,
+                'value', value
+              )) as quantitative_measurements
+            `)
+          )
+          .from('observation_subcount_quantitative_measurement')
+          .whereIn('observation_subcount_id', (qb1) => {
+            qb1
+              .select('observation_subcount_id')
+              .from('observation_subcount')
+              .whereIn('survey_observation_id', (qb2) => {
+                qb2.select('survey_observation_id').from('survey_observation').whereIn('survey_id', getSurveyIdsQuery);
+              });
+          })
+          .groupBy('observation_subcount_id')
+      )
+      // Get all qualitative environments for all subcounts associated to all observations for the survey
+      .with(
+        'w_qualitative_environments',
+        knex
+          .select(
+            'observation_subcount_id',
+            knex.raw(`
+              json_agg(json_build_object(
+                'observation_subcount_qualitative_environment_id', observation_subcount_qualitative_environment_id,
+                'environment_qualitative_id', environment_qualitative_id,
+                'environment_qualitative_option_id', environment_qualitative_option_id
+              )) as qualitative_environments
+            `)
+          )
+          .from('observation_subcount_qualitative_environment')
+          .whereIn('observation_subcount_id', (qb1) => {
+            qb1
+              .select('observation_subcount_id')
+              .from('observation_subcount')
+              .whereIn('survey_observation_id', (qb2) => {
+                qb2.select('survey_observation_id').from('survey_observation').whereIn('survey_id', getSurveyIdsQuery);
+              });
+          })
+          .groupBy('observation_subcount_id')
+      )
+      // Get all quantitative environments for all subcounts associated to all observations for the survey
+      .with(
+        'w_quantitative_environments',
+        knex
+          .select(
+            'observation_subcount_id',
+            knex.raw(`
+              json_agg(json_build_object(
+                'observation_subcount_quantitative_environment_id', observation_subcount_quantitative_environment_id,
+                'environment_quantitative_id', environment_quantitative_id,
+                'value', value
+              )) as quantitative_environments
+            `)
+          )
+          .from('observation_subcount_quantitative_environment')
+          .whereIn('observation_subcount_id', (qb1) => {
+            qb1
+              .select('observation_subcount_id')
+              .from('observation_subcount')
+              .whereIn('survey_observation_id', (qb2) => {
+                qb2.select('survey_observation_id').from('survey_observation').whereIn('survey_id', getSurveyIdsQuery);
+              });
+          })
+          .groupBy('observation_subcount_id')
+      )
+      // Rollup the subcount records into an array of objects for each observation
+      .with(
+        'w_subcounts',
+        knex
+          .select(
+            'survey_observation_id',
+            knex.raw(`
+              json_agg(json_build_object(
+                'observation_subcount_id', observation_subcount.observation_subcount_id,
+                'observation_subcount_sign_id', observation_subcount.observation_subcount_sign_id,
+                'comment', observation_subcount.comment,
+                'subcount', subcount,
+                'qualitative_measurements', COALESCE(w_qualitative_measurements.qualitative_measurements, '[]'::json),
+                'quantitative_measurements', COALESCE(w_quantitative_measurements.quantitative_measurements, '[]'::json),
+                'qualitative_environments', COALESCE(w_qualitative_environments.qualitative_environments, '[]'::json),
+                'quantitative_environments', COALESCE(w_quantitative_environments.quantitative_environments, '[]'::json)
+              )) as subcounts
+            `)
+          )
+          .from('observation_subcount')
+          .leftJoin(
+            'w_qualitative_measurements',
+            'observation_subcount.observation_subcount_id',
+            'w_qualitative_measurements.observation_subcount_id'
+          )
+          .leftJoin(
+            'w_quantitative_measurements',
+            'observation_subcount.observation_subcount_id',
+            'w_quantitative_measurements.observation_subcount_id'
+          )
+          .leftJoin(
+            'w_qualitative_environments',
+            'observation_subcount.observation_subcount_id',
+            'w_qualitative_environments.observation_subcount_id'
+          )
+          .leftJoin(
+            'w_quantitative_environments',
+            'observation_subcount.observation_subcount_id',
+            'w_quantitative_environments.observation_subcount_id'
+          )
+          .whereIn(
+            'survey_observation_id',
+            knex('survey_observation').select('survey_observation_id').whereIn('survey_id', getSurveyIdsQuery)
+          )
+          .groupBy('survey_observation_id')
+      )
+      // Return all observations for the surveys, including the additional sampling data, and rolled up subcount data
+      .select(
+        // Observation data
+        'survey_observation.survey_observation_id',
+        'survey_observation.survey_id',
+        'survey_observation.itis_tsn',
+        'survey_observation.itis_scientific_name',
+        'survey_observation.latitude',
+        'survey_observation.longitude',
+        'survey_observation.count',
+        'survey_observation.observation_date',
+        'survey_observation.observation_time',
+        // Observation subcount data
+        knex.raw(`COALESCE(w_subcounts.subcounts, '[]'::json) as subcounts`),
+        // Site data
+        'w_sampling_data.survey_sample_site_id',
+        'w_sampling_data.survey_sample_site_name',
+        // Technique data
+        'w_sampling_data.method_technique_id',
+        'w_sampling_data.method_technique_name',
+        // Period data
+        'w_sampling_data.survey_sample_period_id',
+        'w_sampling_data.survey_sample_period_start_datetime'
+      )
+      .from('survey_observation')
+      .leftJoin(
+        'w_sampling_data',
+        'survey_observation.survey_sample_period_id',
+        'w_sampling_data.survey_sample_period_id'
+      )
+      // Note: inner join requires every observation record to have at least one subcount record, otherwise use left join
+      .innerJoin('w_subcounts', 'w_subcounts.survey_observation_id', 'survey_observation.survey_observation_id')
+      .whereIn('survey_observation.survey_id', getSurveyIdsQuery)
+  );
+}

--- a/api/src/services/code-service.test.ts
+++ b/api/src/services/code-service.test.ts
@@ -49,7 +49,8 @@ describe('CodeService', () => {
         'telemetry_device_makes',
         'frequency_units',
         'alert_types',
-        'vantages'
+        'vantages',
+        'habitat_feature_types'
       );
     });
   });

--- a/api/src/services/code-service.ts
+++ b/api/src/services/code-service.ts
@@ -52,7 +52,8 @@ export class CodeService extends DBService {
       telemetry_device_makes: this.codeRepository.getActiveTelemetryDeviceMakes(),
       frequency_units: this.codeRepository.getFrequencyUnits(),
       alert_types: this.codeRepository.getAlertTypes(),
-      vantages: this.codeRepository.getVantages()
+      vantages: this.codeRepository.getVantages(),
+      habitat_feature_types: this.codeRepository.getHabitatFeatureTypes()
     };
 
     // Fetch all code sets in parallel

--- a/api/src/services/habitat-feature-services/habitat-feature-service.ts
+++ b/api/src/services/habitat-feature-services/habitat-feature-service.ts
@@ -1,0 +1,62 @@
+import { IDBConnection } from '../../database/db';
+import { HabitatFeatureRepository } from '../../repositories/habitat-feature-repository/habitat-feature-repository';
+import {
+  FindHabitatFeatureDefinitionAdvancedFilters,
+  FindHabitatFeatureDefinitions,
+  FindHabitatFeatureQualitativeDefinition,
+  FindHabitatFeatureQuantitativeDefinition
+} from '../../repositories/habitat-feature-repository/habitat-feature-repository.interface';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
+import { DBService } from '../db-service';
+
+export class HabitatFeatureService extends DBService {
+  habitatFeatureRepository: HabitatFeatureRepository;
+
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.habitatFeatureRepository = new HabitatFeatureRepository(connection);
+  }
+
+  /**
+   * Find habitat feature quantitative definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindHabitatFeatureQuantitativeDefinition[]>}
+   * @memberof HabitatFeatureService
+   */
+  async findHabitatFeatureQuantitativeDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindHabitatFeatureQuantitativeDefinition[]> {
+    return this.habitatFeatureRepository.findHabitatFeatureQuantitativeDefinitions(filterFields, pagination);
+  }
+
+  /**
+   * Find habitat feature qualitative definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<FindHabitatFeatureQualitativeDefinition[]>}
+   * @memberof HabitatFeatureService
+   */
+  async findHabitatFeatureQualitativeDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FindHabitatFeatureQualitativeDefinition[]> {
+    return this.habitatFeatureRepository.findHabitatFeatureQualitativeDefinitions(filterFields, pagination);
+  }
+
+  /**
+   * Find habitat feature definitions.
+   *
+   * @param {FindHabitatFeatureDefinitionAdvancedFilters} filterFields
+   * @return {*}  {Promise<FindHabitatFeatureDefinitions>}
+   * @memberof HabitatFeatureService
+   */
+  async findHabitatFeatureDefinitions(
+    filterFields: FindHabitatFeatureDefinitionAdvancedFilters
+  ): Promise<FindHabitatFeatureDefinitions> {
+    return this.habitatFeatureRepository.findHabitatFeatureDefinitions(filterFields);
+  }
+}

--- a/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
+++ b/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
@@ -1,0 +1,109 @@
+import { IDBConnection } from '../../database/db';
+import { FindHabitatFeatureDefinitions } from '../../repositories/habitat-feature-repository/habitat-feature-repository.interface';
+import { SurveyHabitatFeatureRepository } from '../../repositories/habitat-feature-repository/survey-habitat-feature-repository';
+import {
+  InsertSurveyHabitatFeature,
+  SurveyHabitatFeaturesWithSupplementaryData,
+  SurveyHabitatFeatureWithTaxons
+} from '../../repositories/habitat-feature-repository/survey-habitat-feature-repository.interface';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
+import { DBService } from '../db-service';
+import { HabitatFeatureService } from './habitat-feature-service';
+
+export class SurveyHabitatFeatureService extends DBService {
+  surveyHabitatFeatureRepository: SurveyHabitatFeatureRepository;
+
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.surveyHabitatFeatureRepository = new SurveyHabitatFeatureRepository(connection);
+  }
+
+  async insertSurveyHabitatFeatures(surveyId: number, habitatFeatures: InsertSurveyHabitatFeature[]): Promise<void> {
+    this.surveyHabitatFeatureRepository.insertSurveyHabitatFeatures(surveyId, habitatFeatures);
+  }
+
+  /**
+   * Get a single survey habitat feature record.
+   *
+   * @param {number} surveyId
+   * @param {number} surveyHabitatFeatureId
+   * @return {*}  {Promise<SurveyHabitatFeatureWithTaxons[]>}
+   * @memberof SurveyHabitatFeatureService
+   */
+  async getSurveyHabitatFeature(
+    surveyId: number,
+    surveyHabitatFeatureId: number
+  ): Promise<SurveyHabitatFeatureWithTaxons> {
+    return this.surveyHabitatFeatureRepository.getSurveyHabitatFeature(surveyId, surveyHabitatFeatureId);
+  }
+
+  /**
+   * Get paginated habitat features for a survey.
+   *
+   * @param {number} surveyId
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<SurveyHabitatFeatureWithTaxons[]>}
+   * @memberof SurveyHabitatFeatureService
+   */
+  async getSurveyHabitatFeatures(
+    surveyId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<SurveyHabitatFeatureWithTaxons[]> {
+    return this.surveyHabitatFeatureRepository.getSurveyHabitatFeatures(surveyId, pagination);
+  }
+
+  /**
+   * Get the total count of habitat features for a survey.
+   *
+   * @param {number} surveyId
+   * @return {*}  {Promise<number>}
+   * @memberof SurveyHabitatFeatureService
+   */
+  async getSurveyHabitatFeaturesCount(surveyId: number): Promise<number> {
+    return this.surveyHabitatFeatureRepository.getSurveyHabitatFeaturesCount(surveyId);
+  }
+
+  /**
+   * Get paginated survey habitat feature records, with supplementary data, for a survey.
+   *
+   * @param {number} surveyId
+   * @param {ApiPaginationOptions} [pagination]
+   * @return {*}  {Promise<SurveyHabitatFeaturesWithSupplementaryData>}
+   * @memberof ObservationService
+   */
+  async getSurveyHabitatFeaturesWithSupplementaryData(
+    surveyId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<SurveyHabitatFeaturesWithSupplementaryData> {
+    const [surveyHabitatFeatures, surveyHabitatFeaturesCount, surveyHabitatFeatureTypeDefinitions] = await Promise.all([
+      // Fetch observations
+      this.getSurveyHabitatFeatures(surveyId, pagination),
+      // Fetch pagination count data
+      this.getSurveyHabitatFeaturesCount(surveyId),
+      // Fetch habitat feature definitions applicable to this survey
+      this.getSurveyHabitatFeatureDefinitions(surveyId)
+    ]);
+
+    return {
+      surveyHabitatFeatures: surveyHabitatFeatures,
+      supplementaryData: {
+        count: surveyHabitatFeaturesCount,
+        habitatFeatureQuantitativeDefinition: surveyHabitatFeatureTypeDefinitions.habitatFeatureQuantitativeDefinition,
+        habitatFeatureQualitativeDefinition: surveyHabitatFeatureTypeDefinitions.habitatFeatureQualitativeDefinition
+      }
+    };
+  }
+
+  /**
+   * Get habitat feature definitions for a survey.
+   *
+   * @param {number} surveyId
+   * @return {*}  {Promise<FindHabitatFeatureDefinitions>}
+   * @memberof SurveyHabitatFeatureService
+   */
+  async getSurveyHabitatFeatureDefinitions(surveyId: number): Promise<FindHabitatFeatureDefinitions> {
+    const habitatFeatureService = new HabitatFeatureService(this.connection);
+
+    return habitatFeatureService.findHabitatFeatureDefinitions({ survey_id: surveyId });
+  }
+}

--- a/app/src/interfaces/useCodesApi.interface.ts
+++ b/app/src/interfaces/useCodesApi.interface.ts
@@ -51,4 +51,5 @@ export interface IGetAllCodeSetsResponse {
   frequency_units: CodeSet<{ id: number; name: string; description: string }>;
   alert_types: CodeSet<{ id: number; name: string; description: string }>;
   vantages: CodeSet<{ id: number; name: string; description: string }>;
+  habitat_feature_types: CodeSet<{ id: number; name: string; description: string }>;
 }

--- a/app/src/test-helpers/code-helpers.ts
+++ b/app/src/test-helpers/code-helpers.ts
@@ -82,5 +82,9 @@ export const codes: IGetAllCodeSetsResponse = {
   vantages: [
     { id: 1, name: 'Vantage 1', description: 'Vantage point 1.' },
     { id: 2, name: 'Vantage 2', description: 'Vantage point 2.' }
+  ],
+  habitat_feature_types: [
+    { id: 1, name: 'Habitat feature 1', description: 'Habitat feature 1.' },
+    { id: 2, name: 'Habitat feature 2', description: 'Habitat feature 2.' }
   ]
 };

--- a/database/src/seeds/03_basic_project_survey_setup.ts
+++ b/database/src/seeds/03_basic_project_survey_setup.ts
@@ -136,6 +136,9 @@ export async function seed(knex: Knex): Promise<void> {
             await knex.raw(insertObservationSubCount(createObservationResponse.rows[0].survey_observation_id));
           }
         }
+
+        // Insert survey habitat features
+        await knex.raw(insertSurveyHabitatFeaturesData(surveyId));
       }
     }
   }
@@ -1120,3 +1123,66 @@ const insertSystemAlert = () => `
     (SELECT system_user_id FROM "system_user" ORDER BY random() LIMIT 1)
   );
 `;
+
+/**
+ * Insert 3 survey_habitat_feature records, with 3 different random habitat_feature_types.
+ *
+ * @param {number} surveyId
+ * @return {*}
+ */
+const insertSurveyHabitatFeaturesData = (surveyId: number) => {
+  return `
+    WITH w_habitat_features AS (
+        SELECT * FROM habitat_feature_type ORDER BY random() LIMIT 3
+    )
+    INSERT INTO survey_habitat_feature
+    (
+        survey_id,
+        habitat_feature_type_id,
+        count,
+        latitude,
+        longitude,
+        observed_date,
+        observed_time
+    )
+    VALUES (
+        ${surveyId},
+        (SELECT habitat_feature_type_id FROM w_habitat_features LIMIT 1 OFFSET 0),
+        ${faker.number.int({ min: 1, max: 20 })},
+        ${faker.location.latitude()},
+        ${faker.location.longitude()},
+        $$${faker.date
+          .between({ from: '2000-01-01T00:00:00-08:00', to: '2001-01-01T00:00:00-08:00' })
+          .toISOString()}$$::date,
+        timestamp $$${faker.date
+          .between({ from: '2002-01-01T00:00:00-08:00', to: '2005-01-01T00:00:00-08:00' })
+          .toISOString()}$$::time
+    ),
+    (
+        ${surveyId},
+        (SELECT habitat_feature_type_id FROM w_habitat_features LIMIT 1 OFFSET 1),
+        ${faker.number.int({ min: 1, max: 20 })},
+        ${faker.location.latitude()},
+        ${faker.location.longitude()},
+        $$${faker.date
+          .between({ from: '2000-01-01T00:00:00-08:00', to: '2001-01-01T00:00:00-08:00' })
+          .toISOString()}$$::date,
+        timestamp $$${faker.date
+          .between({ from: '2002-01-01T00:00:00-08:00', to: '2005-01-01T00:00:00-08:00' })
+          .toISOString()}$$::time
+    ),
+    (
+        ${surveyId},
+        (SELECT habitat_feature_type_id FROM w_habitat_features LIMIT 1 OFFSET 2),
+        ${faker.number.int({ min: 1, max: 20 })},
+        ${faker.location.latitude()},
+        ${faker.location.longitude()},
+        $$${faker.date
+          .between({ from: '2000-01-01T00:00:00-08:00', to: '2001-01-01T00:00:00-08:00' })
+          .toISOString()}$$::date,
+        timestamp $$${faker.date
+          .between({ from: '2002-01-01T00:00:00-08:00', to: '2005-01-01T00:00:00-08:00' })
+          .toISOString()}$$::time
+    );
+  `;
+};


### PR DESCRIPTION
## Links to Jira Tickets

https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-673

## Description of Changes

- Add habitat_feature_type codes to codes endpoint/service/repo.
- Add GET endpoint for survey habitat features. Add related service/repo functions.
- Add database-models for all new habitat feature related tables.
- Update seed to include survey habitat feature records.

## Testing Notes

Should be able to call `GET .../survey/{surveyId}/habitat-features`

Added a postman endpoint for the above request.
