### PR TITLE
TechDebt: Fix API Taxon Response When BioHub Service Unavailable

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/taxon/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/taxon/index.ts
@@ -72,13 +72,21 @@ GET.apiDoc = {
               type: 'object',
               additionalProperties: false,
               properties: {
-                tsn: { type: 'number', description: 'The TSN of the observed species' },
+                tsn: {
+                  type: 'number',
+                  description: 'The TSN of the observed species'
+                },
                 commonNames: {
                   type: 'array',
-                  items: { type: 'string' },
+                  items: {
+                    type: 'string'
+                  },
                   description: 'Common names of the observed species'
                 },
-                scientificName: { type: 'string', description: 'Scientific name of the observed species' }
+                scientificName: {
+                  type: 'string',
+                  description: 'Scientific name of the observed species'
+                }
               }
             }
           }
@@ -126,9 +134,25 @@ export function getSurveyObservedSpecies(): RequestHandler {
 
       await connection.commit();
 
-      const species = await platformService.getTaxonomyByTsns(observedSpecies.flatMap((species) => species.itis_tsn));
+      const taxonomyResponse = await platformService.getTaxonomyByTsns(
+        observedSpecies.flatMap((species) => species.itis_tsn)
+      );
 
-      const formattedResponse = species.map((taxon) => ({ ...taxon, tsn: taxon.tsn }));
+      const formattedResponse: {
+        tsn: number;
+        scientificName: string;
+        commonNames: string[];
+      }[] = [];
+
+      for (const species of observedSpecies) {
+        const taxon = taxonomyResponse.find((taxonomy) => Number(taxonomy.tsn) === species.itis_tsn);
+
+        formattedResponse.push({
+          tsn: species.itis_tsn,
+          scientificName: taxon?.scientificName ?? 'Unavailable',
+          commonNames: taxon?.commonNames ?? []
+        });
+      }
 
       return res.status(200).json(formattedResponse);
     } catch (error) {

--- a/api/src/repositories/observation-repository/observation-repository.ts
+++ b/api/src/repositories/observation-repository/observation-repository.ts
@@ -424,7 +424,7 @@ export class ObservationRepository extends BaseRepository {
       )
       .leftJoin('method_technique', 'method_technique.method_technique_id', 'survey_sample_period.method_technique_id')
       .where('survey_observation_id', surveyObservationId)
-      .andWhere('survey_id', surveyId);
+      .andWhere('survey_observation.survey_id', surveyId);
 
     const response = await this.connection.knex(query, ObservationRecordWithSampling);
 

--- a/api/src/services/survey-service.test.ts
+++ b/api/src/services/survey-service.test.ts
@@ -376,10 +376,11 @@ describe('SurveyService', () => {
         { tsn: 456, scientificName: 'Species 2' }
       ];
       const mockResponse = new GetFocalSpeciesData([
-        { tsn: 123, scientificName: 'Species 1', ecological_units: [] },
+        { tsn: 123, scientificName: 'Species 1', commonNames: [], ecological_units: [] },
         {
           tsn: 456,
           scientificName: 'Species 2',
+          commonNames: [],
           ecological_units: mockEcologicalUnits
         }
       ]);

--- a/api/src/services/survey-service.ts
+++ b/api/src/services/survey-service.ts
@@ -179,8 +179,14 @@ export class SurveyService extends DBService {
     const focalSpecies = [];
 
     for (const species of studySpeciesResponse) {
-      const taxon = taxonomyResponse.find((taxonomy) => Number(taxonomy.tsn) === species.itis_tsn) ?? {};
-      focalSpecies.push({ ...taxon, tsn: species.itis_tsn, ecological_units: species.ecological_units });
+      const taxon = taxonomyResponse.find((taxonomy) => Number(taxonomy.tsn) === species.itis_tsn);
+
+      focalSpecies.push({
+        tsn: species.itis_tsn,
+        scientificName: taxon?.scientificName ?? 'Unavailable',
+        commonNames: taxon?.commonNames ?? [],
+        ecological_units: species.ecological_units
+      });
     }
 
     // Return the combined data

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -20,9 +20,9 @@ export default defineConfig({
         process: true
       }
     }),
-    !process.env.VITEST ? checker({ typescript: true }) : undefined,
     !process.env.VITEST
       ? checker({
+          typescript: true,
           eslint: {
             useFlatConfig: true,
             lintCommand: 'eslint .'


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Add better fallbacks for taxon data when the biohub service is unavailable. Just happened to come across this particular instance because I had a bad biohub url in my env, and the survey failed to load as a result.

Fix issue with the observation popup SQL (ambiguous survey_id).

## Testing Notes

If you use a bad biohub url in your env, the survey page should not fail to load (previously it would, because the api response validation failed due to missing common names and scientific name)

Clicking an observation on the survey map should load the popup (previously there was a sql error due to ambiguous survey_id)
