### PR TITLE
BugFix: Change `deployment.frequency` Column Type To Decimal

### DIFF
--- a/database/src/migrations/20250313000001_alter_frequency_column.ts
+++ b/database/src/migrations/20250313000001_alter_frequency_column.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+/**
+ * Changes:
+ *  - Alter deployment table frequency column type from int4 to decimal.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH=biohub;
+
+    -- Alter deployment frequency column from int4 to decimal
+    ALTER TABLE deployment ALTER COLUMN frequency TYPE decimal;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- {Include a link to all applicable Jira tickets}

## Description of Changes

Migration to change `deployment.frequency` column type to decimal.

Before it was set to integer, which caused frequency values to be quietly truncated.

## Testing Notes

Create and/or edit a deployment with a frequency that has decimals (ex: `150.123`).
- See that in the database it is stored as `150.123`.
- See that in the UI it is displayed as `150.123`
