### PR TITLE
Inviting members to surveys via email address

### DIFF
--- a/api/src/constants/administrative-activity.ts
+++ b/api/src/constants/administrative-activity.ts
@@ -3,6 +3,7 @@ export enum ADMINISTRATIVE_ACTIVITY_TYPE {
 }
 
 export enum ADMINISTRATIVE_ACTIVITY_STATUS_TYPE {
+  INVITED = 'Invited',
   PENDING = 'Pending',
   ACTIONED = 'Actioned',
   REJECTED = 'Rejected'

--- a/api/src/paths/administrative-activity/invited.ts
+++ b/api/src/paths/administrative-activity/invited.ts
@@ -1,0 +1,140 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../constants/roles';
+import { getDBConnection } from '../../database/db';
+import { HTTP400 } from '../../errors/http-error';
+import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
+import { AdministrativeActivityService } from '../../services/administrative-activity-service';
+import { getLogger } from '../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative-activity/invited');
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => {
+    return {
+      and: [
+        {
+          validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  createInvitedAccessRequest()
+];
+
+POST.apiDoc = {
+  description: 'Create a new invited Administrative Activity for users invited via email.',
+  tags: ['admin'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  requestBody: {
+    description: 'Invited Administrative Activity post request object.',
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          title: 'Invited Administrative Activity request object',
+          type: 'object',
+          additionalProperties: false,
+          required: ['systemUserId', 'userGuid', 'email'],
+          properties: {
+            systemUserId: { type: 'number', description: 'The system user ID for the invited user.' },
+            reason: { type: 'string', description: 'Reason for the invitation.' },
+            userGuid: { type: 'string', description: 'Unique keycloak GUID for the user.' },
+            name: { type: 'string' },
+            username: { type: 'string' },
+            email: { type: 'string' },
+            identitySource: { type: 'string', description: 'Whether the account is an IDIR or BCeID.' },
+            company: { type: 'string', description: 'The company that the user belongs to.', nullable: true },
+            displayName: { type: 'string' }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Invited administrative activity post response object.',
+      content: {
+        'application/json': {
+          schema: {
+            title: 'Invited Administrative Activity Response Object',
+            type: 'object',
+            additionalProperties: false,
+            required: ['id', 'date'],
+            properties: {
+              id: {
+                type: 'number'
+              },
+              date: {
+                description: 'The date this administrative activity was made',
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Creates a new administrative activity for an invited access request.
+ *
+ * @returns {RequestHandler}
+ */
+export function createInvitedAccessRequest(): RequestHandler {
+  return async (req, res) => {
+    const systemUserId = req.body.systemUserId;
+
+    if (!systemUserId) {
+      throw new HTTP400('Missing required systemUserId');
+    }
+
+    // Extract user data from request body (excluding systemUserId)
+    const { systemUserId: _, ...userData } = req.body;
+
+    if (!userData.email) {
+      throw new HTTP400('Missing required email');
+    }
+
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const administrativeActivityService = new AdministrativeActivityService(connection);
+
+      const response = await administrativeActivityService.createInvitedAccessRequest(systemUserId, userData);
+
+      await connection.commit();
+
+      return res.status(200).json(response);
+    } catch (error) {
+      defaultLog.error({ label: 'createInvitedAccessRequest', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/user/add.ts
+++ b/api/src/paths/user/add.ts
@@ -96,7 +96,23 @@ POST.apiDoc = {
   },
   responses: {
     200: {
-      description: 'Add system user OK.'
+      description: 'System user created successfully.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['system_user_id'],
+            properties: {
+              system_user_id: {
+                type: 'integer',
+                minimum: 1,
+                description: 'The ID of the created system user'
+              }
+            }
+          }
+        }
+      }
     },
     400: {
       $ref: '#/components/responses/400'
@@ -180,7 +196,7 @@ export function addSystemRoleUser(): RequestHandler {
 
       await connection.commit();
 
-      return res.status(200).send();
+      return res.status(200).json({ system_user_id: userObject.system_user_id });
     } catch (error) {
       defaultLog.error({ label: 'addSystemRoleUser', message: 'error', error });
       await connection.rollback();

--- a/api/src/repositories/administrative-activity-repository.ts
+++ b/api/src/repositories/administrative-activity-repository.ts
@@ -186,6 +186,61 @@ export class AdministrativeActivityRepository extends BaseRepository {
   }
 
   /**
+   * Inserts a row in the administrative_activity table reflecting an invited access request.
+   * Used when users are invited via email to surveys.
+   *
+   * @param {number} systemUserId
+   * @param {(string | object)} data
+   * @return {*}  {Promise<ICreateAdministrativeActivity>}
+   * @memberof AdministrativeActivityRepository
+   */
+  async createInvitedAccessRequest(
+    systemUserId: number,
+    data: string | object
+  ): Promise<ICreateAdministrativeActivity> {
+    const sqlStatement = SQL`
+      INSERT INTO administrative_activity (
+        reported_system_user_id,
+        administrative_activity_type_id,
+        administrative_activity_status_type_id,
+        data
+      ) VALUES (
+        ${systemUserId},
+        (
+          SELECT
+            aat.administrative_activity_type_id
+          FROM
+            administrative_activity_type aat
+          WHERE
+            aat.name = ${ADMINISTRATIVE_ACTIVITY_TYPE.SYSTEM_ACCESS}
+        ),
+        (
+          SELECT
+            aast.administrative_activity_status_type_id
+          FROM
+            administrative_activity_status_type aast
+          WHERE
+            aast.name = ${ADMINISTRATIVE_ACTIVITY_STATUS_TYPE.INVITED}
+        ),
+        ${data}
+      )
+      RETURNING
+        administrative_activity_id AS id,
+        create_date::timestamptz AS date
+    `;
+
+    const response = await this.connection.sql(sqlStatement, ICreateAdministrativeActivity);
+
+    if (!response.rows.length) {
+      throw new ApiExecuteSQLError('Failed to create administrative activity record', [
+        'AdministrativeActivityRepository->createInvitedAccessRequest'
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
    * SQL query to count pending records in the administrative_activity table for a given user GUID
    *
    * @param {string} userGUID

--- a/api/src/services/administrative-activity-service.ts
+++ b/api/src/services/administrative-activity-service.ts
@@ -70,6 +70,22 @@ export class AdministrativeActivityService extends DBService {
   }
 
   /**
+   * Create a new administrative activity record with type "System Access" and status "Invited".
+   * Used when users are invited via email to surveys.
+   *
+   * @param {number} systemUserId
+   * @param {(string | object)} data
+   * @return {*}  {Promise<ICreateAdministrativeActivity>}
+   * @memberof AdministrativeActivityService
+   */
+  async createInvitedAccessRequest(
+    systemUserId: number,
+    data: string | object
+  ): Promise<ICreateAdministrativeActivity> {
+    return this.administrativeActivityRepository.createInvitedAccessRequest(systemUserId, data);
+  }
+
+  /**
    * Update the status of an existing administrative activity record.
    *
    * @param {number} administrativeActivityId

--- a/app/src/constants/colours.ts
+++ b/app/src/constants/colours.ts
@@ -70,6 +70,7 @@ const NRM_REGION_COLOUR_MAP = {
  *
  */
 const ACCESS_REQUEST_STATUS_COLOUR_MAP = {
+  Invited: { colour: blueGrey },
   Pending: { colour: purple },
   Actioned: { colour: green },
   Rejected: { colour: red }

--- a/app/src/constants/misc.ts
+++ b/app/src/constants/misc.ts
@@ -3,6 +3,7 @@ export enum AdministrativeActivityType {
 }
 
 export enum AdministrativeActivityStatusType {
+  INVITED = 'Invited',
   PENDING = 'Pending',
   ACTIONED = 'Actioned',
   REJECTED = 'Rejected'

--- a/app/src/features/admin/AdminManagePage.tsx
+++ b/app/src/features/admin/AdminManagePage.tsx
@@ -17,6 +17,7 @@ const AdminManagePage = () => {
     biohubApi.admin.getAdministrativeActivities(
       [AdministrativeActivityType.SYSTEM_ACCESS],
       [
+        AdministrativeActivityStatusType.INVITED,
         AdministrativeActivityStatusType.PENDING,
         AdministrativeActivityStatusType.REJECTED,
         AdministrativeActivityStatusType.ACTIONED

--- a/app/src/features/admin/AdminManagePage.tsx
+++ b/app/src/features/admin/AdminManagePage.tsx
@@ -17,8 +17,8 @@ const AdminManagePage = () => {
     biohubApi.admin.getAdministrativeActivities(
       [AdministrativeActivityType.SYSTEM_ACCESS],
       [
-        AdministrativeActivityStatusType.INVITED,
         AdministrativeActivityStatusType.PENDING,
+        AdministrativeActivityStatusType.INVITED,
         AdministrativeActivityStatusType.REJECTED,
         AdministrativeActivityStatusType.ACTIONED
       ]

--- a/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
+++ b/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
@@ -33,14 +33,14 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
 
   const [activeView, setActiveView] = useState<AccessRequestViewEnum>(AccessRequestViewEnum.PENDING);
 
-  const invitedRequests = accessRequests.filter((request) => request.status_name === 'Invited');
   const pendingRequests = accessRequests.filter((request) => request.status_name === 'Pending');
+  const invitedRequests = accessRequests.filter((request) => request.status_name === 'Invited');
   const actionedRequests = accessRequests.filter((request) => request.status_name === 'Actioned');
   const rejectedRequests = accessRequests.filter((request) => request.status_name === 'Rejected');
 
   const views = [
-    { value: AccessRequestViewEnum.INVITED, label: `Invited (${invitedRequests.length})`, icon: mdiEmailPlusOutline },
     { value: AccessRequestViewEnum.PENDING, label: `Pending (${pendingRequests.length})`, icon: mdiExclamationThick },
+    { value: AccessRequestViewEnum.INVITED, label: `Invited (${invitedRequests.length})`, icon: mdiEmailPlusOutline },
     { value: AccessRequestViewEnum.ACTIONED, label: `Approved (${actionedRequests.length})`, icon: mdiCheck },
     { value: AccessRequestViewEnum.REJECTED, label: `Rejected (${rejectedRequests.length})`, icon: mdiCancel }
   ];
@@ -65,11 +65,11 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
       </Box>
       <Divider />
       <Box>
-        {activeView === AccessRequestViewEnum.INVITED && (
-          <AccessRequestInvitedList accessRequests={invitedRequests} refresh={refresh} />
-        )}
         {activeView === AccessRequestViewEnum.PENDING && (
           <AccessRequestPendingList accessRequests={pendingRequests} refresh={refresh} />
+        )}
+        {activeView === AccessRequestViewEnum.INVITED && (
+          <AccessRequestInvitedList accessRequests={invitedRequests} refresh={refresh} />
         )}
         {activeView === AccessRequestViewEnum.ACTIONED && (
           <AccessRequestActionedList accessRequests={actionedRequests} />

--- a/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
+++ b/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
@@ -1,4 +1,4 @@
-import { mdiCancel, mdiCheck, mdiExclamationThick } from '@mdi/js';
+import { mdiCancel, mdiCheck, mdiEmailPlusOutline, mdiExclamationThick } from '@mdi/js';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
@@ -17,6 +17,7 @@ interface IAccessRequestContainerProps {
 }
 
 enum AccessRequestViewEnum {
+  INVITED = 'INVITED',
   ACTIONED = 'ACTIONED',
   PENDING = 'PENDING',
   REJECTED = 'REJECTED'
@@ -31,11 +32,13 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
 
   const [activeView, setActiveView] = useState<AccessRequestViewEnum>(AccessRequestViewEnum.PENDING);
 
+  const invitedRequests = accessRequests.filter((request) => request.status_name === 'Invited');
   const pendingRequests = accessRequests.filter((request) => request.status_name === 'Pending');
   const actionedRequests = accessRequests.filter((request) => request.status_name === 'Actioned');
   const rejectedRequests = accessRequests.filter((request) => request.status_name === 'Rejected');
 
   const views = [
+    { value: AccessRequestViewEnum.INVITED, label: `Invited (${invitedRequests.length})`, icon: mdiEmailPlusOutline },
     { value: AccessRequestViewEnum.PENDING, label: `Pending (${pendingRequests.length})`, icon: mdiExclamationThick },
     { value: AccessRequestViewEnum.ACTIONED, label: `Approved (${actionedRequests.length})`, icon: mdiCheck },
     { value: AccessRequestViewEnum.REJECTED, label: `Rejected (${rejectedRequests.length})`, icon: mdiCancel }
@@ -61,6 +64,9 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
       </Box>
       <Divider />
       <Box>
+        {activeView === AccessRequestViewEnum.INVITED && (
+          <AccessRequestPendingList accessRequests={invitedRequests} refresh={refresh} />
+        )}
         {activeView === AccessRequestViewEnum.PENDING && (
           <AccessRequestPendingList accessRequests={pendingRequests} refresh={refresh} />
         )}

--- a/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
+++ b/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
@@ -1,7 +1,5 @@
 import { mdiCancel, mdiCheck, mdiEmailPlusOutline, mdiExclamationThick } from '@mdi/js';
-import Icon from '@mdi/react';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Toolbar from '@mui/material/Toolbar';
@@ -53,13 +51,6 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
         <Typography variant="h4" component="h2">
           Access Requests
         </Typography>
-        <Button
-          color="primary"
-          variant="contained"
-          startIcon={<Icon path={mdiEmailPlusOutline} size={1} />}
-          onClick={() => {}}>
-          Invite
-        </Button>
       </Toolbar>
       <Divider />
       <Box p={2} display="flex" justifyContent="space-between">

--- a/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
+++ b/app/src/features/admin/users/access-requests/AccessRequestContainer.tsx
@@ -1,5 +1,7 @@
 import { mdiCancel, mdiCheck, mdiEmailPlusOutline, mdiExclamationThick } from '@mdi/js';
+import Icon from '@mdi/react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Toolbar from '@mui/material/Toolbar';
@@ -8,6 +10,7 @@ import CustomToggleButtonGroup from 'components/toolbar/CustomToggleButtonGroup'
 import { IGetAccessRequestsListResponse } from 'interfaces/useAdminApi.interface';
 import { useState } from 'react';
 import AccessRequestActionedList from './list/actioned/AccessRequestActionedList';
+import AccessRequestInvitedList from './list/invited/AccessRequestInvitedList';
 import AccessRequestPendingList from './list/pending/AccessRequestPendingList';
 import AccessRequestRejectedList from './list/rejected/AccessRequestRejectedList';
 
@@ -46,10 +49,17 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
 
   return (
     <Paper>
-      <Toolbar>
+      <Toolbar style={{ display: 'flex', justifyContent: 'space-between' }}>
         <Typography variant="h4" component="h2">
           Access Requests
         </Typography>
+        <Button
+          color="primary"
+          variant="contained"
+          startIcon={<Icon path={mdiEmailPlusOutline} size={1} />}
+          onClick={() => {}}>
+          Invite
+        </Button>
       </Toolbar>
       <Divider />
       <Box p={2} display="flex" justifyContent="space-between">
@@ -65,7 +75,7 @@ const AccessRequestContainer = (props: IAccessRequestContainerProps) => {
       <Divider />
       <Box>
         {activeView === AccessRequestViewEnum.INVITED && (
-          <AccessRequestPendingList accessRequests={invitedRequests} refresh={refresh} />
+          <AccessRequestInvitedList accessRequests={invitedRequests} refresh={refresh} />
         )}
         {activeView === AccessRequestViewEnum.PENDING && (
           <AccessRequestPendingList accessRequests={pendingRequests} refresh={refresh} />

--- a/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
+++ b/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
@@ -1,0 +1,282 @@
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { GridColDef } from '@mui/x-data-grid';
+import ColouredRectangleChip from 'components/chips/ColouredRectangleChip';
+import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
+import RequestDialog from 'components/dialog/RequestDialog';
+import { getAccessRequestStatusColour } from 'constants/colours';
+import { DATE_FORMAT } from 'constants/dateTimeFormats';
+import { ReviewAccessRequestI18N } from 'constants/i18n';
+import { DialogContext, ISnackbarProps } from 'contexts/dialogContext';
+import dayjs from 'dayjs';
+import { APIError } from 'hooks/api/useAxios';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import { useCodesContext } from 'hooks/useContext';
+import { IGetAccessRequestsListResponse } from 'interfaces/useAdminApi.interface';
+import { useContext, useEffect, useState } from 'react';
+import ReviewAccessRequestForm, {
+  IReviewAccessRequestForm,
+  ReviewAccessRequestFormInitialValues,
+  ReviewAccessRequestFormYupSchema
+} from '../../components/ReviewAccessRequestForm';
+
+interface IAccessRequestInvitedListProps {
+  accessRequests: IGetAccessRequestsListResponse[];
+  refresh: () => void;
+}
+
+/**
+ * Returns a data grid component displaying pending access requests
+ *
+ * @param props {IAccessRequestInvitedListProps}
+ * @returns
+ */
+const AccessRequestInvitedList = (props: IAccessRequestInvitedListProps) => {
+  const { accessRequests, refresh } = props;
+
+  const codesContext = useCodesContext();
+  const codes = codesContext.codesDataLoader?.data;
+
+  const biohubApi = useBiohubApi();
+  const dialogContext = useContext(DialogContext);
+
+  const [showReviewDialog, setShowReviewDialog] = useState<boolean>(false);
+  const [activeReview, setActiveReview] = useState<IGetAccessRequestsListResponse | null>(null);
+
+  useEffect(() => {
+    codesContext.codesDataLoader.load();
+  }, [codesContext.codesDataLoader]);
+
+  const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
+    dialogContext.setSnackbar({ ...textDialogProps, open: true });
+  };
+
+  const accessRequestsColumnDefs: GridColDef<IGetAccessRequestsListResponse>[] = [
+    {
+      field: 'display_name',
+      headerName: 'Display Name',
+      flex: 1,
+      disableColumnMenu: true,
+      valueGetter: (params) => {
+        return params.row.data?.displayName;
+      }
+    },
+    {
+      field: 'username',
+      headerName: 'Username',
+      flex: 1,
+      disableColumnMenu: true,
+      valueGetter: (params) => {
+        return params.row.data?.username;
+      }
+    },
+    {
+      field: 'create_date',
+      flex: 1,
+      headerName: 'Date of Request',
+      disableColumnMenu: true,
+      valueFormatter: (params) => {
+        return dayjs(params.value).format(DATE_FORMAT.ShortMediumDateTimeFormat);
+      }
+    },
+    {
+      field: 'status_name',
+      width: 170,
+      headerName: 'Status',
+      disableColumnMenu: true,
+      renderCell: (params) => {
+        return (
+          <ColouredRectangleChip
+            label={params.row.status_name}
+            colour={getAccessRequestStatusColour(params.row.status_name as 'Invited')}
+          />
+        );
+      }
+    },
+    {
+      field: 'actions',
+      headerName: '',
+      type: 'actions',
+      flex: 1,
+      sortable: false,
+      disableColumnMenu: true,
+      resizable: false,
+      align: 'right',
+      renderCell: (params) => (
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={() => {
+            setActiveReview(params.row);
+            setShowReviewDialog(true);
+          }}>
+          Review Request
+        </Button>
+      )
+    }
+  ];
+
+  const defaultErrorDialogProps = {
+    dialogTitle: ReviewAccessRequestI18N.reviewErrorTitle,
+    dialogText: ReviewAccessRequestI18N.reviewErrorText,
+    open: false,
+    onClose: () => {
+      dialogContext.setErrorDialog({ open: false });
+    },
+    onOk: () => {
+      dialogContext.setErrorDialog({ open: false });
+    }
+  };
+
+  const handleReviewDialogApprove = async (values: IReviewAccessRequestForm) => {
+    if (!activeReview) {
+      return;
+    }
+
+    setShowReviewDialog(false);
+
+    try {
+      await biohubApi.admin.approveAccessRequest(activeReview.id, {
+        userGuid: activeReview.data.userGuid,
+        userIdentifier: activeReview.data.username,
+        identitySource: activeReview.data.identitySource,
+        email: activeReview.data.email,
+        displayName: activeReview.data.displayName,
+        roleIds: (values.system_role && [values.system_role]) || []
+      });
+
+      showSnackBar({
+        snackbarMessage: (
+          <Typography variant="body2" component="div">
+            Approved access request
+          </Typography>
+        )
+      });
+
+      try {
+        await biohubApi.admin.sendGCNotification(
+          {
+            emailAddress: activeReview.data.email,
+            phoneNumber: '',
+            userId: activeReview.id
+          },
+          {
+            subject: 'SIMS: Your request for access has been approved.',
+            header: 'Your request for access to the Species Inventory Management System has been approved.',
+            main_body1: 'This is an automated message from the Species Inventory Management System',
+            main_body2: '',
+            footer: ''
+          }
+        );
+      } catch (_error) {
+        showSnackBar({
+          snackbarMessage: (
+            <Typography variant="body2" component="div">
+              Approved access request, but failed to send notification
+            </Typography>
+          )
+        });
+      } finally {
+        refresh();
+      }
+    } catch (error) {
+      dialogContext.setErrorDialog({
+        ...defaultErrorDialogProps,
+        open: true,
+        dialogErrorDetails: (error as APIError).errors
+      });
+    }
+  };
+
+  const handleReviewDialogDeny = async () => {
+    if (!activeReview) {
+      return;
+    }
+
+    setShowReviewDialog(false);
+
+    try {
+      await biohubApi.admin.denyAccessRequest(activeReview.id);
+
+      showSnackBar({
+        snackbarMessage: (
+          <Typography variant="body2" component="div">
+            Approved access request
+          </Typography>
+        )
+      });
+
+      try {
+        await biohubApi.admin.sendGCNotification(
+          {
+            emailAddress: activeReview.data.email,
+            phoneNumber: '',
+            userId: activeReview.id
+          },
+          {
+            subject: 'SIMS: Your request for access has been denied.',
+            header: 'Your request for access to the Species Inventory Management System has been denied.',
+            main_body1: 'This is an automated message from the Species Inventory Management System',
+            main_body2: '',
+            footer: ''
+          }
+        );
+      } catch (_error) {
+        showSnackBar({
+          snackbarMessage: (
+            <Typography variant="body2" component="div">
+              Denied access request, but failed to send notification
+            </Typography>
+          )
+        });
+      } finally {
+        refresh();
+      }
+    } catch (error) {
+      dialogContext.setErrorDialog({
+        ...defaultErrorDialogProps,
+        open: true,
+        dialogErrorDetails: (error as APIError).errors
+      });
+    }
+  };
+
+  return (
+    <>
+      <RequestDialog
+        dialogTitle={'Review Access Request'}
+        open={showReviewDialog}
+        onClose={() => setShowReviewDialog(false)}
+        onDeny={handleReviewDialogDeny}
+        onApprove={handleReviewDialogApprove}
+        component={{
+          initialValues: ReviewAccessRequestFormInitialValues,
+          validationSchema: ReviewAccessRequestFormYupSchema,
+          element: activeReview ? (
+            <ReviewAccessRequestForm
+              request={activeReview}
+              system_roles={codes?.system_roles?.map((item: any) => ({ value: item.id, label: item.name })) || []}
+            />
+          ) : (
+            <></>
+          )
+        }}
+      />
+      <StyledDataGrid
+        columns={accessRequestsColumnDefs}
+        rows={accessRequests}
+        noRowsMessage="No Invited Access Requests"
+        pageSizeOptions={[10, 25, 50]}
+        initialState={{
+          pagination: {
+            paginationModel: {
+              pageSize: 10
+            }
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default AccessRequestInvitedList;

--- a/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
+++ b/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
@@ -62,15 +62,6 @@ const AccessRequestInvitedList = (props: IAccessRequestInvitedListProps) => {
       }
     },
     {
-      field: 'username',
-      headerName: 'Username',
-      flex: 1,
-      disableColumnMenu: true,
-      valueGetter: (params) => {
-        return params.row.data?.username;
-      }
-    },
-    {
       field: 'create_date',
       flex: 1,
       headerName: 'Date of Request',

--- a/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
+++ b/app/src/features/admin/users/access-requests/list/invited/AccessRequestInvitedList.tsx
@@ -1,24 +1,10 @@
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
 import { GridColDef } from '@mui/x-data-grid';
 import ColouredRectangleChip from 'components/chips/ColouredRectangleChip';
 import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
-import RequestDialog from 'components/dialog/RequestDialog';
 import { getAccessRequestStatusColour } from 'constants/colours';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
-import { ReviewAccessRequestI18N } from 'constants/i18n';
-import { DialogContext, ISnackbarProps } from 'contexts/dialogContext';
 import dayjs from 'dayjs';
-import { APIError } from 'hooks/api/useAxios';
-import { useBiohubApi } from 'hooks/useBioHubApi';
-import { useCodesContext } from 'hooks/useContext';
 import { IGetAccessRequestsListResponse } from 'interfaces/useAdminApi.interface';
-import { useContext, useEffect, useState } from 'react';
-import ReviewAccessRequestForm, {
-  IReviewAccessRequestForm,
-  ReviewAccessRequestFormInitialValues,
-  ReviewAccessRequestFormYupSchema
-} from '../../components/ReviewAccessRequestForm';
 
 interface IAccessRequestInvitedListProps {
   accessRequests: IGetAccessRequestsListResponse[];
@@ -26,30 +12,13 @@ interface IAccessRequestInvitedListProps {
 }
 
 /**
- * Returns a data grid component displaying pending access requests
+ * Returns a data grid component displaying invited access requests
  *
  * @param props {IAccessRequestInvitedListProps}
  * @returns
  */
 const AccessRequestInvitedList = (props: IAccessRequestInvitedListProps) => {
-  const { accessRequests, refresh } = props;
-
-  const codesContext = useCodesContext();
-  const codes = codesContext.codesDataLoader?.data;
-
-  const biohubApi = useBiohubApi();
-  const dialogContext = useContext(DialogContext);
-
-  const [showReviewDialog, setShowReviewDialog] = useState<boolean>(false);
-  const [activeReview, setActiveReview] = useState<IGetAccessRequestsListResponse | null>(null);
-
-  useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
-
-  const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
-    dialogContext.setSnackbar({ ...textDialogProps, open: true });
-  };
+  const { accessRequests } = props;
 
   const accessRequestsColumnDefs: GridColDef<IGetAccessRequestsListResponse>[] = [
     {
@@ -62,9 +31,18 @@ const AccessRequestInvitedList = (props: IAccessRequestInvitedListProps) => {
       }
     },
     {
+      field: 'email',
+      headerName: 'Email',
+      flex: 1,
+      disableColumnMenu: true,
+      valueGetter: (params) => {
+        return params.row.data?.email;
+      }
+    },
+    {
       field: 'create_date',
       flex: 1,
-      headerName: 'Date of Request',
+      headerName: 'Date Invited',
       disableColumnMenu: true,
       valueFormatter: (params) => {
         return dayjs(params.value).format(DATE_FORMAT.ShortMediumDateTimeFormat);
@@ -83,190 +61,23 @@ const AccessRequestInvitedList = (props: IAccessRequestInvitedListProps) => {
           />
         );
       }
-    },
-    {
-      field: 'actions',
-      headerName: '',
-      type: 'actions',
-      flex: 1,
-      sortable: false,
-      disableColumnMenu: true,
-      resizable: false,
-      align: 'right',
-      renderCell: (params) => (
-        <Button
-          color="primary"
-          variant="contained"
-          onClick={() => {
-            setActiveReview(params.row);
-            setShowReviewDialog(true);
-          }}>
-          Review Request
-        </Button>
-      )
     }
   ];
 
-  const defaultErrorDialogProps = {
-    dialogTitle: ReviewAccessRequestI18N.reviewErrorTitle,
-    dialogText: ReviewAccessRequestI18N.reviewErrorText,
-    open: false,
-    onClose: () => {
-      dialogContext.setErrorDialog({ open: false });
-    },
-    onOk: () => {
-      dialogContext.setErrorDialog({ open: false });
-    }
-  };
-
-  const handleReviewDialogApprove = async (values: IReviewAccessRequestForm) => {
-    if (!activeReview) {
-      return;
-    }
-
-    setShowReviewDialog(false);
-
-    try {
-      await biohubApi.admin.approveAccessRequest(activeReview.id, {
-        userGuid: activeReview.data.userGuid,
-        userIdentifier: activeReview.data.username,
-        identitySource: activeReview.data.identitySource,
-        email: activeReview.data.email,
-        displayName: activeReview.data.displayName,
-        roleIds: (values.system_role && [values.system_role]) || []
-      });
-
-      showSnackBar({
-        snackbarMessage: (
-          <Typography variant="body2" component="div">
-            Approved access request
-          </Typography>
-        )
-      });
-
-      try {
-        await biohubApi.admin.sendGCNotification(
-          {
-            emailAddress: activeReview.data.email,
-            phoneNumber: '',
-            userId: activeReview.id
-          },
-          {
-            subject: 'SIMS: Your request for access has been approved.',
-            header: 'Your request for access to the Species Inventory Management System has been approved.',
-            main_body1: 'This is an automated message from the Species Inventory Management System',
-            main_body2: '',
-            footer: ''
-          }
-        );
-      } catch (_error) {
-        showSnackBar({
-          snackbarMessage: (
-            <Typography variant="body2" component="div">
-              Approved access request, but failed to send notification
-            </Typography>
-          )
-        });
-      } finally {
-        refresh();
-      }
-    } catch (error) {
-      dialogContext.setErrorDialog({
-        ...defaultErrorDialogProps,
-        open: true,
-        dialogErrorDetails: (error as APIError).errors
-      });
-    }
-  };
-
-  const handleReviewDialogDeny = async () => {
-    if (!activeReview) {
-      return;
-    }
-
-    setShowReviewDialog(false);
-
-    try {
-      await biohubApi.admin.denyAccessRequest(activeReview.id);
-
-      showSnackBar({
-        snackbarMessage: (
-          <Typography variant="body2" component="div">
-            Approved access request
-          </Typography>
-        )
-      });
-
-      try {
-        await biohubApi.admin.sendGCNotification(
-          {
-            emailAddress: activeReview.data.email,
-            phoneNumber: '',
-            userId: activeReview.id
-          },
-          {
-            subject: 'SIMS: Your request for access has been denied.',
-            header: 'Your request for access to the Species Inventory Management System has been denied.',
-            main_body1: 'This is an automated message from the Species Inventory Management System',
-            main_body2: '',
-            footer: ''
-          }
-        );
-      } catch (_error) {
-        showSnackBar({
-          snackbarMessage: (
-            <Typography variant="body2" component="div">
-              Denied access request, but failed to send notification
-            </Typography>
-          )
-        });
-      } finally {
-        refresh();
-      }
-    } catch (error) {
-      dialogContext.setErrorDialog({
-        ...defaultErrorDialogProps,
-        open: true,
-        dialogErrorDetails: (error as APIError).errors
-      });
-    }
-  };
-
   return (
-    <>
-      <RequestDialog
-        dialogTitle={'Review Access Request'}
-        open={showReviewDialog}
-        onClose={() => setShowReviewDialog(false)}
-        onDeny={handleReviewDialogDeny}
-        onApprove={handleReviewDialogApprove}
-        component={{
-          initialValues: ReviewAccessRequestFormInitialValues,
-          validationSchema: ReviewAccessRequestFormYupSchema,
-          element: activeReview ? (
-            <ReviewAccessRequestForm
-              request={activeReview}
-              system_roles={codes?.system_roles?.map((item: any) => ({ value: item.id, label: item.name })) || []}
-            />
-          ) : (
-            <></>
-          )
-        }}
-      />
-      <StyledDataGrid
-        columns={accessRequestsColumnDefs}
-        rows={accessRequests}
-        noRowsMessage="No Invited Access Requests"
-        pageSizeOptions={[10, 25, 50]}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 10
-            }
+    <StyledDataGrid
+      columns={accessRequestsColumnDefs}
+      rows={accessRequests}
+      noRowsMessage="No Invited Access Requests"
+      pageSizeOptions={[10, 25, 50]}
+      initialState={{
+        pagination: {
+          paginationModel: {
+            pageSize: 10
           }
-        }}
-      />
-    </>
+        }
+      }}
+    />
   );
 };
 

--- a/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
+++ b/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
@@ -11,16 +11,16 @@ import { ISystemUser } from 'interfaces/useUserApi.interface';
 import { TransitionGroup } from 'react-transition-group';
 import yup from 'utils/YupSchema';
 
-export const SurveyMembersYupSchema = yup.object().shape({
+export const SurveyMembersEmailYupSchema = yup.object().shape({
   members: yup.array().of(
     yup.object().shape({
-      system_user_id: yup.string().required('Username is required'),
+      email: yup.string().required('A valid email address is required'), //add functionality to validate email format
       survey_role_name: yup.string().required('Select a survey role for this team member')
     })
   )
 });
 
-interface ISurveyMembersFormProps {
+interface ISurveyMembersEmailFormProps {
   roles: ICodeWithDescription[];
 }
 
@@ -31,9 +31,9 @@ export const SurveyMembersFormInitialValues = {
 /**
  * Form for adding members to a survey, granting them permissions to view the survey
  *
- * @param {ISurveyMembersFormProps} props
+ * @param {ISurveyMembersEmailFormProps} props
  */
-export const SurveyMembersEmailsForm = (props: ISurveyMembersFormProps) => {
+export const SurveyMembersEmailsForm = (props: ISurveyMembersEmailFormProps) => {
   const { handleSubmit, values, setFieldValue, errors, setErrors } = useFormikContext<ICreateSurveyRequest>();
 
   const handleAddUser = (user: ISystemUser | ISurveyMember) => {
@@ -94,7 +94,7 @@ export const SurveyMembersEmailsForm = (props: ISurveyMembersFormProps) => {
       <SystemUserAutocompleteField
         formikFieldName="members"
         label="Members"
-        helpText="Only active users who have requested access to the Species Inventory Management System before can be invited"
+        helpText="You can grant permissions for survey participation via email address, but individuals will still need to be granted access to Species Inventory Management System before they can access the survey."
         selectedUsers={values.members.map((member) => member.system_user_id)}
         clearOnSelect
         onSelect={(value) => {

--- a/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
+++ b/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
@@ -1,0 +1,136 @@
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import Typography from '@mui/material/Typography';
+import AlertBar from 'components/alert/AlertBar';
+import { SystemUserAutocompleteField } from 'components/fields/SystemUserAutocompleteField';
+import UserRoleSelector from 'components/user/UserRoleSelector';
+import { useFormikContext } from 'formik';
+import { ICodeWithDescription } from 'interfaces/useCodesApi.interface';
+import { ICreateSurveyRequest, ISurveyMember } from 'interfaces/useSurveyApi.interface';
+import { ISystemUser } from 'interfaces/useUserApi.interface';
+import { TransitionGroup } from 'react-transition-group';
+import yup from 'utils/YupSchema';
+
+export const SurveyMembersYupSchema = yup.object().shape({
+  members: yup.array().of(
+    yup.object().shape({
+      system_user_id: yup.string().required('Username is required'),
+      survey_role_name: yup.string().required('Select a survey role for this team member')
+    })
+  )
+});
+
+interface ISurveyMembersFormProps {
+  roles: ICodeWithDescription[];
+}
+
+export const SurveyMembersFormInitialValues = {
+  members: []
+};
+
+/**
+ * Form for adding members to a survey, granting them permissions to view the survey
+ *
+ * @param {ISurveyMembersFormProps} props
+ */
+export const SurveyMembersEmailsForm = (props: ISurveyMembersFormProps) => {
+  const { handleSubmit, values, setFieldValue, errors, setErrors } = useFormikContext<ICreateSurveyRequest>();
+
+  const handleAddUser = (user: ISystemUser | ISurveyMember) => {
+    setFieldValue(`members[${values.members.length}]`, {
+      system_user_id: user.system_user_id,
+      display_name: user.display_name,
+      email: user.email,
+      agency: user.agency,
+      identity_source: user.identity_source,
+      survey_role_name: ''
+    });
+    clearErrors();
+  };
+
+  const handleAddUserRole = (survey_role_name: string, index: number) => {
+    setFieldValue(`members[${index}].survey_role_name`, survey_role_name);
+    clearErrors();
+  };
+
+  const handleRemoveUser = (systemUserId: number) => {
+    const filteredUsers = values.members.filter(
+      (item: ISystemUser | ISurveyMember) => item.system_user_id !== systemUserId
+    );
+
+    setFieldValue(`members`, filteredUsers);
+    clearErrors();
+  };
+
+  const clearErrors = () => {
+    setErrors({ ...errors, members: undefined });
+  };
+
+  const rowItemError = (index: number): JSX.Element | undefined => {
+    if (errors?.members && Array.isArray(errors.members)) {
+      const errorAtIndex = errors.members[index];
+      if (errorAtIndex) {
+        return (
+          <Typography style={{ fontSize: '12px', color: '#f44336' }}>
+            {errorAtIndex ? 'Select a survey role for this team member.' : ''}
+          </Typography>
+        );
+      }
+    }
+  };
+
+  const getSelectedRole = (index: number): string => {
+    // users should only ever have a single role on a project so index: 0 is a safe selection
+    return values.members?.[index]?.survey_role_name || '';
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {errors?.['members'] && !Array.isArray(errors['members']) && (
+        <Box my={3}>
+          <AlertBar severity="error" variant="outlined" title="Missing Invites" text={errors['members']} />
+        </Box>
+      )}
+      <SystemUserAutocompleteField
+        formikFieldName="members"
+        label="Members"
+        helpText="Only active users who have requested access to the Species Inventory Management System before can be invited"
+        selectedUsers={values.members.map((member) => member.system_user_id)}
+        clearOnSelect
+        onSelect={(value) => {
+          if (value) {
+            handleAddUser(value);
+          }
+        }}
+      />
+      <Box>
+        <Box
+          sx={{
+            '& .userRoleItemContainer + .userRoleItemContainer': {
+              mt: 1
+            }
+          }}>
+          <TransitionGroup>
+            {values.members.map((user: ISystemUser | ISurveyMember, index: number) => {
+              const error = rowItemError(index);
+              return (
+                <Collapse key={user.system_user_id}>
+                  <UserRoleSelector
+                    index={index}
+                    user={user}
+                    roles={props.roles}
+                    error={error}
+                    selectedRole={getSelectedRole(index)}
+                    handleAdd={handleAddUserRole}
+                    handleRemove={handleRemoveUser}
+                    label="Select a Role"
+                  />
+                </Collapse>
+              );
+            })}
+          </TransitionGroup>
+        </Box>
+      </Box>
+    </form>
+  );
+};

--- a/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
+++ b/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
@@ -1,20 +1,26 @@
+import { mdiClose, mdiPlus } from '@mdi/js';
+import Icon from '@mdi/react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import grey from '@mui/material/colors/grey';
 import AlertBar from 'components/alert/AlertBar';
-import { SystemUserAutocompleteField } from 'components/fields/SystemUserAutocompleteField';
-import UserRoleSelector from 'components/user/UserRoleSelector';
+import CustomTextField from 'components/fields/CustomTextField';
 import { useFormikContext } from 'formik';
 import { ICodeWithDescription } from 'interfaces/useCodesApi.interface';
-import { ICreateSurveyRequest, ISurveyMember } from 'interfaces/useSurveyApi.interface';
-import { ISystemUser } from 'interfaces/useUserApi.interface';
+import { ICreateSurveyRequest } from 'interfaces/useSurveyApi.interface';
 import { TransitionGroup } from 'react-transition-group';
 import yup from 'utils/YupSchema';
 
 export const SurveyMembersEmailYupSchema = yup.object().shape({
   members: yup.array().of(
     yup.object().shape({
-      email: yup.string().required('A valid email address is required'), //add functionality to validate email format
+      email: yup.string().email('Must be a valid email address').required('A valid email address is required'),
       survey_role_name: yup.string().required('Select a survey role for this team member')
     })
   )
@@ -25,40 +31,49 @@ interface ISurveyMembersEmailFormProps {
 }
 
 export const SurveyMembersFormInitialValues = {
-  members: []
+  members: [
+    {
+      email: '',
+      survey_role_name: ''
+    }
+  ]
 };
 
+interface IMemberEmailRole {
+  email: string;
+  survey_role_name: string;
+}
+
 /**
- * Form for adding members to a survey, granting them permissions to view the survey
+ * Form for adding members to a survey by email, granting them permissions to view the survey
  *
  * @param {ISurveyMembersEmailFormProps} props
  */
 export const SurveyMembersEmailsForm = (props: ISurveyMembersEmailFormProps) => {
   const { handleSubmit, values, setFieldValue, errors, setErrors } = useFormikContext<ICreateSurveyRequest>();
 
-  const handleAddUser = (user: ISystemUser | ISurveyMember) => {
-    setFieldValue(`members[${values.members.length}]`, {
-      system_user_id: user.system_user_id,
-      display_name: user.display_name,
-      email: user.email,
-      agency: user.agency,
-      identity_source: user.identity_source,
+  const handleAddMember = () => {
+    const newMember: IMemberEmailRole = {
+      email: '',
       survey_role_name: ''
-    });
+    };
+    setFieldValue(`members[${values.members.length}]`, newMember);
     clearErrors();
   };
 
-  const handleAddUserRole = (survey_role_name: string, index: number) => {
+  const handleUpdateEmail = (email: string, index: number) => {
+    setFieldValue(`members[${index}].email`, email);
+    clearErrors();
+  };
+
+  const handleUpdateRole = (survey_role_name: string, index: number) => {
     setFieldValue(`members[${index}].survey_role_name`, survey_role_name);
     clearErrors();
   };
 
-  const handleRemoveUser = (systemUserId: number) => {
-    const filteredUsers = values.members.filter(
-      (item: ISystemUser | ISurveyMember) => item.system_user_id !== systemUserId
-    );
-
-    setFieldValue(`members`, filteredUsers);
+  const handleRemoveMember = (index: number) => {
+    const filteredMembers = values.members.filter((_, memberIndex) => memberIndex !== index);
+    setFieldValue(`members`, filteredMembers);
     clearErrors();
   };
 
@@ -72,7 +87,9 @@ export const SurveyMembersEmailsForm = (props: ISurveyMembersEmailFormProps) => 
       if (errorAtIndex) {
         return (
           <Typography style={{ fontSize: '12px', color: '#f44336' }}>
-            {errorAtIndex ? 'Select a survey role for this team member.' : ''}
+            {typeof errorAtIndex === 'string'
+              ? errorAtIndex
+              : errorAtIndex.email || errorAtIndex.survey_role_name || 'Please fix the errors above.'}
           </Typography>
         );
       }
@@ -80,7 +97,6 @@ export const SurveyMembersEmailsForm = (props: ISurveyMembersEmailFormProps) => 
   };
 
   const getSelectedRole = (index: number): string => {
-    // users should only ever have a single role on a project so index: 0 is a safe selection
     return values.members?.[index]?.survey_role_name || '';
   };
 
@@ -91,40 +107,111 @@ export const SurveyMembersEmailsForm = (props: ISurveyMembersEmailFormProps) => 
           <AlertBar severity="error" variant="outlined" title="Missing Invites" text={errors['members']} />
         </Box>
       )}
-      <SystemUserAutocompleteField
-        formikFieldName="members"
-        label="Members"
-        helpText="You can grant permissions for survey participation via email address, but individuals will still need to be granted access to Species Inventory Management System before they can access the survey."
-        selectedUsers={values.members.map((member) => member.system_user_id)}
-        clearOnSelect
-        onSelect={(value) => {
-          if (value) {
-            handleAddUser(value);
-          }
-        }}
-      />
+
+      <Box mb={2}>
+        <Button
+          variant="outlined"
+          startIcon={<Icon path={mdiPlus} size={1} />}
+          onClick={handleAddMember}
+          sx={{ mb: 2 }}>
+          Add Member
+        </Button>
+      </Box>
+
       <Box>
         <Box
           sx={{
-            '& .userRoleItemContainer + .userRoleItemContainer': {
+            '& .memberItemContainer + .memberItemContainer': {
               mt: 1
             }
           }}>
           <TransitionGroup>
-            {values.members.map((user: ISystemUser | ISurveyMember, index: number) => {
+            {values.members.map((member: IMemberEmailRole, index: number) => {
               const error = rowItemError(index);
               return (
-                <Collapse key={user.system_user_id}>
-                  <UserRoleSelector
-                    index={index}
-                    user={user}
-                    roles={props.roles}
-                    error={error}
-                    selectedRole={getSelectedRole(index)}
-                    handleAdd={handleAddUserRole}
-                    handleRemove={handleRemoveUser}
-                    label="Select a Role"
-                  />
+                <Collapse key={`member-${index}`}>
+                  <Box mt={1} className="memberItemContainer">
+                    <Paper
+                      variant="outlined"
+                      sx={{
+                        background: grey[100],
+                        ...(error
+                          ? {
+                              '& + p': {
+                                pt: 0.75,
+                                pb: 0.75,
+                                pl: 2
+                              }
+                            }
+                          : undefined)
+                      }}>
+                      <Box display="flex" alignItems="center" px={2} py={1.5} gap={2}>
+                        <Box flex="1 1 auto">
+                          <CustomTextField
+                            name={`members[${index}].email`}
+                            label="Email Address"
+                            placeholder="Enter email address"
+                            other={{
+                              type: 'email',
+                              value: member.email,
+                              onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+                                handleUpdateEmail(event.target.value, index);
+                              }
+                            }}
+                          />
+                        </Box>
+                        <Box flex="0 0 auto" minWidth="200px">
+                          <Select
+                            size="small"
+                            inputProps={{
+                              'aria-label': 'Select a role'
+                            }}
+                            error={Boolean(error)}
+                            data-testid={`select-member-role-button-${index}`}
+                            sx={{ width: '100%', backgroundColor: '#fff' }}
+                            displayEmpty
+                            value={getSelectedRole(index)}
+                            onChange={(event) => {
+                              handleUpdateRole(String(event.target.value), index);
+                            }}
+                            renderValue={(selected) => {
+                              if (!selected) {
+                                return 'Select a Role';
+                              }
+                              return selected;
+                            }}>
+                            {props.roles.map((item) => (
+                              <MenuItem
+                                key={item.id}
+                                value={item.name}
+                                sx={{
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  alignItems: 'flex-start'
+                                }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>{item.name}</Box>
+                                <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                                  {item.description}
+                                </Typography>
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </Box>
+                        <Box flex="0 0 auto">
+                          <IconButton
+                            data-testid={`remove-member-button-${index}`}
+                            sx={{ ml: 1 }}
+                            aria-label="remove member"
+                            onClick={() => {
+                              handleRemoveMember(index);
+                            }}>
+                            <Icon path={mdiClose} size={1} />
+                          </IconButton>
+                        </Box>
+                      </Box>
+                    </Paper>
+                    {error}
+                  </Box>
                 </Collapse>
               );
             })}

--- a/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
+++ b/app/src/features/surveys/components/member/SurveyMembersEmailsForm.tsx
@@ -20,7 +20,7 @@ import yup from 'utils/YupSchema';
 export const SurveyMembersEmailYupSchema = yup.object().shape({
   members: yup.array().of(
     yup.object().shape({
-      email: yup.string().email('Must be a valid email address').required('A valid email address is required'),
+      email: yup.string().trim().email('Must be a valid email address').required('A valid email address is required'),
       survey_role_name: yup.string().required('Select a survey role for this team member')
     })
   )

--- a/app/src/features/surveys/details/tabs/permissions/members/SurveyMembersContainer.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/SurveyMembersContainer.tsx
@@ -26,6 +26,7 @@ import { useEffect, useState } from 'react';
 import { StringValues } from 'types/misc';
 import { getCodesName } from 'utils/Utils';
 import SurveyMemberDialog from './dialog/SurveyMembersDialog';
+import SurveyMembersEmailDialog from './dialog/SurveyMembersEmailDialog';
 
 type SurveyDataTableURLParams = {
   // filter
@@ -46,6 +47,7 @@ const SurveyMembersContainer = () => {
 
   const { searchParams, setSearchParams } = useSearchParams<StringValues<SurveyDataTableURLParams>>();
   const [participantDialogIsOpen, setParticipantDialogIsOpen] = useState(false);
+  const [participantEmailDialogIsOpen, setParticipantEmailDialogIsOpen] = useState(false);
 
   const [advancedFiltersModel, setAdvancedFiltersModel] = useState<ISurveyMembersAdvancedFilters>({
     keyword: searchParams.get('sm_keyword') ?? undefined,
@@ -129,6 +131,12 @@ const SurveyMembersContainer = () => {
               setParticipantDialogIsOpen(true);
             }}
           />
+          <CreateButton
+            label="Invite via Email"
+            onClick={() => {
+              setParticipantEmailDialogIsOpen(true);
+            }}
+          />
           <HelpButtonDialog markdownType={MarkdownTypeNameEnum.SURVEYS} />
         </Stack>
       </Toolbar>
@@ -183,6 +191,17 @@ const SurveyMembersContainer = () => {
           setParticipantDialogIsOpen(false);
         }}
         open={participantDialogIsOpen}
+      />
+      <SurveyMembersEmailDialog
+        surveyId={surveyContext.surveyId}
+        onSubmit={() => {
+          surveyMembersDataLoader.refresh(advancedFiltersModel);
+          setParticipantEmailDialogIsOpen(false);
+        }}
+        onClose={() => {
+          setParticipantEmailDialogIsOpen(false);
+        }}
+        open={participantEmailDialogIsOpen}
       />
     </>
   );

--- a/app/src/features/surveys/details/tabs/permissions/members/SurveyMembersContainer.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/SurveyMembersContainer.tsx
@@ -1,5 +1,7 @@
-import { mdiArrowTopRight } from '@mdi/js';
+import { mdiArrowTopRight, mdiEmailPlus } from '@mdi/js';
+import Icon from '@mdi/react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import grey from '@mui/material/colors/grey';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
@@ -131,12 +133,13 @@ const SurveyMembersContainer = () => {
               setParticipantDialogIsOpen(true);
             }}
           />
-          <CreateButton
-            label="Invite via Email"
+          <Button
+            variant="outlined"
             onClick={() => {
               setParticipantEmailDialogIsOpen(true);
-            }}
-          />
+            }}>
+            <Icon path={mdiEmailPlus} size={1} />
+          </Button>
           <HelpButtonDialog markdownType={MarkdownTypeNameEnum.SURVEYS} />
         </Stack>
       </Toolbar>

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -1,0 +1,119 @@
+import Typography from '@mui/material/Typography';
+import EditDialog from 'components/dialog/EditDialog';
+import { IErrorDialogProps } from 'components/dialog/ErrorDialog';
+import { CreateCollectionSurveyI18N } from 'constants/i18n';
+import { ISnackbarProps } from 'contexts/dialogContext';
+import { SurveyMembersEmailsForm } from 'features/surveys/components/member/SurveyMembersEmailsForm';
+import { APIError } from 'hooks/api/useAxios';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import { useCodesContext, useDialogContext } from 'hooks/useContext';
+import { ISurveyMemberEmailForm } from 'interfaces/useSurveyApi.interface';
+import { useState } from 'react';
+import { pluralize } from 'utils/Utils';
+import yup from 'utils/YupSchema';
+
+interface ISurveyMemberEmailDialogProps {
+  surveyId: number;
+  open: boolean;
+  onSubmit: () => void;
+  onClose?: (refresh?: boolean) => void;
+}
+
+/**
+ * Dialog for inviting survey members via email
+ *
+ * NOTE: On naming conventions, SurveyMemberForm is from the perspective of a survey (adding one survey to multiple surveys).
+ * Whereas CollectionSurveyForm is from the perspective of a survey (adding multiple surveys to one survey)
+ *
+ * @param {ISurveyMemberEmailDialogProps} props
+ * @returns
+ */
+const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogContext = useDialogContext();
+  const codesContext = useCodesContext();
+
+  const biohubApi = useBiohubApi();
+
+  const CollectionSurveyYupSchema = yup.object().shape({
+    members: yup
+      .array(
+        yup.object({
+          system_user_id: yup.number().required('You must supply an email address'),
+          survey_role_name: yup.string().required('You must select a role')
+        })
+      )
+      .min(1, 'You must supply at least one email address')
+  });
+
+  const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
+    dialogContext.setSnackbar({ ...textDialogProps, open: true });
+  };
+
+  const showCreateErrorDialog = (textDialogProps?: Partial<IErrorDialogProps>) => {
+    dialogContext.setErrorDialog({
+      dialogTitle: CreateCollectionSurveyI18N.createErrorTitle,
+      dialogText: CreateCollectionSurveyI18N.createErrorText,
+      onClose: () => dialogContext.setErrorDialog({ open: false }),
+      onOk: () => dialogContext.setErrorDialog({ open: false }),
+      ...textDialogProps,
+      open: true
+    });
+  };
+
+  const handleSubmitCollectionService = async (values: ISurveyMemberEmailForm) => {
+    try {
+      setIsSubmitting(true);
+
+      await biohubApi.survey.addSurveyMembers(
+        props.surveyId,
+        values.members.map((member) => ({
+          system_user_id: member.system_user_id,
+          survey_role_name: member.survey_role_name
+        }))
+      );
+
+      props.onSubmit();
+
+      showSnackBar({
+        snackbarMessage: (
+          <>
+            <Typography variant="body2" component="span">
+              Added {values.members.length} {pluralize(values.members.length, 'user')} to survey
+            </Typography>
+          </>
+        ),
+        open: true
+      });
+    } catch (error: any) {
+      showCreateErrorDialog({
+        dialogError: (error as APIError).message,
+        dialogErrorDetails: (error as APIError).errors
+      });
+    }
+    setIsSubmitting(false);
+  };
+
+  return (
+    <EditDialog
+      dialogTitle="Invite members via email"
+      dialogText="Enter the email addresses of the users you would like to invite to this survey."
+      open={props.open}
+      dialogLoading={isSubmitting}
+      component={{
+        element: <SurveyMembersEmailsForm roles={codesContext.codesDataLoader.data?.survey_roles ?? []} />,
+        initialValues: {
+          members: []
+        },
+        validationSchema: CollectionSurveyYupSchema
+      }}
+      dialogSaveButtonLabel="Add"
+      onCancel={() => props.onClose && props.onClose()}
+      onSave={(formValues) => {
+        handleSubmitCollectionService(formValues);
+      }}
+    />
+  );
+};
+
+export default SurveyMemberEmailDialog;

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -3,6 +3,7 @@ import EditDialog from 'components/dialog/EditDialog';
 import { IErrorDialogProps } from 'components/dialog/ErrorDialog';
 import { SYSTEM_IDENTITY_SOURCE } from 'constants/auth';
 import { CreateCollectionSurveyI18N } from 'constants/i18n';
+import { SURVEY_ROLE } from 'constants/roles';
 import { ISnackbarProps } from 'contexts/dialogContext';
 import {
   SurveyMembersEmailsForm,
@@ -12,6 +13,7 @@ import {
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext } from 'hooks/useContext';
+import { IPostSurveyMember } from 'interfaces/useSurveyApi.interface';
 import { useState } from 'react';
 import { pluralize } from 'utils/Utils';
 
@@ -56,7 +58,7 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
     try {
       setIsSubmitting(true);
 
-      const createdUsers: { system_user_id: number; survey_role_name: string }[] = [];
+      const createdUsers: IPostSurveyMember[] = [];
 
       // Step 1: Create system users for each email
       for (const member of values.members) {
@@ -71,7 +73,7 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
 
           createdUsers.push({
             system_user_id: response.system_user_id,
-            survey_role_name: member.survey_role_name
+            survey_role_name: member.survey_role_name as SURVEY_ROLE // Cast to SURVEY_ROLE enum
           });
         } catch (userError) {
           console.error(`Failed to create user for ${member.email}:`, userError);

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -75,6 +75,22 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
             system_user_id: response.system_user_id,
             survey_role_name: member.survey_role_name as SURVEY_ROLE // Cast to SURVEY_ROLE enum
           });
+
+          // Step 1.5: Create an "Invited" administrative activity record for the user
+          try {
+            await biohubApi.admin.createInvitedAccessRequest(response.system_user_id, {
+              email: member.email,
+              userGuid: '', // Will be populated when user actually logs in
+              name: member.email, // Using email as name placeholder
+              username: member.email, // Using email as username placeholder
+              identitySource: SYSTEM_IDENTITY_SOURCE.UNVERIFIED,
+              displayName: member.email,
+              reason: 'Invited via email to survey'
+            });
+          } catch (activityError) {
+            console.error(`Failed to create administrative activity for ${member.email}:`, activityError);
+            // Continue even if activity creation fails
+          }
         } catch (userError) {
           console.error(`Failed to create user for ${member.email}:`, userError);
           // Continue with other users even if one fails

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -9,7 +9,6 @@ import {
   SurveyMembersFormInitialValues
 } from 'features/surveys/components/member/SurveyMembersEmailsForm';
 import { APIError } from 'hooks/api/useAxios';
-import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext } from 'hooks/useContext';
 import { useState } from 'react';
 import { pluralize } from 'utils/Utils';
@@ -34,8 +33,6 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const dialogContext = useDialogContext();
   const codesContext = useCodesContext();
-
-  const biohubApi = useBiohubApi();
 
   const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
     dialogContext.setSnackbar({ ...textDialogProps, open: true });

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -3,14 +3,16 @@ import EditDialog from 'components/dialog/EditDialog';
 import { IErrorDialogProps } from 'components/dialog/ErrorDialog';
 import { CreateCollectionSurveyI18N } from 'constants/i18n';
 import { ISnackbarProps } from 'contexts/dialogContext';
-import { SurveyMembersEmailsForm } from 'features/surveys/components/member/SurveyMembersEmailsForm';
+import {
+  SurveyMembersEmailsForm,
+  SurveyMembersEmailYupSchema,
+  SurveyMembersFormInitialValues
+} from 'features/surveys/components/member/SurveyMembersEmailsForm';
 import { APIError } from 'hooks/api/useAxios';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext } from 'hooks/useContext';
-import { ISurveyMemberEmailForm } from 'interfaces/useSurveyApi.interface';
 import { useState } from 'react';
 import { pluralize } from 'utils/Utils';
-import yup from 'utils/YupSchema';
 
 interface ISurveyMemberEmailDialogProps {
   surveyId: number;
@@ -35,17 +37,6 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
 
   const biohubApi = useBiohubApi();
 
-  const CollectionSurveyYupSchema = yup.object().shape({
-    members: yup
-      .array(
-        yup.object({
-          system_user_id: yup.number().required('You must supply an email address'),
-          survey_role_name: yup.string().required('You must select a role')
-        })
-      )
-      .min(1, 'You must supply at least one email address')
-  });
-
   const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
     dialogContext.setSnackbar({ ...textDialogProps, open: true });
   };
@@ -61,17 +52,12 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
     });
   };
 
-  const handleSubmitCollectionService = async (values: ISurveyMemberEmailForm) => {
+  const handleSubmitCollectionService = async (values: any) => {
     try {
       setIsSubmitting(true);
 
-      await biohubApi.survey.addSurveyMembers(
-        props.surveyId,
-        values.members.map((member) => ({
-          system_user_id: member.system_user_id,
-          survey_role_name: member.survey_role_name
-        }))
-      );
+      //TECH DEBT: UPDATE API ENDPOINT
+      console.log('Email members to invite:', values.members);
 
       props.onSubmit();
 
@@ -79,7 +65,7 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
         snackbarMessage: (
           <>
             <Typography variant="body2" component="span">
-              Added {values.members.length} {pluralize(values.members.length, 'user')} to survey
+              Would invite {values.members.length} {pluralize(values.members.length, 'user')} to survey
             </Typography>
           </>
         ),
@@ -102,10 +88,8 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
       dialogLoading={isSubmitting}
       component={{
         element: <SurveyMembersEmailsForm roles={codesContext.codesDataLoader.data?.survey_roles ?? []} />,
-        initialValues: {
-          members: []
-        },
-        validationSchema: CollectionSurveyYupSchema
+        initialValues: SurveyMembersFormInitialValues,
+        validationSchema: SurveyMembersEmailYupSchema
       }}
       dialogSaveButtonLabel="Add"
       onCancel={() => props.onClose && props.onClose()}

--- a/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
+++ b/app/src/features/surveys/details/tabs/permissions/members/dialog/SurveyMembersEmailDialog.tsx
@@ -1,6 +1,7 @@
 import Typography from '@mui/material/Typography';
 import EditDialog from 'components/dialog/EditDialog';
 import { IErrorDialogProps } from 'components/dialog/ErrorDialog';
+import { SYSTEM_IDENTITY_SOURCE } from 'constants/auth';
 import { CreateCollectionSurveyI18N } from 'constants/i18n';
 import { ISnackbarProps } from 'contexts/dialogContext';
 import {
@@ -9,6 +10,7 @@ import {
   SurveyMembersFormInitialValues
 } from 'features/surveys/components/member/SurveyMembersEmailsForm';
 import { APIError } from 'hooks/api/useAxios';
+import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext } from 'hooks/useContext';
 import { useState } from 'react';
 import { pluralize } from 'utils/Utils';
@@ -32,6 +34,7 @@ interface ISurveyMemberEmailDialogProps {
 const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const dialogContext = useDialogContext();
+  const biohubApi = useBiohubApi();
   const codesContext = useCodesContext();
 
   const showSnackBar = (textDialogProps?: Partial<ISnackbarProps>) => {
@@ -49,12 +52,37 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
     });
   };
 
-  const handleSubmitCollectionService = async (values: any) => {
+  const handleSubmit = async (values: any) => {
     try {
       setIsSubmitting(true);
 
-      //TECH DEBT: UPDATE API ENDPOINT
-      console.log('Email members to invite:', values.members);
+      const createdUsers: { system_user_id: number; survey_role_name: string }[] = [];
+
+      // Step 1: Create system users for each email
+      for (const member of values.members) {
+        try {
+          const response = await biohubApi.admin.addSystemUser(
+            member.email, // user identifier, using email as placeholder until we get name from keycloak
+            SYSTEM_IDENTITY_SOURCE.UNVERIFIED, // unverified source until keycloak confirms
+            member.email, // email as display name until keycloak overwrites it
+            member.email, // email
+            2 // roleId (assign them a creator role)
+          );
+
+          createdUsers.push({
+            system_user_id: response.system_user_id,
+            survey_role_name: member.survey_role_name
+          });
+        } catch (userError) {
+          console.error(`Failed to create user for ${member.email}:`, userError);
+          // Continue with other users even if one fails
+        }
+      }
+
+      // Step 2: Add created users to the survey
+      if (createdUsers.length > 0) {
+        await biohubApi.survey.addSurveyMembers(props.surveyId, createdUsers);
+      }
 
       props.onSubmit();
 
@@ -62,7 +90,8 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
         snackbarMessage: (
           <>
             <Typography variant="body2" component="span">
-              Would invite {values.members.length} {pluralize(values.members.length, 'user')} to survey
+              Successfully invited {createdUsers.length} of {values.members.length}{' '}
+              {pluralize(values.members.length, 'user')} to survey
             </Typography>
           </>
         ),
@@ -91,7 +120,7 @@ const SurveyMemberEmailDialog = (props: ISurveyMemberEmailDialogProps) => {
       dialogSaveButtonLabel="Add"
       onCancel={() => props.onClose && props.onClose()}
       onSave={(formValues) => {
-        handleSubmitCollectionService(formValues);
+        handleSubmit(formValues);
       }}
     />
   );

--- a/app/src/hooks/api/useAdminApi.ts
+++ b/app/src/hooks/api/useAdminApi.ts
@@ -135,6 +135,34 @@ const useAdminApi = (axios: AxiosInstance) => {
     return data;
   };
 
+  /**
+   * Creates an invited access request administrative activity.
+   *
+   * @param {number} systemUserId
+   * @param {object} userData - User information (email, userGuid, name, etc.)
+   * @return {*} {Promise<{ id: number; date: string }>}
+   */
+  const createInvitedAccessRequest = async (
+    systemUserId: number,
+    userData: {
+      email: string;
+      userGuid?: string;
+      name?: string;
+      username?: string;
+      identitySource?: string;
+      company?: string;
+      displayName?: string;
+      reason?: string;
+    }
+  ): Promise<{ id: number; date: string }> => {
+    const { data: response } = await axios.post(`/api/administrative-activity/invited`, {
+      systemUserId,
+      ...userData
+    });
+
+    return response;
+  };
+
   return {
     sendGCNotification,
     getAdministrativeActivities,
@@ -142,7 +170,8 @@ const useAdminApi = (axios: AxiosInstance) => {
     denyAccessRequest,
     createAdministrativeActivity,
     getAdministrativeActivityStanding,
-    addSystemUser
+    addSystemUser,
+    createInvitedAccessRequest
   };
 };
 

--- a/app/src/hooks/api/useAdminApi.ts
+++ b/app/src/hooks/api/useAdminApi.ts
@@ -115,7 +115,7 @@ const useAdminApi = (axios: AxiosInstance) => {
    * @param {string} displayName
    * @param {string} email
    * @param {number} roleId
-   * @return {*} {boolean} True if the user is successfully added, false otherwise.
+   * @return {*} {{ system_user_id: number }} The created user data.
    */
   const addSystemUser = async (
     userIdentifier: string,
@@ -123,8 +123,8 @@ const useAdminApi = (axios: AxiosInstance) => {
     displayName: string,
     email: string,
     roleId: number
-  ): Promise<boolean> => {
-    const { status } = await axios.post(`/api/user/add`, {
+  ): Promise<{ system_user_id: number }> => {
+    const { data } = await axios.post(`/api/user/add`, {
       identitySource,
       userIdentifier,
       displayName,
@@ -132,7 +132,7 @@ const useAdminApi = (axios: AxiosInstance) => {
       roleId
     });
 
-    return status === 200;
+    return data;
   };
 
   return {

--- a/app/src/interfaces/useSurveyApi.interface.ts
+++ b/app/src/interfaces/useSurveyApi.interface.ts
@@ -89,6 +89,11 @@ export interface ISurveyMemberResponse {
 export interface ISurveyMemberForm {
   members: ISurveyMember[];
 }
+
+export interface ISurveyMemberEmailForm {
+  members: ISurveyMember[];
+}
+
 export interface ISurveyMembersAdvancedFilters {
   system_user_id?: number;
   keyword?: string;

--- a/database/src/migrations/20250806000000_invited_admin_status.ts
+++ b/database/src/migrations/20250806000000_invited_admin_status.ts
@@ -1,0 +1,26 @@
+import { Knex } from 'knex';
+
+/**
+ * Adding an option for invited admin status
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    set search_path=biohub;
+
+    ----------------------------------------------------------------------------------------
+    -- Invited status for administrative activities
+    ----------------------------------------------------------------------------------------
+
+    INSERT INTO administrative_activity_status_type (name, record_effective_date, description) 
+VALUES ('Invited', now(), 'User has been invited via email but has not yet requested access');
+
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(``);
+}


### PR DESCRIPTION
## Description of Changes

- Created new email dialog popup that contains role selector and the text box for an email:
-  The process becomes invite → sign-up → instant access instead of sign-up → approval → manual add → access.

TO DO: 
- have checks that check that the email doesn't already exist in the table prior to adding a new record (Confirm that if the member already exists that instead of adding them by email, it will just pull that user record and add their permissions to the survey)
- delete branch email-invite

## Testing Notes

- NA
