### PR TITLE
Added wide to narrow instructional video to observation import dialogue

### DIFF
--- a/app/src/components/csv/CSVSingleImportDialog.tsx
+++ b/app/src/components/csv/CSVSingleImportDialog.tsx
@@ -1,5 +1,18 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import LoadingButton from '@mui/lab/LoadingButton/LoadingButton';
-import { Box, Dialog, DialogActions, DialogContent, Divider, useMediaQuery, useTheme } from '@mui/material';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Divider,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme
+} from '@mui/material';
 import { AxiosProgressEvent } from 'axios';
 import { UploadFileStatus } from 'components/file-upload/FileUploadItem';
 import { FileUploadSingleItem } from 'components/file-upload/FileUploadSingleItem';
@@ -8,6 +21,53 @@ import { useContext, useState } from 'react';
 import { isCSVValidationError } from 'utils/csv-utils';
 import { getAxiosProgress, waitForRenderCycle } from 'utils/Utils';
 import { CSVDropzoneSection } from './CSVDropzoneSection';
+
+// New component for the instructions and video
+const TransformInstructions = () => (
+  <Box sx={{ width: '100%', my: 3 }}>
+    <Stack spacing={2}>
+      <Typography variant="h6" component="h3">
+        How to Transform Your Data from Wide to Narrow Format in Excel
+      </Typography>
+
+      <Box sx={{ pl: 2 }}>
+        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
+          <strong>Step 1:</strong> Select your data, navigate to the "Data" tab and choose "From Data/Range", then
+          confirm with "OK".
+        </Typography>
+
+        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
+          <strong>Step 2:</strong> Select all columns you want to transform, open the "Transform" tab and select
+          "Unpivot Columns".
+        </Typography>
+
+        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
+          <strong>Step 3:</strong> Rename your new columns appropriately, return to the home tab, then select "Close and
+          Load".
+        </Typography>
+      </Box>
+
+      <Box sx={{ overflow: 'hidden', position: 'relative' }}>
+        <video
+          src="https://nrs.objectstore.gov.bc.ca/locsch/resources/Import_PQMP4_2_slow.mp4"
+          autoPlay
+          loop
+          muted
+          playsInline
+          style={{
+            display: 'block',
+            width: '100%',
+            maxWidth: '800px',
+            height: 'auto',
+            margin: '0 auto',
+            border: '1px solid #eee',
+            objectFit: 'cover'
+          }}
+        />
+      </Box>
+    </Stack>
+  </Box>
+);
 
 interface CSVSingleImportDialogProps {
   open: boolean;
@@ -35,6 +95,8 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
   const [uploadStatus, setUploadStatus] = useState<UploadFileStatus>(UploadFileStatus.STAGED);
   const [progress, setProgress] = useState<number>(0);
   const [error, setError] = useState<Error | null>(null);
+  // New state to control video visibility
+  const [showInstructions, setShowInstructions] = useState<boolean>(false);
 
   const isUploading = uploadStatus === UploadFileStatus.UPLOADING || uploadStatus === UploadFileStatus.FINISHING_UPLOAD;
   const disableImportButton =
@@ -121,25 +183,6 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
   return (
     <Dialog open={props.open} maxWidth={'xl'} fullScreen={fullScreen}>
       <DialogContent sx={{ mt: 2 }}>
-        <Box sx={{ width: '100%', my: 3, overflow: 'hidden', position: 'relative' }}>
-          <video
-            src="https://nrs.objectstore.gov.bc.ca/locsch/resources/Import_PQMP4_1.mp4"
-            autoPlay
-            loop
-            muted
-            playsInline
-            style={{
-              display: 'block',
-              width: '100%',
-              maxWidth: '800px',
-              height: 'auto',
-              margin: '0 auto',
-              border: '1px solid #eee',
-              objectFit: 'cover'
-            }}
-          />
-        </Box>
-
         <Box>
           <CSVDropzoneSection
             title={props.dialogTitle}
@@ -157,6 +200,34 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
             />
           </CSVDropzoneSection>
         </Box>
+
+        {/* Moved transformation help link below the CSV upload section */}
+        <Box
+          onClick={() => setShowInstructions(!showInstructions)}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            my: 2,
+            cursor: 'pointer',
+            color: 'primary.main',
+            '&:hover': {
+              textDecoration: 'underline'
+            }
+          }}>
+          <InfoOutlinedIcon fontSize="small" sx={{ mr: 0.5 }} />
+          <Typography variant="body2" component="span">
+            {showInstructions
+              ? 'Hide data transformation instructions'
+              : 'Need help transforming data from wide to narrow?'}
+          </Typography>
+          {showInstructions ? (
+            <KeyboardArrowUpIcon fontSize="small" sx={{ ml: 0.5 }} />
+          ) : (
+            <KeyboardArrowDownIcon fontSize="small" sx={{ ml: 0.5 }} />
+          )}
+        </Box>
+
+        {showInstructions && <TransformInstructions />}
       </DialogContent>
       <Divider />
 

--- a/app/src/components/csv/CSVSingleImportDialog.tsx
+++ b/app/src/components/csv/CSVSingleImportDialog.tsx
@@ -121,6 +121,25 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
   return (
     <Dialog open={props.open} maxWidth={'xl'} fullScreen={fullScreen}>
       <DialogContent sx={{ mt: 2 }}>
+        <Box sx={{ width: '100%', my: 3, overflow: 'hidden', position: 'relative' }}>
+          <video
+            src="https://nrs.objectstore.gov.bc.ca/locsch/resources/Import_PQMP4_1.mp4"
+            autoPlay
+            loop
+            muted
+            playsInline
+            style={{
+              display: 'block',
+              width: '100%',
+              maxWidth: '800px',
+              height: 'auto',
+              margin: '0 auto',
+              border: '1px solid #eee',
+              objectFit: 'cover'
+            }}
+          />
+        </Box>
+
         <Box>
           <CSVDropzoneSection
             title={props.dialogTitle}

--- a/app/src/components/csv/CSVSingleImportDialog.tsx
+++ b/app/src/components/csv/CSVSingleImportDialog.tsx
@@ -1,18 +1,5 @@
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import LoadingButton from '@mui/lab/LoadingButton/LoadingButton';
-import {
-  Box,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  Divider,
-  Stack,
-  Typography,
-  useMediaQuery,
-  useTheme
-} from '@mui/material';
+import { Box, Dialog, DialogActions, DialogContent, Divider, useMediaQuery, useTheme } from '@mui/material';
 import { AxiosProgressEvent } from 'axios';
 import { UploadFileStatus } from 'components/file-upload/FileUploadItem';
 import { FileUploadSingleItem } from 'components/file-upload/FileUploadSingleItem';
@@ -22,53 +9,6 @@ import { isCSVValidationError } from 'utils/csv-utils';
 import { getAxiosProgress, waitForRenderCycle } from 'utils/Utils';
 import { CSVDropzoneSection } from './CSVDropzoneSection';
 
-// New component for the instructions and video
-const TransformInstructions = () => (
-  <Box sx={{ width: '100%', my: 3 }}>
-    <Stack spacing={2}>
-      <Typography variant="h6" component="h3">
-        How to Transform Your Data from Wide to Narrow Format in Excel
-      </Typography>
-
-      <Box sx={{ pl: 2 }}>
-        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
-          <strong>Step 1:</strong> Select your data, navigate to the "Data" tab and choose "From Data/Range", then
-          confirm with "OK".
-        </Typography>
-
-        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
-          <strong>Step 2:</strong> Select all columns you want to transform, open the "Transform" tab and select
-          "Unpivot Columns".
-        </Typography>
-
-        <Typography variant="body1" component="div" sx={{ mb: 1 }}>
-          <strong>Step 3:</strong> Rename your new columns appropriately, return to the home tab, then select "Close and
-          Load".
-        </Typography>
-      </Box>
-
-      <Box sx={{ overflow: 'hidden', position: 'relative' }}>
-        <video
-          src="https://nrs.objectstore.gov.bc.ca/locsch/resources/Import_PQMP4_2_slow.mp4"
-          autoPlay
-          loop
-          muted
-          playsInline
-          style={{
-            display: 'block',
-            width: '100%',
-            maxWidth: '800px',
-            height: 'auto',
-            margin: '0 auto',
-            border: '1px solid #eee',
-            objectFit: 'cover'
-          }}
-        />
-      </Box>
-    </Stack>
-  </Box>
-);
-
 interface CSVSingleImportDialogProps {
   open: boolean;
   dialogTitle: string;
@@ -76,6 +16,11 @@ interface CSVSingleImportDialogProps {
   onClose: () => void;
   onImport: (file: File, onProgress: (progressEvent: AxiosProgressEvent) => void) => Promise<void>;
   onDownloadTemplate: () => void;
+  /**
+   * Optional component to display help instructions for the import process
+   * If provided, a help section will be displayed below the CSV upload section
+   */
+  VideoHelp?: React.ComponentType;
 }
 
 /**
@@ -95,8 +40,6 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
   const [uploadStatus, setUploadStatus] = useState<UploadFileStatus>(UploadFileStatus.STAGED);
   const [progress, setProgress] = useState<number>(0);
   const [error, setError] = useState<Error | null>(null);
-  // New state to control video visibility
-  const [showInstructions, setShowInstructions] = useState<boolean>(false);
 
   const isUploading = uploadStatus === UploadFileStatus.UPLOADING || uploadStatus === UploadFileStatus.FINISHING_UPLOAD;
   const disableImportButton =
@@ -180,6 +123,8 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
     return null;
   }
 
+  const { VideoHelp } = props;
+
   return (
     <Dialog open={props.open} maxWidth={'xl'} fullScreen={fullScreen}>
       <DialogContent sx={{ mt: 2 }}>
@@ -201,33 +146,8 @@ export const CSVSingleImportDialog = (props: CSVSingleImportDialogProps) => {
           </CSVDropzoneSection>
         </Box>
 
-        {/* Moved transformation help link below the CSV upload section */}
-        <Box
-          onClick={() => setShowInstructions(!showInstructions)}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            my: 2,
-            cursor: 'pointer',
-            color: 'primary.main',
-            '&:hover': {
-              textDecoration: 'underline'
-            }
-          }}>
-          <InfoOutlinedIcon fontSize="small" sx={{ mr: 0.5 }} />
-          <Typography variant="body2" component="span">
-            {showInstructions
-              ? 'Hide data transformation instructions'
-              : 'Need help transforming data from wide to narrow?'}
-          </Typography>
-          {showInstructions ? (
-            <KeyboardArrowUpIcon fontSize="small" sx={{ ml: 0.5 }} />
-          ) : (
-            <KeyboardArrowDownIcon fontSize="small" sx={{ ml: 0.5 }} />
-          )}
-        </Box>
-
-        {showInstructions && <TransformInstructions />}
+        {/* Display video help component if provided */}
+        {VideoHelp && <VideoHelp />}
       </DialogContent>
       <Divider />
 

--- a/app/src/components/dialog/video-help/TransformDataHelp.tsx
+++ b/app/src/components/dialog/video-help/TransformDataHelp.tsx
@@ -1,0 +1,29 @@
+import { VideoHelpSection, VideoHelpSectionProps } from './VideoHelpSection';
+
+/**
+ * Help content for transforming data from wide to narrow format
+ */
+export const TransformDataHelp = () => {
+  const helpProps: VideoHelpSectionProps = {
+    title: 'How to Transform Your Data from Wide to Narrow Format in Excel',
+    videoUrl: 'https://nrs.objectstore.gov.bc.ca/locsch/resources/Import_PQMP4_2_slow.mp4',
+    steps: [
+      {
+        label: 'Step 1:',
+        text: 'Select your data, navigate to the "Data" tab and choose "From Data/Range", then confirm with "OK".'
+      },
+      {
+        label: 'Step 2:',
+        text: 'Select all columns you want to transform, open the "Transform" tab and select "Unpivot Columns".'
+      },
+      {
+        label: 'Step 3:',
+        text: 'Rename your new columns appropriately, return to the home tab, then select "Close and Load".'
+      }
+    ],
+    collapsedText: 'Need help transforming data from wide to narrow?',
+    expandedText: 'Hide data transformation instructions'
+  };
+
+  return <VideoHelpSection {...helpProps} />;
+};

--- a/app/src/components/dialog/video-help/VideoHelpSection.tsx
+++ b/app/src/components/dialog/video-help/VideoHelpSection.tsx
@@ -87,10 +87,8 @@ export const VideoHelpSection = (props: VideoHelpSectionProps) => {
             <Box sx={{ overflow: 'hidden', position: 'relative' }}>
               <video
                 src={videoUrl}
-                autoPlay
-                loop
-                muted
                 playsInline
+                controls
                 style={{
                   display: 'block',
                   width: '100%',

--- a/app/src/components/dialog/video-help/VideoHelpSection.tsx
+++ b/app/src/components/dialog/video-help/VideoHelpSection.tsx
@@ -1,0 +1,110 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import { Box, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+
+export interface VideoHelpStep {
+  label: string;
+  text: string;
+}
+
+export interface VideoHelpSectionProps {
+  /**
+   * Title of the help section
+   */
+  title: string;
+
+  /**
+   * URL to the video to play
+   */
+  videoUrl: string;
+
+  /**
+   * Array of steps to display
+   */
+  steps: VideoHelpStep[];
+
+  /**
+   * Text to show when collapsed
+   */
+  collapsedText?: string;
+
+  /**
+   * Text to show when expanded
+   */
+  expandedText?: string;
+}
+
+/**
+ * A reusable component for displaying video help instructions
+ */
+export const VideoHelpSection = (props: VideoHelpSectionProps) => {
+  const [showInstructions, setShowInstructions] = useState<boolean>(false);
+
+  const { title, videoUrl, steps, collapsedText = 'Show instructions', expandedText = 'Hide instructions' } = props;
+
+  return (
+    <>
+      <Box
+        onClick={() => setShowInstructions(!showInstructions)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          my: 2,
+          cursor: 'pointer',
+          color: 'primary.main',
+          '&:hover': {
+            textDecoration: 'underline'
+          }
+        }}>
+        <InfoOutlinedIcon fontSize="small" sx={{ mr: 0.5 }} />
+        <Typography variant="body2" component="span">
+          {showInstructions ? expandedText : collapsedText}
+        </Typography>
+        {showInstructions ? (
+          <KeyboardArrowUpIcon fontSize="small" sx={{ ml: 0.5 }} />
+        ) : (
+          <KeyboardArrowDownIcon fontSize="small" sx={{ ml: 0.5 }} />
+        )}
+      </Box>
+
+      {showInstructions && (
+        <Box sx={{ width: '100%', my: 3 }}>
+          <Stack spacing={2}>
+            <Typography variant="h6" component="h3">
+              {title}
+            </Typography>
+
+            <Box sx={{ pl: 2 }}>
+              {steps.map((step, index) => (
+                <Typography key={index} variant="body1" component="div" sx={{ mb: 1 }}>
+                  <strong>{step.label}</strong> {step.text}
+                </Typography>
+              ))}
+            </Box>
+
+            <Box sx={{ overflow: 'hidden', position: 'relative' }}>
+              <video
+                src={videoUrl}
+                autoPlay
+                loop
+                muted
+                playsInline
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  maxWidth: '800px',
+                  height: 'auto',
+                  margin: '0 auto',
+                  border: '1px solid #eee',
+                  objectFit: 'cover'
+                }}
+              />
+            </Box>
+          </Stack>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/app/src/components/dialog/video-help/observationsHelp.tsx
+++ b/app/src/components/dialog/video-help/observationsHelp.tsx
@@ -1,0 +1,29 @@
+import { VideoHelpSection, VideoHelpSectionProps } from './VideoHelpSection';
+
+/**
+ * Help content for importing observation data
+ */
+export const ObservationsHelp = () => {
+  const helpProps: VideoHelpSectionProps = {
+    title: 'How to Prepare Observation Data for Import',
+    videoUrl: 'https://nrs.objectstore.gov.bc.ca/locsch/resources/observations_demo.mp4', // Example URL
+    steps: [
+      {
+        label: 'Step 1:',
+        text: 'Ensure your observation data is in the correct format with required columns.'
+      },
+      {
+        label: 'Step 2:',
+        text: 'Each row should represent a single observation with date, location, and measurement values.'
+      },
+      {
+        label: 'Step 3:',
+        text: 'Use the template to ensure all required fields are included.'
+      }
+    ],
+    collapsedText: 'Need help preparing observation data?',
+    expandedText: 'Hide observation data instructions'
+  };
+
+  return <VideoHelpSection {...helpProps} />;
+};

--- a/app/src/features/surveys/observations/components/ImportObservationsButton.tsx
+++ b/app/src/features/surveys/observations/components/ImportObservationsButton.tsx
@@ -1,6 +1,7 @@
 import Button, { ButtonProps } from '@mui/material/Button';
 import axios, { AxiosProgressEvent } from 'axios';
 import { CSVSingleImportDialog } from 'components/csv/CSVSingleImportDialog';
+import { TransformDataHelp } from 'components/dialog/video-help/TransformDataHelp';
 import { SurveyContext } from 'contexts/surveyContext';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useContext, useState } from 'react';
@@ -118,6 +119,7 @@ export const ImportObservationsButton = (props: IImportObservationsButtonProps) 
         onClose={() => setOpen(false)}
         onImport={handleImportObservations}
         onDownloadTemplate={() => downloadFile(getObservationCSVTemplate(), 'SIMS-observations-template.csv')}
+        VideoHelp={TransformDataHelp}
       />
     </>
   );


### PR DESCRIPTION
## Links to Jira Tickets

- NA

## Description of Changes

- Implements a help dropdown feature that guides users through a 3-step process for transforming wide data into a narrow format using Power Query in Excel.
- The dropdown includes a concise, audioless MP4 video tutorial that demonstrates the workflow within an Excel spreadsheet. This video serves as a practical guide to help users quickly understand how to use Power Query for their data transformation needs.
- The MP4 format was chosen over GIF due to its superior ability to maintain high visual quality while minimizing file size, ensuring efficient loading and playback for users.
- The video file is stored on Amazon S3, and the frontend renders the tutorial using an HTML `<video>` tag in the return statement, allowing for smooth and compatible playback across browsers.
- The MP4 was created using ffmpeg in a Git Bash terminal, with custom settings for quality and frames per second (fps) to optimize both clarity and performance.
- Updates relevant UI components and supporting code to incorporate the new help dropdown and tutorial feature.

---

## Testing Notes

- Verify that the help dropdown displays correctly and is accessible from the intended area in the application.
- Confirm the MP4 tutorial loads and plays smoothly, with no audio, maintaining high visual quality and fast load times.
- Check that the 3-step instructional text accurately describes the process and aligns with the actions shown in the video.
- Ensure the video is retrieved from S3 and embedded using the `<video>` HTML tag, and that error handling is in place if the video fails to load.
- Test on multiple browsers and devices to confirm compatibility.