### PR TITLE
FEATURE: Habitat Feature Table Improvements

### DIFF
--- a/app/src/constants/session-storage.ts
+++ b/app/src/constants/session-storage.ts
@@ -23,6 +23,11 @@ export const SIMS_OBSERVATIONS_MEASUREMENT_COLUMNS = 'SIMS_OBSERVATIONS_MEASUREM
 export const SIMS_OBSERVATIONS_ENVIRONMENT_COLUMNS = 'SIMS_OBSERVATIONS_ENVIRONMENT_COLUMNS';
 
 /**
+ * Key used to cache habitat feature column visiblity in sessionStorage
+ */
+export const SIMS_HABITAT_FEATURES_HIDDEN_COLUMNS = 'SIMS_HABITAT_FEATURES_HIDDEN_COLUMNS';
+
+/**
  * Get a session storage key which is unique to the provided survey id.
  *
  * @param {number} surveyId

--- a/app/src/contexts/habitatFeatureTableContext.tsx
+++ b/app/src/contexts/habitatFeatureTableContext.tsx
@@ -1,10 +1,13 @@
 import { GridColDef } from '@mui/x-data-grid';
-import { createContext, PropsWithChildren } from 'react';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import { useCodesContext, useSurveyContext } from 'hooks/useContext';
+import useDataLoader from 'hooks/useDataLoader';
+import { createContext, PropsWithChildren, useEffect, useMemo } from 'react';
 
 export interface IHabitatFeatureRow {
   survey_habitat_feature_id: number;
   survey_id: number;
-  habitat_feature_id: number;
+  habitat_feature_type_id: number;
   count: number;
   latitude: number | null;
   longitude: number | null;
@@ -31,61 +34,137 @@ export const HabitatFeatureTableContext = createContext<IHabitatFeatureTableCont
  * @returns {*}
  */
 export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableContextProviderProps) => {
-  const columns: GridColDef<IHabitatFeatureRow>[] = [
-    {
-      field: 'habitat_feature_id',
-      headerName: 'Habitat Feature',
-      align: 'left',
-      maxWidth: 200,
-      valueGetter: (params) => {
-        return params.row.habitat_feature_id; // TODO: Mac: Replace this with the actual habitat feature name
-      },
-      flex: 1
-    },
-    {
-      field: 'count',
-      headerName: 'Count',
-      headerAlign: 'right',
-      align: 'right',
-      maxWidth: 100,
-      flex: 1
-    },
-    {
-      field: 'latitude',
-      headerName: 'Lat',
-      headerAlign: 'right',
-      align: 'right',
-      maxWidth: 100
-    },
-    {
-      field: 'longitude',
-      headerName: 'Long',
-      headerAlign: 'right',
-      align: 'right',
-      maxWidth: 100
-    },
-    {
-      field: 'observed_date',
-      headerName: 'Date',
-      maxWidth: 120
-    },
-    {
-      field: 'observed_time',
-      headerName: 'Time',
-      headerAlign: 'right',
-      align: 'right',
-      maxWidth: 100
-    }
-    // TODO: Mac: Dynamically add the qualitative / quantitative columns
-  ];
+  const biohubApi = useBiohubApi();
+  const codesContext = useCodesContext();
+  const { projectId, surveyId } = useSurveyContext();
 
-  // TODO: Implement the context with the actual data
-  const habitatFeatureTableContxt: IHabitatFeatureTableContext = {
-    columns: columns,
-    rows: [],
-    rowCount: -1,
-    isLoading: false
-  };
+  const habitatFeatureDataLoader = useDataLoader(() =>
+    biohubApi.habitatFeatureApi.getSurveyHabitatFeaturesWithSupplementaryData(projectId, surveyId)
+  );
+
+  useEffect(() => {
+    codesContext.codesDataLoader.load();
+  }, [codesContext.codesDataLoader]);
+
+  useEffect(() => {
+    habitatFeatureDataLoader.load();
+  }, [habitatFeatureDataLoader]);
+
+  // Create a map of habitat feature type IDs to their names
+  const habitatFeatureTypeMap: Map<number, string> = useMemo(() => {
+    const habitatFeatureTypeMap = new Map();
+
+    // Populate the map with the habitat feature types
+    for (const featureType of codesContext.codesDataLoader.data?.habitat_feature_types ?? []) {
+      habitatFeatureTypeMap.set(featureType.id, featureType.name);
+    }
+
+    return habitatFeatureTypeMap;
+  }, [codesContext.codesDataLoader.data?.habitat_feature_types]);
+
+  // Create the rows for the table
+  const habitatFeatureTableRows: IHabitatFeatureRow[] = useMemo(() => {
+    if (!habitatFeatureDataLoader.data) {
+      return [];
+    }
+
+    return habitatFeatureDataLoader.data.surveyHabitatFeatures.map((habitatFeature) => ({
+      survey_habitat_feature_id: habitatFeature.survey_habitat_feature_id,
+      survey_id: habitatFeature.survey_id,
+      habitat_feature_type_id: habitatFeature.habitat_feature_type_id,
+      count: habitatFeature.count,
+      latitude: habitatFeature.latitude,
+      longitude: habitatFeature.longitude,
+      observed_date: habitatFeature.observed_date,
+      observed_time: habitatFeature.observed_time
+    }));
+  }, [habitatFeatureDataLoader.data]);
+
+  // Create the columns for the table
+  const habitatFeatureTableColumns: GridColDef<IHabitatFeatureRow>[] = useMemo(() => {
+    const quantitativeColumns: GridColDef<IHabitatFeatureRow>[] =
+      habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQuantitativeDefinitions.map(
+        (quantitativeDefintion) => ({
+          field: `habitat_feature_quantitative_definition_id`,
+          headerName: quantitativeDefintion.name,
+          align: 'right'
+        })
+      ) ?? [];
+
+    const qualitativeColumns: GridColDef<IHabitatFeatureRow>[] =
+      habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQualitativeDefinitions.map(
+        (qualitativeDefinition) => ({
+          field: `habitat_feature_qualitative_definition_id`,
+          headerName: qualitativeDefinition.name,
+          align: 'left'
+        })
+      ) ?? [];
+
+    const standardColumns: GridColDef<IHabitatFeatureRow>[] = [
+      {
+        field: 'habitat_feature_type_id',
+        headerName: 'Habitat Feature',
+        align: 'left',
+        maxWidth: 200,
+        valueGetter: (params) => habitatFeatureTypeMap.get(params.value),
+        flex: 1
+      },
+      {
+        field: 'count',
+        headerName: 'Count',
+        headerAlign: 'right',
+        align: 'right',
+        maxWidth: 100
+      },
+      {
+        field: 'latitude',
+        headerName: 'Lat',
+        headerAlign: 'right',
+        align: 'right',
+        maxWidth: 150
+      },
+      {
+        field: 'longitude',
+        headerName: 'Long',
+        headerAlign: 'right',
+        align: 'right',
+        maxWidth: 150
+      },
+      {
+        field: 'observed_date',
+        headerName: 'Date',
+        maxWidth: 120
+      },
+      {
+        field: 'observed_time',
+        headerName: 'Time',
+        headerAlign: 'right',
+        align: 'right',
+        maxWidth: 100
+      }
+    ];
+
+    return standardColumns.concat(quantitativeColumns).concat(qualitativeColumns);
+  }, [
+    habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQualitativeDefinitions,
+    habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQuantitativeDefinitions,
+    habitatFeatureTypeMap
+  ]);
+
+  // Create the memoized context object
+  const habitatFeatureTableContxt: IHabitatFeatureTableContext = useMemo(() => {
+    return {
+      columns: habitatFeatureTableColumns,
+      rows: habitatFeatureTableRows,
+      rowCount: habitatFeatureDataLoader.data?.pagination.total ?? 0,
+      isLoading: habitatFeatureDataLoader.isLoading
+    };
+  }, [
+    habitatFeatureTableColumns,
+    habitatFeatureTableRows,
+    habitatFeatureDataLoader.data?.pagination.total,
+    habitatFeatureDataLoader.isLoading
+  ]);
 
   return (
     <HabitatFeatureTableContext.Provider value={habitatFeatureTableContxt}>

--- a/app/src/contexts/habitatFeatureTableContext.tsx
+++ b/app/src/contexts/habitatFeatureTableContext.tsx
@@ -8,12 +8,13 @@ export interface IHabitatFeatureRow {
   survey_habitat_feature_id: number;
   survey_id: number;
   habitat_feature_type_id: number;
+  habitat_feature_taxons: string[];
   count: number;
   latitude: number | null;
   longitude: number | null;
   observed_date: string;
   observed_time: string;
-  // TODO: Mac: Add the qualitative / quantitative arrays
+  [habitatFeatureDefinitionUuid: string]: number | string | unknown;
 }
 
 export interface IHabitatFeatureTableContext {
@@ -50,16 +51,11 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
     habitatFeatureDataLoader.load();
   }, [habitatFeatureDataLoader]);
 
-  // Create a map of habitat feature type IDs to their names
+  // Create a map of habitat feature type ids to their respective names
   const habitatFeatureTypeMap: Map<number, string> = useMemo(() => {
-    const habitatFeatureTypeMap = new Map();
-
-    // Populate the map with the habitat feature types
-    for (const featureType of codesContext.codesDataLoader.data?.habitat_feature_types ?? []) {
-      habitatFeatureTypeMap.set(featureType.id, featureType.name);
-    }
-
-    return habitatFeatureTypeMap;
+    return new Map(
+      codesContext.codesDataLoader.data?.habitat_feature_types.map((featureType) => [featureType.id, featureType.name])
+    );
   }, [codesContext.codesDataLoader.data?.habitat_feature_types]);
 
   // Create the rows for the table
@@ -72,11 +68,13 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
       survey_habitat_feature_id: habitatFeature.survey_habitat_feature_id,
       survey_id: habitatFeature.survey_id,
       habitat_feature_type_id: habitatFeature.habitat_feature_type_id,
+      habitat_feature_taxons: habitatFeature.survey_habitat_feature_taxons.map((taxon) => taxon.itis_scientific_name),
       count: habitatFeature.count,
       latitude: habitatFeature.latitude,
       longitude: habitatFeature.longitude,
       observed_date: habitatFeature.observed_date,
       observed_time: habitatFeature.observed_time
+      // TODO: Mac: Add the qualitative and quantitative data to the row
     }));
   }, [habitatFeatureDataLoader.data]);
 
@@ -85,18 +83,18 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
     const quantitativeColumns: GridColDef<IHabitatFeatureRow>[] =
       habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQuantitativeDefinitions.map(
         (quantitativeDefintion) => ({
-          field: `habitat_feature_quantitative_definition_id`,
+          field: quantitativeDefintion.habitat_feature_quantitative_definition_id,
           headerName: quantitativeDefintion.name,
-          align: 'right'
+          align: 'right' // Quantitative columns are numeric
         })
       ) ?? [];
 
     const qualitativeColumns: GridColDef<IHabitatFeatureRow>[] =
       habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQualitativeDefinitions.map(
         (qualitativeDefinition) => ({
-          field: `habitat_feature_qualitative_definition_id`,
+          field: qualitativeDefinition.habitat_feature_qualitative_definition_id,
           headerName: qualitativeDefinition.name,
-          align: 'left'
+          align: 'left' // Qualitative columns are text
         })
       ) ?? [];
 
@@ -105,8 +103,21 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
         field: 'habitat_feature_type_id',
         headerName: 'Habitat Feature',
         align: 'left',
-        maxWidth: 200,
+        minWidth: 200,
         valueGetter: (params) => habitatFeatureTypeMap.get(params.value),
+        flex: 1
+      },
+      {
+        field: 'habitat_feature_taxons',
+        headerName: 'Species',
+        align: 'left',
+        valueGetter: (params) => params.row.habitat_feature_taxons.join(', '),
+        flex: 1
+      },
+      {
+        field: 'survey_sample_site_id',
+        headerName: 'Sample Site',
+        align: 'left',
         flex: 1
       },
       {
@@ -114,33 +125,38 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
         headerName: 'Count',
         headerAlign: 'right',
         align: 'right',
-        maxWidth: 100
+        minWidth: 100,
+        flex: 1
       },
       {
         field: 'latitude',
         headerName: 'Lat',
         headerAlign: 'right',
         align: 'right',
-        maxWidth: 150
+        minWidth: 150,
+        flex: 1
       },
       {
         field: 'longitude',
         headerName: 'Long',
         headerAlign: 'right',
         align: 'right',
-        maxWidth: 150
+        minWidth: 150,
+        flex: 1
       },
       {
         field: 'observed_date',
         headerName: 'Date',
-        maxWidth: 120
+        minWidth: 120,
+        flex: 1
       },
       {
         field: 'observed_time',
         headerName: 'Time',
         headerAlign: 'right',
         align: 'right',
-        maxWidth: 100
+        minWidth: 120,
+        flex: 1
       }
     ];
 

--- a/app/src/contexts/habitatFeatureTableContext.tsx
+++ b/app/src/contexts/habitatFeatureTableContext.tsx
@@ -1,8 +1,11 @@
-import { GridColDef } from '@mui/x-data-grid';
+import { GridColDef, GridColumnVisibilityModel, useGridApiRef } from '@mui/x-data-grid';
+import { GridApiCommunity } from '@mui/x-data-grid/internals';
+import { SIMS_HABITAT_FEATURES_HIDDEN_COLUMNS } from 'constants/session-storage';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { createContext, PropsWithChildren, useEffect, useMemo } from 'react';
+import { usePersistentState } from 'hooks/usePersistentState';
+import { createContext, PropsWithChildren, useCallback, useEffect, useMemo } from 'react';
 
 export interface IHabitatFeatureRow {
   survey_habitat_feature_id: number;
@@ -18,10 +21,42 @@ export interface IHabitatFeatureRow {
 }
 
 export interface IHabitatFeatureTableContext {
+  /**
+   * API ref used to interface with an MUI DataGrid representing the habitat feature records
+   */
+  _muiDataGridApiRef: React.MutableRefObject<GridApiCommunity>;
+  /**
+   * The columns of the table
+   */
   columns: GridColDef<IHabitatFeatureRow>[];
+  /**
+   * The columns that are currently hidden
+   */
+  hiddenColumns: string[];
+  /**
+   * The rows of the table
+   */
   rows: IHabitatFeatureRow[];
+  /**
+   * The total number of rows the server has
+   */
   rowCount: number;
+  /**
+   * Indicates if the data is currently loading
+   */
   isLoading: boolean;
+  /**
+   * The column visibility model, which defines which columns are visible
+   */
+  columnVisibilityModel: GridColumnVisibilityModel;
+  /**
+   * Callback fired when column visibility model changes
+   */
+  onColumnVisibilityModelChange: (model: GridColumnVisibilityModel) => void;
+  /**
+   * Toggle a columns visibility
+   */
+  toggleColumnVisibility: (column: string) => void;
 }
 
 type IHabitatFeatureTableContextProviderProps = PropsWithChildren;
@@ -35,9 +70,17 @@ export const HabitatFeatureTableContext = createContext<IHabitatFeatureTableCont
  * @returns {*}
  */
 export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableContextProviderProps) => {
+  const _muiDataGridApiRef = useGridApiRef();
+
   const biohubApi = useBiohubApi();
   const codesContext = useCodesContext();
   const { projectId, surveyId } = useSurveyContext();
+
+  // Stores the column visibility state in local storage
+  const [columnVisibilityModel, setColumnVisibilityModel] = usePersistentState<GridColumnVisibilityModel>(
+    SIMS_HABITAT_FEATURES_HIDDEN_COLUMNS,
+    {}
+  );
 
   const habitatFeatureDataLoader = useDataLoader(() =>
     biohubApi.habitatFeatureApi.getSurveyHabitatFeaturesWithSupplementaryData(projectId, surveyId)
@@ -50,6 +93,29 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
   useEffect(() => {
     habitatFeatureDataLoader.load();
   }, [habitatFeatureDataLoader]);
+
+  // Columns hidden from table view
+  const hiddenColumns = useMemo(() => {
+    const columns = Object.keys(columnVisibilityModel);
+    return columns.filter((column) => !columnVisibilityModel[column]);
+  }, [columnVisibilityModel]);
+
+  /**
+   * Toggle the table columns visibility
+   *
+   * @param {{columns: string[]}} [config] - Array of columns to hide
+   * @returns {void}
+   */
+  const toggleColumnsVisibility = useCallback(
+    (column: string) => {
+      const updatedVisibilityModel = { ...columnVisibilityModel };
+
+      updatedVisibilityModel[column] = !updatedVisibilityModel[column];
+
+      setColumnVisibilityModel(updatedVisibilityModel);
+    },
+    [columnVisibilityModel, setColumnVisibilityModel]
+  );
 
   // Create a map of habitat feature type ids to their respective names
   const habitatFeatureTypeMap: Map<number, string> = useMemo(() => {
@@ -170,16 +236,26 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
   // Create the memoized context object
   const habitatFeatureTableContxt: IHabitatFeatureTableContext = useMemo(() => {
     return {
+      _muiDataGridApiRef: _muiDataGridApiRef,
       columns: habitatFeatureTableColumns,
       rows: habitatFeatureTableRows,
       rowCount: habitatFeatureDataLoader.data?.pagination.total ?? 0,
-      isLoading: habitatFeatureDataLoader.isLoading
+      isLoading: habitatFeatureDataLoader.isLoading,
+      columnVisibilityModel: columnVisibilityModel,
+      onColumnVisibilityModelChange: setColumnVisibilityModel,
+      hiddenColumns: hiddenColumns,
+      toggleColumnVisibility: toggleColumnsVisibility
     };
   }, [
+    _muiDataGridApiRef,
     habitatFeatureTableColumns,
     habitatFeatureTableRows,
     habitatFeatureDataLoader.data?.pagination.total,
-    habitatFeatureDataLoader.isLoading
+    habitatFeatureDataLoader.isLoading,
+    columnVisibilityModel,
+    setColumnVisibilityModel,
+    hiddenColumns,
+    toggleColumnsVisibility
   ]);
 
   return (

--- a/app/src/features/projects/create/CreateProjectPage.tsx
+++ b/app/src/features/projects/create/CreateProjectPage.tsx
@@ -13,7 +13,7 @@ import { DialogContext } from 'contexts/dialogContext';
 import { FormikProps } from 'formik';
 import { useAuthStateContext } from 'hooks/useAuthStateContext';
 import { useBiohubApi } from 'hooks/useBioHubApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateProjectRequest, IGetProjectParticipant } from 'interfaces/useProjectApi.interface';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -44,7 +44,7 @@ const CreateProjectPage = () => {
   const [enableCancelCheck, setEnableCancelCheck] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const dialogContext = useContext(DialogContext);
   const codesContext = useContext(CodesContext);
@@ -117,7 +117,8 @@ const CreateProjectPage = () => {
       }
 
       setEnableCancelCheck(false);
-      history.push(`/admin/projects/${response.id}`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${response.id}`);
     } finally {
       setIsSaving(false);
     }

--- a/app/src/features/projects/edit/EditProjectPage.tsx
+++ b/app/src/features/projects/edit/EditProjectPage.tsx
@@ -13,7 +13,7 @@ import { ProjectContext } from 'contexts/projectContext';
 import { FormikProps } from 'formik';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { IUpdateProjectRequest, UPDATE_GET_ENTITIES } from 'interfaces/useProjectApi.interface';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -36,7 +36,7 @@ const EditProjectPage = () => {
   const [enableCancelCheck, setEnableCancelCheck] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const dialogContext = useContext(DialogContext);
   const codesContext = useContext(CodesContext);
@@ -100,7 +100,8 @@ const EditProjectPage = () => {
       }
 
       setEnableCancelCheck(false);
-      history.push(`/admin/projects/${response.id}`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${response.id}`);
     } finally {
       setIsSaving(false);
     }

--- a/app/src/features/surveys/CreateSurveyPage.tsx
+++ b/app/src/features/surveys/CreateSurveyPage.tsx
@@ -18,7 +18,7 @@ import { SurveyPartnershipsFormInitialValues } from 'features/surveys/view/compo
 import { FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateSurveyRequest, IEditSurveyRequest } from 'interfaces/useSurveyApi.interface';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -78,7 +78,7 @@ const CreateSurveyPage = () => {
 
   // Ability to bypass showing the 'Are you sure you want to cancel' dialog
   const [enableCancelCheck, setEnableCancelCheck] = useState<boolean>(true);
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -151,10 +151,8 @@ const CreateSurveyPage = () => {
 
       setEnableCancelCheck(false);
 
-      history.push(
-        `/admin/projects/${projectData?.project.project_id}/surveys/${response.id}/details`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectData?.project.project_id}/surveys/${response.id}/details`);
     } catch (error) {
       const apiError = error as APIError;
       showCreateErrorDialog({

--- a/app/src/features/surveys/animals/animal-form/create/CreateAnimalPage.tsx
+++ b/app/src/features/surveys/animals/animal-form/create/CreateAnimalPage.tsx
@@ -15,7 +15,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateEditAnimalRequest } from 'interfaces/useCritterApi.interface';
 import { useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -46,7 +46,7 @@ export const CreateAnimalPage = () => {
   const dialogContext = useDialogContext();
   const animalPageContext = useAnimalPageContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -124,7 +124,8 @@ export const CreateAnimalPage = () => {
       // Refresh the context, so the next page loads with the latest data
       surveyContext.critterDataLoader.refresh(surveyContext.projectId, surveyContext.surveyId);
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`);
     } catch (error) {
       const apiError = error as APIError;
       showCreateErrorDialog({

--- a/app/src/features/surveys/animals/animal-form/edit/EditAnimalPage.tsx
+++ b/app/src/features/surveys/animals/animal-form/edit/EditAnimalPage.tsx
@@ -21,7 +21,7 @@ import {
   useTaxonomyContext
 } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateEditAnimalRequest } from 'interfaces/useCritterApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -45,7 +45,7 @@ export const EditAnimalPage = () => {
   const urlParams: Record<string, string | number | undefined> = useParams();
   const surveyCritterId: number | undefined = Number(urlParams['critter_id']);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -152,7 +152,8 @@ export const EditAnimalPage = () => {
       surveyContext.critterDataLoader.refresh(projectId, surveyId);
       animalPageContext.critterDataLoader.refresh(projectId, surveyId, critter.critter_id);
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`);
     } catch (error) {
       const apiError = error as APIError;
       showCreateErrorDialog({

--- a/app/src/features/surveys/animals/profile/captures/capture-form/create/CreateCapturePage.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/create/CreateCapturePage.tsx
@@ -20,7 +20,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateCaptureRequest, ILocationCreate } from 'interfaces/useCritterApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -68,7 +68,7 @@ export const CreateCapturePage = () => {
   const urlParams: Record<string, string | number | undefined> = useParams();
   const surveyCritterId: number | undefined = Number(urlParams['critter_id']);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -222,7 +222,8 @@ export const CreateCapturePage = () => {
         animalPageContext.critterDataLoader.refresh(projectId, surveyId, surveyCritterId);
       }
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`);
     } catch (error) {
       const apiError = error as APIError;
       showCreateErrorDialog({

--- a/app/src/features/surveys/animals/profile/captures/capture-form/edit/EditCapturePage.tsx
+++ b/app/src/features/surveys/animals/profile/captures/capture-form/edit/EditCapturePage.tsx
@@ -17,7 +17,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { IEditCaptureRequest } from 'interfaces/useCritterApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -45,7 +45,7 @@ export const EditCapturePage = () => {
   const surveyCritterId: number | undefined = Number(urlParams['critter_id']);
   const captureId: string | undefined = String(urlParams['capture_id']);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -212,7 +212,8 @@ export const EditCapturePage = () => {
         animalPageContext.critterDataLoader.refresh(projectId, surveyId, surveyCritterId);
       }
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`);
     } catch (error) {
       const apiError = error as APIError;
 

--- a/app/src/features/surveys/animals/profile/captures/import-captures/CreateCSVCapturesPage.tsx
+++ b/app/src/features/surveys/animals/profile/captures/import-captures/CreateCSVCapturesPage.tsx
@@ -13,7 +13,7 @@ import { FileUploadSingleItem } from 'components/file-upload/FileUploadSingleIte
 import PageHeader from 'components/layout/PageHeader';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { useCallback, useMemo, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
@@ -60,7 +60,7 @@ export const CreateCSVCapturesPage = () => {
   const history = useHistory();
   const biohubApi = useBiohubApi();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
   const dialogContext = useDialogContext();
 
   const projectContext = useProjectContext();
@@ -189,7 +189,8 @@ export const CreateCSVCapturesPage = () => {
       animalPageContext.critterDataLoader.refresh(projectId, surveyId, animalPageContext.selectedAnimal.critter_id);
     }
 
-    history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`, SKIP_CONFIRMATION_DIALOG);
+    skipUnsavedChangesDialog();
+    history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals`);
   };
 
   /**

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/create/CreateMortalityPage.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/create/CreateMortalityPage.tsx
@@ -21,7 +21,7 @@ import { FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateMortalityRequest } from 'interfaces/useCritterApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -64,7 +64,7 @@ export const CreateMortalityPage = () => {
   const urlParams: Record<string, string | number | undefined> = useParams();
   const surveyCritterId: number | undefined = Number(urlParams['critter_id']);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -184,7 +184,8 @@ export const CreateMortalityPage = () => {
       // Refresh page
       animalPageContext.critterDataLoader.refresh(projectId, surveyId, surveyCritterId);
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`);
     } catch (error) {
       const apiError = error as APIError;
       showCreateErrorDialog({

--- a/app/src/features/surveys/animals/profile/mortality/mortality-form/edit/EditMortalityPage.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/mortality-form/edit/EditMortalityPage.tsx
@@ -17,7 +17,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useAnimalPageContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { IEditMortalityRequest } from 'interfaces/useCritterApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -44,7 +44,7 @@ export const EditMortalityPage = () => {
   const surveyCritterId: number | undefined = Number(urlParams['critter_id']);
   const mortalityId: string | undefined = String(urlParams['mortality_id']);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -186,7 +186,8 @@ export const EditMortalityPage = () => {
       // Refresh page
       if (surveyCritterId) animalPageContext.critterDataLoader.refresh(projectId, surveyId, surveyCritterId);
 
-      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`, SKIP_CONFIRMATION_DIALOG);
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectId}/surveys/${surveyId}/animals/details`);
     } catch (error) {
       const apiError = error as APIError;
 

--- a/app/src/features/surveys/edit/EditSurveyPage.tsx
+++ b/app/src/features/surveys/edit/EditSurveyPage.tsx
@@ -18,7 +18,7 @@ import { FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { IEditSurveyRequest } from 'interfaces/useSurveyApi.interface';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -42,7 +42,7 @@ const EditSurveyPage = () => {
   // Ability to bypass showing the 'Are you sure you want to cancel' dialog
   const [enableCancelCheck, setEnableCancelCheck] = useState<boolean>(true);
   const [isSaving, setIsSaving] = useState(false);
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const dialogContext = useContext(DialogContext);
   const codesContext = useContext(CodesContext);
@@ -139,10 +139,8 @@ const EditSurveyPage = () => {
 
       surveyContext.surveyDataLoader.refresh(projectContext.projectId, surveyContext.surveyId);
 
-      history.push(
-        `/admin/projects/${projectContext.projectId}/surveys/${response.id}/details`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${projectContext.projectId}/surveys/${response.id}/details`);
     } catch (error) {
       const apiError = error as APIError;
       showEditErrorDialog({

--- a/app/src/features/surveys/habitat-features/SurveyHabitatFeaturePage.tsx
+++ b/app/src/features/surveys/habitat-features/SurveyHabitatFeaturePage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CircularProgress, Stack } from '@mui/material';
+import { Box, CircularProgress, Stack } from '@mui/material';
 import { DialogContextProvider } from 'contexts/dialogContext';
 import { HabitatFeatureTableContextProvider } from 'contexts/habitatFeatureTableContext';
 import { ProjectContext } from 'contexts/projectContext';
@@ -49,7 +49,7 @@ export const SurveyHabitatFeaturePage = (): JSX.Element => {
         <Box flex="0 0 auto" width="400px">
           <DialogContextProvider>
             {/* TODO: Mac: Update isDisabled with correct value */}
-            <SamplingSiteListContainer isDisabled={false} getSamplePeriodImportButton={() => <Button>test</Button>} />
+            <SamplingSiteListContainer isDisabled={false} getSamplePeriodImportButton={() => <></>} />
           </DialogContextProvider>
         </Box>
 

--- a/app/src/features/surveys/habitat-features/SurveyHabitatFeatureRouter.tsx
+++ b/app/src/features/surveys/habitat-features/SurveyHabitatFeatureRouter.tsx
@@ -26,6 +26,12 @@ export const HabitatFeatureRouter = () => {
         to="/admin/projects/:id/surveys/:survey_id/sampling/:survey_sample_site_id/edit"
       />
 
+      <Redirect
+        exact
+        from="/admin/projects/:id/surveys/:survey_id/habitat-features/sampling"
+        to="/admin/projects/:id/surveys/:survey_id/sampling"
+      />
+
       <RouteWithTitle
         exact
         path="/admin/projects/:id/surveys/:survey_id/habitat-features/details"

--- a/app/src/features/surveys/habitat-features/components/SurveyHabitatFeatureTable.tsx
+++ b/app/src/features/surveys/habitat-features/components/SurveyHabitatFeatureTable.tsx
@@ -13,6 +13,7 @@ export const SurveyHabitatFeatureTable = (): JSX.Element => {
 
   return (
     <StyledDataGrid
+      apiRef={habitatFeatureTableContext._muiDataGridApiRef}
       noRowsMessage="No habitat features found"
       columnHeaderHeight={rowHeight}
       rowHeight={rowHeight}
@@ -24,6 +25,9 @@ export const SurveyHabitatFeatureTable = (): JSX.Element => {
           paginationModel: { page: 0, pageSize: 10 }
         }
       }}
+      // Column visibility
+      columnVisibilityModel={habitatFeatureTableContext.columnVisibilityModel}
+      onColumnVisibilityModelChange={habitatFeatureTableContext.onColumnVisibilityModelChange}
       pageSizeOptions={[10, 25, 50]}
       rowSelection={false}
       autoHeight={false}

--- a/app/src/features/surveys/habitat-features/components/SurveyHabitatFeatureTableContainer.tsx
+++ b/app/src/features/surveys/habitat-features/components/SurveyHabitatFeatureTableContainer.tsx
@@ -1,7 +1,14 @@
-import { Box, Divider, Paper, Stack, Toolbar, Typography } from '@mui/material';
+import { mdiCogOutline } from '@mdi/js';
+import Icon from '@mdi/react';
+import { Box, Divider, IconButton, Paper, Stack, Toolbar, Tooltip, Typography } from '@mui/material';
+import Checkbox from '@mui/material/Checkbox';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import HelpButtonDialog from 'components/buttons/HelpButtonDialog';
 import { useHabitatFeatureTableContext } from 'hooks/useContext';
 import { MarkdownTypeNameEnum } from 'interfaces/useMarkdownApi.interface';
+import { useState } from 'react';
 import { SurveyHabitatFeatureTable } from './SurveyHabitatFeatureTable';
 
 /**
@@ -11,6 +18,12 @@ import { SurveyHabitatFeatureTable } from './SurveyHabitatFeatureTable';
  */
 export const SurveyHabitatFeatureTableContainer = (): JSX.Element => {
   const habitatFeatureTableContext = useHabitatFeatureTableContext();
+
+  const [columnVisibilityMenuAnchorEl, setColumnVisibilityMenuAnchorEl] = useState<Element | null>(null);
+
+  const handleCloseColumnVisibilityMenu = () => {
+    setColumnVisibilityMenuAnchorEl(null);
+  };
 
   return (
     <Paper component={Stack} flexDirection="column" flex="1 1 auto" height="100%">
@@ -34,6 +47,47 @@ export const SurveyHabitatFeatureTableContainer = (): JSX.Element => {
 
         <Stack flexDirection="row" alignItems="center" gap={1} whiteSpace="nowrap">
           <HelpButtonDialog markdownType={MarkdownTypeNameEnum.HABITAT_FEATURES} />
+
+          <Tooltip title="Toggle column visibility">
+            <IconButton onClick={(event) => setColumnVisibilityMenuAnchorEl(event.currentTarget)}>
+              <Icon path={mdiCogOutline} size={1} />
+            </IconButton>
+          </Tooltip>
+
+          <Menu
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right'
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right'
+            }}
+            id="survey-observations-table-actions-menu"
+            anchorEl={columnVisibilityMenuAnchorEl}
+            open={Boolean(columnVisibilityMenuAnchorEl)}
+            onClose={handleCloseColumnVisibilityMenu}
+            MenuListProps={{
+              'aria-labelledby': 'basic-button'
+            }}>
+            <Box
+              sx={{
+                xs: { maxHeight: '300px' },
+                lg: { maxHeight: '400px' }
+              }}>
+              {habitatFeatureTableContext.columns.map((column) => {
+                return (
+                  <MenuItem
+                    dense
+                    key={column.field}
+                    onClick={() => habitatFeatureTableContext.toggleColumnVisibility(column.field)}>
+                    <Checkbox checked={!habitatFeatureTableContext.hiddenColumns.includes(column.field)} />
+                    <ListItemText>{column.headerName}</ListItemText>
+                  </MenuItem>
+                );
+              })}
+            </Box>
+          </Menu>
         </Stack>
       </Toolbar>
 

--- a/app/src/features/surveys/sampling-information/periods/create/CreateSamplePeriodPage.tsx
+++ b/app/src/features/surveys/sampling-information/periods/create/CreateSamplePeriodPage.tsx
@@ -14,7 +14,7 @@ import { Formik, FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { CreateSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -76,7 +76,7 @@ export const CreateSamplePeriodPage = () => {
   const formikRef = useRef<FormikProps<ISurveySamplePeriodFormData>>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   if (!surveyContext.surveyDataLoader.data || !projectContext.projectDataLoader.data) {
     return <CircularProgress className="pageProgress" size={40} />;
@@ -123,10 +123,8 @@ export const CreateSamplePeriodPage = () => {
       );
 
       // create complete, navigate back to observations page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`);
     } catch (error) {
       showCreateErrorDialog({
         dialogTitle: SamplePeriodI18N.createErrorTitle,

--- a/app/src/features/surveys/sampling-information/periods/edit/EditSamplePeriodPage.tsx
+++ b/app/src/features/surveys/sampling-information/periods/edit/EditSamplePeriodPage.tsx
@@ -14,7 +14,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { GetSamplingPeriod, UpdateSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -71,7 +71,7 @@ export const EditSamplePeriodPage = () => {
 
   const biohubApi = useBiohubApi();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const urlParams: Record<string, string | number | undefined> = useParams();
   const surveySamplePeriodId = Number(urlParams['survey_sample_period_id']);
@@ -147,10 +147,8 @@ export const EditSamplePeriodPage = () => {
       );
 
       // create complete, navigate back to observations page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`);
     } catch (error) {
       showCreateErrorDialog({
         dialogTitle: SamplePeriodI18N.createErrorTitle,

--- a/app/src/features/surveys/sampling-information/sites/create/CreateSamplingSitePage.tsx
+++ b/app/src/features/surveys/sampling-information/sites/create/CreateSamplingSitePage.tsx
@@ -6,7 +6,7 @@ import { Formik, FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateSamplingSiteRequest, ISurveySampleSite } from 'interfaces/useSamplingSiteApi.interface';
 import { IGetSurveyBlock, IGetSurveyStratum } from 'interfaces/useSurveyApi.interface';
 import { useRef, useState } from 'react';
@@ -43,7 +43,7 @@ export const CreateSamplingSitePage = () => {
   const formikRef = useRef<FormikProps<ICreateSampleSiteFormData>>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   if (!surveyContext.surveyDataLoader.data || !projectContext.projectDataLoader.data) {
     return <CircularProgress className="pageProgress" size={40} />;
@@ -77,10 +77,8 @@ export const CreateSamplingSitePage = () => {
       await biohubApi.samplingSite.createSamplingSites(surveyContext.projectId, surveyContext.surveyId, requestData);
 
       // create complete, navigate back to observations page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`);
     } catch (error) {
       showCreateErrorDialog({
         dialogTitle: CreateSamplingSiteI18N.createErrorTitle,

--- a/app/src/features/surveys/sampling-information/sites/edit/EditSamplingSitePage.tsx
+++ b/app/src/features/surveys/sampling-information/sites/edit/EditSamplingSitePage.tsx
@@ -10,7 +10,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import {
   IEditSampleSiteRequest,
   IGetSampleBlockDetails,
@@ -54,7 +54,7 @@ export const EditSamplingSitePage = () => {
   const projectContext = useProjectContext();
   const dialogContext = useDialogContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const formikRef = useRef<FormikProps<IEditSampleSiteFormData>>(null);
 
@@ -115,11 +115,8 @@ export const EditSamplingSitePage = () => {
         .then(() => {
           setIsSubmitting(false);
 
-          // create complete, navigate back to observations page
-          history.push(
-            `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-            SKIP_CONFIRMATION_DIALOG
-          );
+          skipUnsavedChangesDialog();
+          history.goBack();
         })
         .catch((error: any) => {
           dialogContext.setYesNoDialog({ open: false });

--- a/app/src/features/surveys/sampling-information/sites/edit/form/SampleSiteEditForm.tsx
+++ b/app/src/features/surveys/sampling-information/sites/edit/form/SampleSiteEditForm.tsx
@@ -5,13 +5,11 @@ import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import HorizontalSplitFormComponent from 'components/fields/HorizontalSplitFormComponent';
-import { SurveyContext } from 'contexts/surveyContext';
 import { SamplingSiteGroupingsForm } from 'features/surveys/sampling-information/sites/components/site-groupings/SamplingSiteGroupingsForm';
 import { useFormikContext } from 'formik';
 import { Feature } from 'geojson';
 import { IGetSampleBlockDetails, IGetSampleStratumDetails } from 'interfaces/useSamplingSiteApi.interface';
-import { useContext } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import yup from 'utils/YupSchema';
 import SurveySamplingSiteEditForm from '../../components/map/SurveySampleSiteEditForm';
 import SampleSiteGeneralInformationEditForm from './SampleSiteGeneralInformationForm';
@@ -46,7 +44,7 @@ export interface ISampleSiteEditFormProps {
  * @returns
  */
 const SampleSiteEditForm = (props: ISampleSiteEditFormProps) => {
-  const surveyContext = useContext(SurveyContext);
+  const history = useHistory();
   const { submitForm } = useFormikContext<IEditSampleSiteFormData>();
 
   return (
@@ -91,8 +89,9 @@ const SampleSiteEditForm = (props: ISampleSiteEditFormProps) => {
             <Button
               variant="outlined"
               color="primary"
-              component={RouterLink}
-              to={`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`}>
+              onClick={() => {
+                history.goBack();
+              }}>
               Cancel
             </Button>
           </Stack>

--- a/app/src/features/surveys/sampling-information/techniques/create/CreateTechniquePage.tsx
+++ b/app/src/features/surveys/sampling-information/techniques/create/CreateTechniquePage.tsx
@@ -17,7 +17,7 @@ import { FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateTechniqueRequest } from 'interfaces/useTechniqueApi.interface';
 import { useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -47,7 +47,7 @@ export const CreateTechniquePage = () => {
   const projectContext = useProjectContext();
   const dialogContext = useDialogContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -94,10 +94,8 @@ export const CreateTechniquePage = () => {
       ]);
 
       // Success, navigate back to the manage sampling information page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`);
     } catch (error) {
       setIsSubmitting(false);
       dialogContext.setErrorDialog({

--- a/app/src/features/surveys/sampling-information/techniques/edit/EditTechniquePage.tsx
+++ b/app/src/features/surveys/sampling-information/techniques/edit/EditTechniquePage.tsx
@@ -18,7 +18,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { IUpdateTechniqueRequest } from 'interfaces/useTechniqueApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -41,7 +41,7 @@ export const EditTechniquePage = () => {
   const projectContext = useProjectContext();
   const dialogContext = useDialogContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -135,10 +135,8 @@ export const EditTechniquePage = () => {
       );
 
       // Success, navigate back to the manage sampling information page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/sampling`);
     } catch (error) {
       setIsSubmitting(false);
       dialogContext.setErrorDialog({

--- a/app/src/features/surveys/telemetry/manage/deployments/create/CreateDeploymentPage.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/create/CreateDeploymentPage.tsx
@@ -12,7 +12,7 @@ import { Formik, FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateAnimalDeployment } from 'interfaces/useTelemetryApi.interface';
 import { useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -31,7 +31,7 @@ export const CreateDeploymentPage = () => {
   const projectContext = useProjectContext();
   const surveyContext = useSurveyContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const formikRef = useRef<FormikProps<ICreateAnimalDeployment>>(null);
 
@@ -64,10 +64,8 @@ export const CreateDeploymentPage = () => {
       );
 
       // create complete, navigate back to telemetry page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`);
     } catch (error) {
       dialogContext.setErrorDialog({
         dialogTitle: CreateAnimalDeploymentI18N.createErrorTitle,

--- a/app/src/features/surveys/telemetry/manage/deployments/edit/EditDeploymentPage.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/edit/EditDeploymentPage.tsx
@@ -12,7 +12,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { ICreateAnimalDeployment } from 'interfaces/useTelemetryApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -31,7 +31,7 @@ export const EditDeploymentPage = () => {
   const projectContext = useProjectContext();
   const surveyContext = useSurveyContext();
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const urlParams: Record<string, string | number | undefined> = useParams();
   const deploymentId: number | undefined = Number(urlParams['deployment_id']);
@@ -96,10 +96,8 @@ export const EditDeploymentPage = () => {
       );
 
       // edit complete, navigate back to telemetry page
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`);
     } catch (error) {
       dialogContext.setErrorDialog({
         dialogTitle: EditAnimalDeploymentI18N.createErrorTitle,

--- a/app/src/features/surveys/telemetry/manage/devices/create/CreateDevicePage.tsx
+++ b/app/src/features/surveys/telemetry/manage/devices/create/CreateDevicePage.tsx
@@ -13,7 +13,7 @@ import { Formik, FormikProps } from 'formik';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { CreateTelemetryDevice } from 'interfaces/useTelemetryDeviceApi.interface';
 import { useRef, useState } from 'react';
 import { Prompt, useHistory } from 'react-router';
@@ -35,7 +35,7 @@ export const CreateDevicePage = () => {
   const formikRef = useRef<FormikProps<CreateTelemetryDevice>>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   if (!surveyContext.surveyDataLoader.data || !projectContext.projectDataLoader.data) {
     return <CircularProgress className="pageProgress" size={40} />;
@@ -52,10 +52,8 @@ export const CreateDevicePage = () => {
         comment: values.comment
       });
 
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`);
     } catch (error) {
       dialogContext.setErrorDialog({
         dialogTitle: TelemetryDeviceI18N.createErrorTitle,

--- a/app/src/features/surveys/telemetry/manage/devices/edit/EditDevicePage.tsx
+++ b/app/src/features/surveys/telemetry/manage/devices/edit/EditDevicePage.tsx
@@ -9,7 +9,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useProjectContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { SKIP_CONFIRMATION_DIALOG, useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
+import { useUnsavedChangesDialog } from 'hooks/useUnsavedChangesDialog';
 import { UpdateTelemetryDevice } from 'interfaces/useTelemetryDeviceApi.interface';
 import { useEffect, useRef, useState } from 'react';
 import { Prompt, useHistory, useParams } from 'react-router';
@@ -31,7 +31,7 @@ export const EditDevicePage = () => {
   const formikRef = useRef<FormikProps<UpdateTelemetryDevice>>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { locationChangeInterceptor } = useUnsavedChangesDialog();
+  const { locationChangeInterceptor, skipUnsavedChangesDialog } = useUnsavedChangesDialog();
 
   const urlParams: Record<string, string | number | undefined> = useParams();
   const deviceId: number | undefined = Number(urlParams['device_id']);
@@ -67,12 +67,8 @@ export const EditDevicePage = () => {
         comment: values.comment
       });
 
-      //   telemetryDataContext.devicesDataLoader.refresh(surveyContext.projectId, surveyContext.surveyId);
-
-      history.push(
-        `/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`,
-        SKIP_CONFIRMATION_DIALOG
-      );
+      skipUnsavedChangesDialog();
+      history.push(`/admin/projects/${surveyContext.projectId}/surveys/${surveyContext.surveyId}/telemetry/manage`);
     } catch (error) {
       dialogContext.setErrorDialog({
         dialogTitle: TelemetryDeviceI18N.createErrorTitle,

--- a/app/src/hooks/api/useSurveyHabitatFeature.ts
+++ b/app/src/hooks/api/useSurveyHabitatFeature.ts
@@ -44,7 +44,7 @@ const useSurveyHabitatFeature = (axios: AxiosInstance) => {
     surveyId: number,
     surveyHabitatFeatureId: number,
     habitatFeature: UpdateSurveyHabitatFeature
-  ): Promise<getSurveyHabitatFeaturesWithSupplementaryData> => {
+  ): Promise<void> => {
     const { data } = await axios.put(
       `/api/project/${projectId}/survey/${surveyId}/habitat-features/${surveyHabitatFeatureId}`,
       habitatFeature
@@ -58,9 +58,12 @@ const useSurveyHabitatFeature = (axios: AxiosInstance) => {
    *
    * @param {number} projectId
    * @param {number} surveyId
-   * @return {*}  {Promise<void>}
+   * @return {*}  {Promise<getSurveyHabitatFeaturesWithSupplementaryData>}
    */
-  const getSurveyHabitatFeaturesWithSupplementaryData = async (projectId: number, surveyId: number): Promise<void> => {
+  const getSurveyHabitatFeaturesWithSupplementaryData = async (
+    projectId: number,
+    surveyId: number
+  ): Promise<getSurveyHabitatFeaturesWithSupplementaryData> => {
     const { data } = await axios.get(`/api/project/${projectId}/survey/${surveyId}/habitat-features`);
 
     return data;

--- a/app/src/hooks/useBioHubApi.ts
+++ b/app/src/hooks/useBioHubApi.ts
@@ -23,6 +23,7 @@ import useSamplingSiteApi from './api/useSamplingSiteApi';
 import useSpatialApi from './api/useSpatialApi';
 import useStandardsApi from './api/useStandardsApi';
 import useSurveyApi from './api/useSurveyApi';
+import useSurveyHabitatFeature from './api/useSurveyHabitatFeature';
 import useTaxonomyApi from './api/useTaxonomyApi';
 import useTechniqueApi from './api/useTechniqueApi';
 import useTelemetryApi from './api/useTelemetryApi';
@@ -87,6 +88,8 @@ export const useBiohubApi = () => {
 
   const alert = useAlertApi(apiAxios);
 
+  const habitatFeatureApi = useSurveyHabitatFeature(apiAxios);
+
   return useMemo(
     () => ({
       analytics,
@@ -113,7 +116,8 @@ export const useBiohubApi = () => {
       telemetryDevice,
       markdown,
       alert,
-      samplingPeriod
+      samplingPeriod,
+      habitatFeatureApi
     }),
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/hooks/useUnsavedChangesDialog.tsx
+++ b/app/src/hooks/useUnsavedChangesDialog.tsx
@@ -22,6 +22,8 @@ export const useUnsavedChangesDialog = () => {
   /**
    * Skip the unsaved changes dialog
    *
+   * Note: This needs to be called before history.push/go/goBack to prevent the dialog from showing
+   *
    * @returns {*} {void}
    */
   const skipUnsavedChangesDialog = (): void => {
@@ -42,7 +44,7 @@ export const useUnsavedChangesDialog = () => {
       return true;
     }
 
-    // Dialog will trigger a another location change if yes selected
+    // Unsaved changes confirmation dialog
     dialogContext.setYesNoDialog({
       dialogTitle: CancelDialogI18N.cancelTitle,
       dialogText: CancelDialogI18N.cancelText,

--- a/app/src/hooks/useUnsavedChangesDialog.tsx
+++ b/app/src/hooks/useUnsavedChangesDialog.tsx
@@ -1,16 +1,8 @@
 import { CancelDialogI18N } from 'constants/i18n';
 import { DialogContext } from 'contexts/dialogContext';
 import * as History from 'history';
-import { useContext } from 'react';
+import { useContext, useRef } from 'react';
 import { useHistory } from 'react-router';
-
-/**
- * Additional object that can be passed to history.push to bypass confirmation dialog when used with `<Prompt/>`
- * @example history.push('location', SKIP_CONFIRMATION_DIALOG)
- */
-export const SKIP_CONFIRMATION_DIALOG = { skipConfirmationDialog: true };
-
-type SkipDialog = { skipConfirmationDialog?: boolean };
 
 /**
  * Hook to handle pages that need confirmation before leaving with unsaved changes.
@@ -25,10 +17,19 @@ export const useUnsavedChangesDialog = () => {
   const history = useHistory();
   const dialogContext = useContext(DialogContext);
 
+  const skipUnsavedChangesDialogRef = useRef(false);
+
+  /**
+   * Skip the unsaved changes dialog
+   *
+   * @returns {*} {void}
+   */
+  const skipUnsavedChangesDialog = (): void => {
+    skipUnsavedChangesDialogRef.current = true;
+  };
+
   /**
    * Intercepts all history navigation attempts usually used with '<Prompt>'
-   *
-   * Note: history.push('location', SKIP_CONFIRMATION_DIALOG) will bypass confirmation dialog.
    *
    * Returning true allows the navigation, returning false prevents it.
    *
@@ -36,12 +37,8 @@ export const useUnsavedChangesDialog = () => {
    * @return {*}
    */
   const locationChangeInterceptor = (location: History.Location) => {
-    /**
-     * onYesSkipConfirmationDialog: when onYes is selected from confirmation dialog or history.push that includes skipConfirmationDialog
-     */
-    const onYesSkipConfirmationDialog = (location.state as SkipDialog)?.skipConfirmationDialog;
-    if (onYesSkipConfirmationDialog) {
-      // Allow the location change
+    if (skipUnsavedChangesDialogRef.current) {
+      skipUnsavedChangesDialogRef.current = false;
       return true;
     }
 
@@ -58,12 +55,10 @@ export const useUnsavedChangesDialog = () => {
       },
       onYes: () => {
         dialogContext.setYesNoDialog({ open: false });
-        /**
-         * History.push allows an additional unknown param to be passed
-         * Allowing explicit control over when the `locationChangeInterceptor`
-         * skips rendering the confirmation dialog.
-         */
-        history.push(location.pathname, SKIP_CONFIRMATION_DIALOG);
+
+        // Set the ref to true so the next location change is allowed
+        skipUnsavedChangesDialogRef.current = true;
+        history.push(location.pathname);
       }
     });
 
@@ -71,5 +66,5 @@ export const useUnsavedChangesDialog = () => {
     return false;
   };
 
-  return { locationChangeInterceptor };
+  return { locationChangeInterceptor, skipUnsavedChangesDialog };
 };


### PR DESCRIPTION
## Description of Changes

- Updated columns for Habitat Features Table
- Created menu and controls for toggling column visibility
- Updated `useUnsavedChangesDialog` hook and provided additional callback to bypass the dialog
- Updated instances where we were passing `SKIP_CONFIRMATION_DIALOG` as state to location changes (now explicity handled with the callback using a ref)
- Editing the sample site from the `Habitat Features` page / `Observations` page should route back to the original page on save / cancel

## Testing Notes
- App should function the same, forms should route to the correct places
- Columns visibility should be toggleable
