### PR TITLE
Displaying deployments in an overview table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ dist
 
 # IDE custom workspace settings
 .vscode/settings.json
+
+**/.vscode

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -29,3 +29,4 @@ yarn-debug.log*
 yarn-error.log*
 
 ts-traces
+**/.vscode

--- a/api/src/models/deployment-view.ts
+++ b/api/src/models/deployment-view.ts
@@ -1,13 +1,76 @@
 export interface IDeploymentAdvancedFilters {
   /**
+   * Filter results by keyword.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  keyword?: string;
+  /**
+   * Filter results by species TSN.
+   *
+   * @type {number}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  itis_tsn?: number;
+  /**
+   * Filter results by start date.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  start_date?: string;
+  /**
+   * Filter results by end date.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  end_date?: string;
+  /**
+   * Filter results by start time.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  start_time?: string;
+  /**
+   * Filter results by end time.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  end_time?: string;
+  /**
    * Filter results by system user id.
    *
    * Note: This is not the id of the user making the request.
    *
    * @type {number}
-   * @memberof IAnimalAdvancedFilters
+   * @memberof IDeploymentAdvancedFilters
    */
   system_user_id?: number;
+  /**
+   * Filter results by device serial.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  device_serial?: string;
+  /**
+   * Filter results by species.
+   *
+   * @type {number}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  species?: number;
+  /**
+   * Filter results by animal alias.
+   *
+   * @type {string}
+   * @memberof IDeploymentAdvancedFilters
+   */
+  animal_alias?: string;
   /**
    * Filter results by deployment ids.
    *

--- a/api/src/paths/deployment/index.ts
+++ b/api/src/paths/deployment/index.ts
@@ -142,9 +142,6 @@ GET.apiDoc = {
                     'attachment_end_date',
                     'attachment_end_time',
                     'attachment_end_timestamp',
-                    'critterbase_start_capture_id',
-                    'critterbase_end_capture_id',
-                    'critterbase_end_mortality_id',
                     // device data
                     'serial',
                     'device_make_id',
@@ -207,7 +204,8 @@ GET.apiDoc = {
                       nullable: true
                     },
                     critterbase_start_capture_id: {
-                      type: 'string'
+                      type: 'string',
+                      nullable: true
                     },
                     critterbase_end_capture_id: {
                       type: 'string',

--- a/api/src/paths/deployment/index.ts
+++ b/api/src/paths/deployment/index.ts
@@ -1,0 +1,324 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../constants/roles';
+import { getDBConnection } from '../../database/db';
+import { IDeploymentAdvancedFilters } from '../../models/deployment-view';
+import { paginationRequestQueryParamSchema, paginationResponseSchema } from '../../openapi/schemas/pagination';
+import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
+import { TelemetryDeploymentService } from '../../services/telemetry-services/telemetry-deployment-service';
+import { getLogger } from '../../utils/logger';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../utils/pagination';
+
+const defaultLog = getLogger('paths/deployments');
+
+export const GET: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      and: [
+        {
+          discriminator: 'SystemUser'
+        }
+      ]
+    };
+  }),
+  findDeployments()
+];
+
+GET.apiDoc = {
+  description:
+    'Gets all deployments that are available to the user, based on their permissions and provided filter criteria.',
+  tags: ['deployment'],
+  security: [
+    {
+      Bearer: []
+    }
+  ],
+  parameters: [
+    ...paginationRequestQueryParamSchema,
+    {
+      in: 'query',
+      name: 'keyword',
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'itis_tsn',
+      schema: {
+        type: 'integer'
+      }
+    },
+    {
+      in: 'query',
+      name: 'start_date',
+      schema: {
+        type: 'string',
+        format: 'date'
+      }
+    },
+    {
+      in: 'query',
+      name: 'end_date',
+      schema: {
+        type: 'string',
+        format: 'date'
+      }
+    },
+    {
+      in: 'query',
+      name: 'start_time',
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'end_time',
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'system_user_id',
+      schema: {
+        type: 'integer'
+      }
+    },
+    {
+      in: 'query',
+      name: 'device_serial',
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'species',
+      schema: {
+        type: 'integer'
+      }
+    },
+    {
+      in: 'query',
+      name: 'animal_alias',
+      schema: {
+        type: 'string'
+      }
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Responds with all deployments that are available to the user.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              deployments: {
+                title: 'Deployments',
+                type: 'array',
+                items: {
+                  title: 'Deployment',
+                  type: 'object',
+                  additionalProperties: false,
+                  required: [
+                    // deployment data
+                    'deployment_id',
+                    'survey_id',
+                    'critter_id',
+                    'device_id',
+                    'device_key',
+                    'frequency',
+                    'frequency_unit_id',
+                    'attachment_start_date',
+                    'attachment_start_time',
+                    'attachment_start_timestamp',
+                    'attachment_end_date',
+                    'attachment_end_time',
+                    'attachment_end_timestamp',
+                    'critterbase_start_capture_id',
+                    'critterbase_end_capture_id',
+                    'critterbase_end_mortality_id',
+                    // device data
+                    'serial',
+                    'device_make_id',
+                    'model',
+                    // critter data
+                    'critterbase_critter_id'
+                  ],
+                  properties: {
+                    deployment_id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    survey_id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    critter_id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    device_id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    device_key: {
+                      type: 'string'
+                    },
+                    frequency: {
+                      type: 'number',
+                      nullable: true
+                    },
+                    frequency_unit_id: {
+                      type: 'integer',
+                      nullable: true
+                    },
+                    attachment_start_date: {
+                      type: 'string',
+                      format: 'date'
+                    },
+                    attachment_start_time: {
+                      type: 'string',
+                      nullable: true
+                    },
+                    attachment_start_timestamp: {
+                      type: 'string',
+                      format: 'date-time'
+                    },
+                    attachment_end_date: {
+                      type: 'string',
+                      format: 'date',
+                      nullable: true
+                    },
+                    attachment_end_time: {
+                      type: 'string',
+                      nullable: true
+                    },
+                    attachment_end_timestamp: {
+                      type: 'string',
+                      format: 'date-time',
+                      nullable: true
+                    },
+                    critterbase_start_capture_id: {
+                      type: 'string'
+                    },
+                    critterbase_end_capture_id: {
+                      type: 'string',
+                      nullable: true
+                    },
+                    critterbase_end_mortality_id: {
+                      type: 'string',
+                      nullable: true
+                    },
+                    serial: {
+                      type: 'string'
+                    },
+                    device_make_id: {
+                      type: 'integer',
+                      minimum: 1
+                    },
+                    model: {
+                      type: 'string',
+                      nullable: true
+                    },
+                    critterbase_critter_id: {
+                      type: 'string'
+                    }
+                  }
+                }
+              },
+              pagination: paginationResponseSchema
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    403: {
+      $ref: '#/components/responses/403'
+    },
+    409: {
+      $ref: '#/components/responses/409'
+    },
+    500: {
+      $ref: '#/components/responses/500'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Finds all deployments that are available to the user, based on their permissions and provided filter criteria.
+ *
+ * @export
+ * @return {*}  {RequestHandler}
+ */
+export function findDeployments(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      const paginationOptions = makePaginationOptionsFromRequest(req);
+
+      await connection.open();
+
+      const telemetryDeploymentService = new TelemetryDeploymentService(connection);
+
+      // Extract filter parameters from query
+      const filterFields: IDeploymentAdvancedFilters = {
+        keyword: req.query.keyword as string,
+        itis_tsn: req.query.itis_tsn ? Number(req.query.itis_tsn) : undefined,
+        start_date: req.query.start_date as string,
+        end_date: req.query.end_date as string,
+        start_time: req.query.start_time as string,
+        end_time: req.query.end_time as string,
+        system_user_id: req.query.system_user_id ? Number(req.query.system_user_id) : undefined,
+        device_serial: req.query.device_serial as string,
+        species: req.query.species ? Number(req.query.species) : undefined,
+        animal_alias: req.query.animal_alias as string
+      };
+
+      // Get user info to determine if they are an admin
+      const isUserAdmin =
+        req.system_user?.role_names?.includes(SYSTEM_ROLE.SYSTEM_ADMIN) ||
+        req.system_user?.role_names?.includes(SYSTEM_ROLE.DATA_ADMINISTRATOR) ||
+        false;
+      const systemUserId = req.system_user?.system_user_id || null;
+
+      const deployments = await telemetryDeploymentService.findDeployments(
+        isUserAdmin,
+        systemUserId,
+        filterFields,
+        ensureCompletePaginationOptions(paginationOptions)
+      );
+
+      await connection.commit();
+
+      return res.status(200).json({
+        deployments: deployments,
+        pagination: makePaginationResponse(deployments.length, paginationOptions)
+      });
+    } catch (error) {
+      defaultLog.error({ label: 'findDeployments', message: 'error', error });
+      await connection.rollback();
+
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/repositories/survey-critter-repository.ts
+++ b/api/src/repositories/survey-critter-repository.ts
@@ -77,14 +77,14 @@ export class SurveyCritterRepository extends BaseRepository {
 
     if (!isUserAdmin) {
       query
-        .leftJoin('survey', 'survey.survey_id', 'critter.survey_id')
-        .leftJoin('project', 'project.project_id', 'survey.project_id')
-        .leftJoin('project_participation', 'project_participation.project_id', 'project.project_id')
+        .innerJoin('survey', 'survey.survey_id', 'critter.survey_id')
+        .innerJoin('project', 'project.project_id', 'survey.project_id')
+        .innerJoin('project_participation', 'project_participation.project_id', 'project.project_id')
         .where('project_participation.system_user_id', systemUserId);
     }
 
     if (filterFields?.system_user_id) {
-      query.whereIn('p.project_id', (subQueryBuilder) => {
+      query.whereIn('project.project_id', (subQueryBuilder) => {
         subQueryBuilder
           .select('project_id')
           .from('project_participation')

--- a/api/src/repositories/telemetry-repositories/telemetry-deployment-repository.ts
+++ b/api/src/repositories/telemetry-repositories/telemetry-deployment-repository.ts
@@ -168,7 +168,7 @@ export class TelemetryDeploymentRepository extends BaseRepository {
     }
 
     if (filterFields.system_user_id) {
-      getSurveyIdsQuery.whereIn('p.project_id', (subQueryBuilder) => {
+      getSurveyIdsQuery.whereIn('survey.project_id', (subQueryBuilder) => {
         subQueryBuilder
           .select('project_id')
           .from('project_participation')
@@ -227,6 +227,38 @@ export class TelemetryDeploymentRepository extends BaseRepository {
           .from('project_participation')
           .where('system_user_id', filterFields.system_user_id);
       });
+    }
+
+    // Add filtering based on additional filter fields
+    if (filterFields.keyword) {
+      queryBuilder.where((builder) => {
+        builder
+          .orWhere('device.serial', 'ilike', `%${filterFields.keyword}%`)
+          .orWhere('critter.critterbase_critter_id', 'ilike', `%${filterFields.keyword}%`);
+      });
+    }
+
+    if (filterFields.device_serial) {
+      queryBuilder.where('device.serial', 'ilike', `%${filterFields.device_serial}%`);
+    }
+
+    if (filterFields.animal_alias) {
+      queryBuilder.where('critter.critterbase_critter_id', 'ilike', `%${filterFields.animal_alias}%`);
+    }
+
+    if (filterFields.itis_tsn) {
+      // Join with survey to get species information if needed
+      queryBuilder
+        .leftJoin('survey_species', 'survey.survey_id', 'survey_species.survey_id')
+        .where('survey_species.itis_tsn', filterFields.itis_tsn);
+    }
+
+    if (filterFields.start_date) {
+      queryBuilder.where('deployment.attachment_start_date', '>=', filterFields.start_date);
+    }
+
+    if (filterFields.end_date) {
+      queryBuilder.where('deployment.attachment_start_date', '<=', filterFields.end_date);
     }
 
     if (pagination) {

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -29,3 +29,5 @@ yarn-debug.log*
 yarn-error.log*
 
 ts-traces
+
+**/.vscode

--- a/app/src/features/summary/tabular-data/TabularDataTableContainer.tsx
+++ b/app/src/features/summary/tabular-data/TabularDataTableContainer.tsx
@@ -1,4 +1,4 @@
-import { mdiEye, mdiPaw, mdiPineTree, mdiWifiMarker } from '@mdi/js';
+import { mdiCellphoneBasic, mdiEye, mdiPaw, mdiPineTree, mdiWifiMarker } from '@mdi/js';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
@@ -12,11 +12,13 @@ import TelemetryListContainer from 'features/summary/tabular-data/telemetry/Tele
 import { useSearchParams } from 'hooks/useSearchParams';
 import { MarkdownTypeNameEnum } from 'interfaces/useMarkdownApi.interface';
 import { useState } from 'react';
+import DeploymentListContainer from './deployments/DeploymentListContainer';
 
 const ACTIVE_VIEW_KEY = 'tavk';
 export enum ACTIVE_VIEW_VALUE {
   observations = 'ov',
   telemetry = 'tv',
+  deployments = 'dev',
   animals = 'av',
   habitatFeatures = 'hv'
 }
@@ -50,6 +52,7 @@ export const TabularDataTableContainer = () => {
     { value: ACTIVE_VIEW_VALUE.observations, label: 'observations', icon: mdiEye },
     { value: ACTIVE_VIEW_VALUE.animals, label: 'animals', icon: mdiPaw },
     { value: ACTIVE_VIEW_VALUE.telemetry, label: 'telemetry', icon: mdiWifiMarker },
+    { value: ACTIVE_VIEW_VALUE.deployments, label: 'deployments', icon: mdiCellphoneBasic },
     { value: ACTIVE_VIEW_VALUE.habitatFeatures, label: 'habitat features', icon: mdiPineTree }
   ];
 
@@ -77,6 +80,7 @@ export const TabularDataTableContainer = () => {
         {activeView === ACTIVE_VIEW_VALUE.observations && <ObservationsListContainer showSearch={showSearch} />}
         {activeView === ACTIVE_VIEW_VALUE.animals && <AnimalsListContainer showSearch={showSearch} />}
         {activeView === ACTIVE_VIEW_VALUE.telemetry && <TelemetryListContainer showSearch={showSearch} />}
+        {activeView === ACTIVE_VIEW_VALUE.deployments && <DeploymentListContainer showSearch={showSearch} />}
         {activeView === ACTIVE_VIEW_VALUE.habitatFeatures && <HabitatFeaturesListContainer showSearch={showSearch} />}
       </Box>
     </Stack>

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
@@ -18,7 +18,7 @@ import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
 import { useSearchParams } from 'hooks/useSearchParams';
 import { TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
 import { firstOrNull } from 'utils/Utils';
 import {
@@ -111,11 +111,27 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
       biohubApi.telemetryDeployment.findTelemetryDeployment(pagination, filter)
   );
 
+  const animalDataLoader = useDataLoader(() => biohubApi.animal.findAnimals());
+
   useDeepCompareEffect(() => {
     deploymentDataLoader.refresh(paginationSort, advancedFiltersModel);
+    animalDataLoader.refresh();
   }, [advancedFiltersModel, paginationSort]);
 
-  const rows = deploymentDataLoader.data?.deployments ?? [];
+  const rows = useMemo(() => deploymentDataLoader.data?.deployments ?? [], [deploymentDataLoader.data]);
+
+  // Create a mapping from critterbase_critter_id to animal_id
+  const critterIdToAnimalIdMap = useMemo(() => {
+    const animals = animalDataLoader.data?.animals ?? [];
+    const map = new Map<string, string>();
+
+    animals.forEach((animal) => {
+      if (animal.critterbase_critter_id && animal.animal_id) {
+        map.set(animal.critterbase_critter_id, animal.animal_id);
+      }
+    });
+    return map;
+  }, [animalDataLoader.data]);
 
   const columns: GridColDef<TelemetryDeployment>[] = [
     {
@@ -139,14 +155,21 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
       headerName: 'Device Serial',
       flex: 1,
       sortable: false,
-      renderCell: (params) => <Typography variant="body2">{params.row.serial}</Typography>
+      renderCell: (params) => {
+        return <Typography variant="body2">{params.row.serial || ''}</Typography>;
+      }
     },
     {
       field: 'critterbase_critter_id',
       headerName: 'Animal Alias',
       flex: 1,
       sortable: false,
-      renderCell: (params) => <Typography variant="body2">{params.row.critterbase_critter_id || 'N/A'}</Typography>
+      renderCell: (params) => {
+        const animalId = critterIdToAnimalIdMap.get(params.row.critterbase_critter_id);
+        // Show animal_id if found, otherwise show critterbase_critter_id as fallback, otherwise empty
+        const displayValue = animalId || params.row.critterbase_critter_id || '';
+        return <Typography variant="body2">{displayValue}</Typography>;
+      }
     },
     {
       field: 'device_make_id',
@@ -157,7 +180,7 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
         const deviceMake = codesContext.codesDataLoader.data?.telemetry_device_makes?.find(
           (make) => make.id === params.row.device_make_id
         );
-        return <Typography variant="body2">{deviceMake?.name || 'N/A'}</Typography>;
+        return <Typography variant="body2">{deviceMake?.name || ''}</Typography>;
       }
     },
     {
@@ -185,7 +208,7 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
       )
     },
     {
-      field: 'survey_id',
+      field: 'survey_id', // techdebt: when collections is merged into dev and project ids are no longer in urls, make this survey id into a link to the survey instead
       headerName: 'Survey ID',
       flex: 1,
       sortable: false,
@@ -217,10 +240,15 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
 
       <Box height="100vh" maxHeight="800px">
         <LoadingGuard
-          isLoading={!rows.length && (deploymentDataLoader.isLoading || !deploymentDataLoader.isReady)}
+          isLoading={
+            deploymentDataLoader.isLoading ||
+            !deploymentDataLoader.isReady ||
+            animalDataLoader.isLoading ||
+            !animalDataLoader.isReady
+          }
           isLoadingFallback={<SkeletonTable />}
           isLoadingFallbackDelay={100}
-          hasNoData={!rows.length}
+          hasNoData={!rows.length && deploymentDataLoader.isReady && animalDataLoader.isReady}
           hasNoDataFallback={
             <NoDataOverlay
               height="500px"
@@ -232,7 +260,7 @@ const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
           hasNoDataFallbackDelay={100}>
           <StyledDataGrid
             noRowsMessage="No deployments found"
-            loading={!rows.length && (deploymentDataLoader.isLoading || !deploymentDataLoader.isReady)}
+            loading={deploymentDataLoader.isLoading || animalDataLoader.isLoading}
             // Columns
             columns={columns}
             // Rows

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
@@ -16,13 +16,15 @@ import { useCodesContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
 import { useSearchParams } from 'hooks/useSearchParams';
-import { IAllDeploymentAdvancedFilters, TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
+import { TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
+
 import { useState } from 'react';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
 import { firstOrNull } from 'utils/Utils';
 import {
   DeploymentAdvancedFiltersInitialValues,
   DeploymentListFilterForm,
+  IAllDeploymentAdvancedFilters,
   IAllDeploymentAdvancedFilters as IFormDeploymentAdvancedFilters
 } from './DeploymentListFilterForm';
 

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
@@ -1,0 +1,281 @@
+import { mdiArrowTopRight } from '@mdi/js';
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import grey from '@mui/material/colors/grey';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import { GridColDef, GridPaginationModel, GridSortDirection, GridSortModel } from '@mui/x-data-grid';
+import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
+import { LoadingGuard } from 'components/loading/LoadingGuard';
+import { SkeletonTable } from 'components/loading/SkeletonLoaders';
+import { NoDataOverlay } from 'components/overlay/NoDataOverlay';
+import { DATE_FORMAT } from 'constants/dateTimeFormats';
+import dayjs from 'dayjs';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import { useCodesContext } from 'hooks/useContext';
+import useDataLoader from 'hooks/useDataLoader';
+import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
+import { useSearchParams } from 'hooks/useSearchParams';
+import { IAllDeploymentAdvancedFilters, TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
+import { useState } from 'react';
+import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
+import { firstOrNull } from 'utils/Utils';
+import {
+  DeploymentAdvancedFiltersInitialValues,
+  DeploymentListFilterForm,
+  IAllDeploymentAdvancedFilters as IFormDeploymentAdvancedFilters
+} from './DeploymentListFilterForm';
+
+// Supported URL parameters
+// Note: Prefix 't_' is used to avoid conflicts with similar query params from other components
+type DeploymentDataTableURLParams = {
+  // filter
+  t_keyword?: string;
+  t_itis_tsn?: string;
+  t_start_date?: string;
+  t_end_date?: string;
+  t_system_user_id?: number;
+  t_device_serial?: string;
+  t_species?: string;
+  t_animal_alias?: string;
+  // pagination
+  t_page?: string;
+  t_limit?: string;
+  t_sort?: string;
+  t_order?: 'asc' | 'desc';
+};
+
+const pageSizeOptions = [10, 25, 50];
+
+interface IAllDeploymentListContainerProps {
+  showSearch: boolean;
+}
+
+// Default pagination parameters
+const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
+  page: 0,
+  limit: 10,
+  sort: 'acquisition_date',
+  order: 'desc'
+};
+
+/**
+ * Displays a list of deployment.
+ *
+ * @return {*}
+ */
+const DeploymentListContainer = (props: IAllDeploymentListContainerProps) => {
+  const { showSearch } = props;
+
+  const biohubApi = useBiohubApi();
+  const codesContext = useCodesContext();
+
+  const { searchParams, setSearchParams } = useSearchParams<StringValues<DeploymentDataTableURLParams>>();
+
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    pageSize: Number(searchParams.get('t_limit') ?? initialPaginationParams.limit),
+    page: Number(searchParams.get('t_page') ?? initialPaginationParams.page)
+  });
+
+  const [sortModel, setSortModel] = useState<GridSortModel>([
+    {
+      field: searchParams.get('t_sort') ?? initialPaginationParams.sort ?? '',
+      sort: (searchParams.get('t_order') ?? initialPaginationParams.order) as GridSortDirection
+    }
+  ]);
+
+  const [advancedFiltersModel, setAdvancedFiltersModel] = useState<IFormDeploymentAdvancedFilters>({
+    keyword: searchParams.get('t_keyword') ?? DeploymentAdvancedFiltersInitialValues.keyword,
+    itis_tsn: searchParams.get('t_itis_tsn')
+      ? Number(searchParams.get('t_itis_tsn'))
+      : DeploymentAdvancedFiltersInitialValues.itis_tsn,
+    start_date: searchParams.get('t_start_date') ?? DeploymentAdvancedFiltersInitialValues.start_date,
+    end_date: searchParams.get('t_end_date') ?? DeploymentAdvancedFiltersInitialValues.end_date,
+    system_user_id: searchParams.get('t_system_user_id')
+      ? Number(searchParams.get('t_system_user_id'))
+      : DeploymentAdvancedFiltersInitialValues.system_user_id
+  });
+
+  const sort = firstOrNull(sortModel);
+  const paginationSort: ApiPaginationRequestOptions = {
+    limit: paginationModel.pageSize,
+    sort: sort?.field || undefined,
+    order: sort?.sort || undefined,
+    page: paginationModel.page + 1 // API pagination pages begin at 1, but MUI DataGrid pagination begins at 0.
+  };
+
+  const deploymentDataLoader = useDataLoader(
+    (pagination?: ApiPaginationRequestOptions, filter?: IAllDeploymentAdvancedFilters) =>
+      biohubApi.telemetryDeployment.findTelemetryDeployment(pagination, filter)
+  );
+
+  useDeepCompareEffect(() => {
+    deploymentDataLoader.refresh(paginationSort, advancedFiltersModel);
+  }, [advancedFiltersModel, paginationSort]);
+
+  const rows = deploymentDataLoader.data?.deployments ?? [];
+
+  const columns: GridColDef<TelemetryDeployment>[] = [
+    {
+      field: 'deployment_id',
+      headerName: 'ID',
+      minWidth: 200,
+      sortable: false,
+      renderHeader: () => (
+        <Typography color={grey[500]} variant="body2" fontWeight={700}>
+          ID
+        </Typography>
+      ),
+      renderCell: (params) => (
+        <Typography color={grey[500]} variant="body2">
+          {params.row.deployment_id}
+        </Typography>
+      )
+    },
+    {
+      field: 'serial',
+      headerName: 'Device Serial',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => <Typography variant="body2">{params.row.serial}</Typography>
+    },
+    {
+      field: 'critterbase_critter_id',
+      headerName: 'Animal Alias',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => <Typography variant="body2">{params.row.critterbase_critter_id || 'N/A'}</Typography>
+    },
+    {
+      field: 'device_make_id',
+      headerName: 'Device Make',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => {
+        const deviceMake = codesContext.codesDataLoader.data?.telemetry_device_makes?.find(
+          (make) => make.id === params.row.device_make_id
+        );
+        return <Typography variant="body2">{deviceMake?.name || 'N/A'}</Typography>;
+      }
+    },
+    {
+      field: 'attachment_start_date',
+      headerName: 'Deployment Start',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => (
+        <Typography variant="body2">
+          {dayjs(params.row.attachment_start_date).format(DATE_FORMAT.MediumDateTimeFormat)}
+        </Typography>
+      )
+    },
+    {
+      field: 'attachment_end_date',
+      headerName: 'Deployment End',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => (
+        <Typography variant="body2">
+          {params.row.attachment_end_date
+            ? dayjs(params.row.attachment_end_date).format(DATE_FORMAT.MediumDateTimeFormat)
+            : 'Ongoing'}
+        </Typography>
+      )
+    },
+    {
+      field: 'survey_id',
+      headerName: 'Survey ID',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => <Typography variant="body2">{params.row.survey_id}</Typography>
+    }
+  ];
+
+  return (
+    <>
+      <Collapse in={showSearch}>
+        <Box py={2} px={2}>
+          <DeploymentListFilterForm
+            initialValues={advancedFiltersModel}
+            handleSubmit={(values) => {
+              setSearchParams(
+                searchParams
+                  .setOrDelete('t_keyword', values.keyword)
+                  .setOrDelete('t_itis_tsn', values.itis_tsn)
+                  .setOrDelete('t_start_date', values.start_date)
+                  .setOrDelete('t_end_date', values.end_date)
+                  .setOrDelete('t_system_user_id', values.system_user_id)
+              );
+              setAdvancedFiltersModel(values);
+            }}
+          />
+        </Box>
+        <Divider />
+      </Collapse>
+
+      <Box height="100vh" maxHeight="800px">
+        <LoadingGuard
+          isLoading={!rows.length && (deploymentDataLoader.isLoading || !deploymentDataLoader.isReady)}
+          isLoadingFallback={<SkeletonTable />}
+          isLoadingFallbackDelay={100}
+          hasNoData={!rows.length}
+          hasNoDataFallback={
+            <NoDataOverlay
+              height="500px"
+              title="Create or Join Surveys to See Deployment Data"
+              subtitle="You currently have no deployment data. Once you create or join surveys with deployment data, it will be displayed here"
+              icon={mdiArrowTopRight}
+            />
+          }
+          hasNoDataFallbackDelay={100}>
+          <StyledDataGrid
+            noRowsMessage="No deployments found"
+            loading={!rows.length && (deploymentDataLoader.isLoading || !deploymentDataLoader.isReady)}
+            // Columns
+            columns={columns}
+            // Rows
+            rows={rows}
+            rowCount={deploymentDataLoader.data?.pagination.total ?? 0}
+            getRowId={(row) => row.deployment_id}
+            // Pagination
+            paginationMode="server"
+            paginationModel={paginationModel}
+            pageSizeOptions={pageSizeOptions}
+            onPaginationModelChange={(model) => {
+              if (!model) {
+                return;
+              }
+              setSearchParams(searchParams.set('t_page', String(model.page)).set('t_limit', String(model.pageSize)));
+              setPaginationModel(model);
+            }}
+            // Sorting
+            sortingMode="server"
+            sortModel={sortModel}
+            sortingOrder={['asc', 'desc']}
+            onSortModelChange={(model) => {
+              if (!model.length) {
+                return;
+              }
+              setSearchParams(searchParams.set('t_sort', model[0].field).set('t_order', model[0].sort ?? 'desc'));
+              setSortModel(model);
+            }}
+            // Row options
+            rowSelection={false}
+            checkboxSelection={false}
+            disableRowSelectionOnClick
+            // Column options
+            disableColumnSelector
+            disableColumnFilter
+            disableColumnMenu
+            // Styling
+            rowHeight={70}
+            getRowHeight={() => 'auto'}
+            autoHeight={false}
+          />
+        </LoadingGuard>
+      </Box>
+    </>
+  );
+};
+
+export default DeploymentListContainer;

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListContainer.tsx
@@ -57,7 +57,7 @@ interface IAllDeploymentListContainerProps {
 const initialPaginationParams: Required<ApiPaginationRequestOptions> = {
   page: 0,
   limit: 10,
-  sort: 'acquisition_date',
+  sort: 'attachment_start_date',
   order: 'desc'
 };
 

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListFilterForm.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListFilterForm.tsx
@@ -1,0 +1,106 @@
+import { AnimalAutocompleteField } from 'components/fields/AnimalAutocompleteField';
+import CustomTextField from 'components/fields/CustomTextField';
+import SpeciesAutocompleteField from 'components/species/components/SpeciesAutocompleteField';
+import { FilterFieldsContainer } from 'features/summary/components/FilterFieldsContainer';
+import { Formik } from 'formik';
+import { useTaxonomyContext } from 'hooks/useContext';
+
+export type IAllDeploymentAdvancedFilters = {
+  keyword?: string;
+  itis_tsn?: number;
+  start_date?: string;
+  end_date?: string;
+  start_time?: string;
+  end_time?: string;
+  system_user_id?: number;
+  device_serial?: string;
+  species?: number;
+  animal_alias?: string;
+};
+
+export const DeploymentAdvancedFiltersInitialValues: IAllDeploymentAdvancedFilters = {
+  keyword: undefined,
+  itis_tsn: undefined,
+  start_date: undefined,
+  end_date: undefined,
+  start_time: undefined,
+  end_time: undefined,
+  system_user_id: undefined,
+  device_serial: undefined,
+  species: undefined,
+  animal_alias: undefined
+};
+
+export interface IAllDeploymentListFilterFormProps {
+  handleSubmit: (filterValues: IAllDeploymentAdvancedFilters) => void;
+  initialValues?: IAllDeploymentAdvancedFilters;
+}
+
+/**
+ * Deployment advanced filters
+ *
+ * @param {IAllDeploymentListFilterFormProps} props
+ * @return {*}
+ */
+export const DeploymentListFilterForm = (props: IAllDeploymentListFilterFormProps) => {
+  const { handleSubmit, initialValues } = props;
+
+  const taxonomyContext = useTaxonomyContext();
+
+  return (
+    <Formik initialValues={initialValues ?? DeploymentAdvancedFiltersInitialValues} onSubmit={handleSubmit}>
+      {(formikProps) => (
+        <FilterFieldsContainer
+          fields={[
+            <CustomTextField
+              name="keyword"
+              label="Keyword"
+              other={{
+                placeholder: 'Search by keyword'
+              }}
+              key="deployment-keyword-filter"
+            />,
+            <CustomTextField
+              name="device_serial"
+              label="Device Serial"
+              other={{
+                placeholder: 'Search by device serial number'
+              }}
+              key="deployment-device-serial-filter"
+            />,
+            <SpeciesAutocompleteField
+              formikFieldName="species"
+              label="Species"
+              placeholder="Search by species"
+              defaultSpecies={
+                (initialValues?.species &&
+                  taxonomyContext.getCachedSpeciesTaxonomyByIdAsync(Number(initialValues.species))) ||
+                undefined
+              }
+              handleSpecies={(value) => {
+                if (value?.tsn) {
+                  formikProps.setFieldValue('species', value.tsn);
+                }
+              }}
+              handleClear={() => {
+                formikProps.setFieldValue('species', undefined);
+              }}
+              key="deployment-species-filter"
+            />,
+            <AnimalAutocompleteField
+              formikFieldName="animal_alias"
+              label="Animal Alias"
+              placeholder="Search by animal nickname"
+              onSelect={(animal) => {
+                if (animal?.animal_id) {
+                  formikProps.setFieldValue('animal_alias', animal.animal_id);
+                }
+              }}
+              key="deployment-animal-alias-filter"
+            />
+          ]}
+        />
+      )}
+    </Formik>
+  );
+};

--- a/app/src/features/summary/tabular-data/deployments/DeploymentListFilterForm.tsx
+++ b/app/src/features/summary/tabular-data/deployments/DeploymentListFilterForm.tsx
@@ -52,22 +52,6 @@ export const DeploymentListFilterForm = (props: IAllDeploymentListFilterFormProp
       {(formikProps) => (
         <FilterFieldsContainer
           fields={[
-            <CustomTextField
-              name="keyword"
-              label="Keyword"
-              other={{
-                placeholder: 'Search by keyword'
-              }}
-              key="deployment-keyword-filter"
-            />,
-            <CustomTextField
-              name="device_serial"
-              label="Device Serial"
-              other={{
-                placeholder: 'Search by device serial number'
-              }}
-              key="deployment-device-serial-filter"
-            />,
             <SpeciesAutocompleteField
               formikFieldName="species"
               label="Species"
@@ -86,6 +70,14 @@ export const DeploymentListFilterForm = (props: IAllDeploymentListFilterFormProp
                 formikProps.setFieldValue('species', undefined);
               }}
               key="deployment-species-filter"
+            />,
+            <CustomTextField
+              name="device_serial"
+              label="Device Serial"
+              other={{
+                placeholder: 'Search by device serial number'
+              }}
+              key="deployment-device-serial-filter"
             />,
             <AnimalAutocompleteField
               formikFieldName="animal_alias"

--- a/app/src/features/surveys/telemetry/list/SurveyDeploymentListItemDetails.tsx
+++ b/app/src/features/surveys/telemetry/list/SurveyDeploymentListItemDetails.tsx
@@ -33,7 +33,9 @@ export const SurveyDeploymentListItemDetails = (props: ISurveyDeploymentListItem
   );
 
   useEffect(() => {
-    startCaptureDataLoader.load(deployment.critterbase_start_capture_id);
+    if (deployment.critterbase_start_capture_id) {
+      startCaptureDataLoader.load(deployment.critterbase_start_capture_id);
+    }
     if (deployment.critterbase_end_capture_id) {
       endCaptureDataLoader.load(deployment.critterbase_end_capture_id);
     }
@@ -48,6 +50,60 @@ export const SurveyDeploymentListItemDetails = (props: ISurveyDeploymentListItem
   const endDate = endCapture?.capture_date || endMortality?.mortality_timestamp || deployment.attachment_end_date;
 
   const endDateFormatted = endDate ? dayjs(endDate).format(DATE_FORMAT.MediumDateFormat) : null;
+
+  // If there's no start capture ID, we can't load capture data, so show deployment data instead
+  if (!deployment.critterbase_start_capture_id) {
+    const startDate = dayjs(deployment.attachment_start_date).format(DATE_FORMAT.MediumDateFormat);
+    const startTime = deployment.attachment_start_time;
+
+    const endTime =
+      endCapture?.capture_time ||
+      (endMortality?.mortality_timestamp &&
+        dayjs(endMortality?.mortality_timestamp).format(TIME_FORMAT.LongTimeFormat24Hour)) ||
+      deployment.attachment_end_time;
+
+    return (
+      <Box>
+        <Box display="flex" justifyContent="space-between" gap={1}>
+          <Box>
+            <Typography variant="subtitle2" color="textSecondary">
+              {'Start'}
+            </Typography>
+            <Typography variant="body2" fontWeight="bold">
+              {startDate}
+            </Typography>
+            {startTime && (
+              <Typography variant="body2" color="textSecondary">
+                {dayjs(`1970-01-01 ${startTime}`).format(TIME_FORMAT.LongTimeFormat24Hour)}
+              </Typography>
+            )}
+          </Box>
+
+          <Box textAlign="right">
+            <Typography variant="subtitle2" color="textSecondary">
+              {'End'}
+            </Typography>
+            {endDateFormatted ? (
+              <>
+                <Typography variant="body2" fontWeight="bold">
+                  {endDateFormatted}
+                </Typography>
+                {endTime && (
+                  <Typography variant="body2" color="textSecondary">
+                    {endTime}
+                  </Typography>
+                )}
+              </>
+            ) : (
+              <Typography variant="body2" fontWeight="bold" color="textSecondary">
+                {'Ongoing'}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
 
   if (startCaptureDataLoader.isLoading || !startCaptureDataLoader.isReady) {
     return <Skeleton width="100%" height="55px" />;

--- a/app/src/features/surveys/telemetry/manage/deployments/edit/EditDeploymentPage.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/edit/EditDeploymentPage.tsx
@@ -67,7 +67,7 @@ export const EditDeploymentPage = () => {
     attachment_start_time: deployment.attachment_start_time,
     attachment_end_date: deployment.attachment_end_date,
     attachment_end_time: deployment.attachment_end_time,
-    critterbase_start_capture_id: deployment.critterbase_start_capture_id,
+    critterbase_start_capture_id: deployment.critterbase_start_capture_id || '',
     critterbase_end_capture_id: deployment.critterbase_end_capture_id,
     critterbase_end_mortality_id: deployment.critterbase_end_mortality_id
   };

--- a/app/src/features/surveys/telemetry/manage/deployments/form/timeline/DeploymentStartForm.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/form/timeline/DeploymentStartForm.tsx
@@ -15,14 +15,14 @@ import yup from 'utils/YupSchema';
 export const DeploymentStartFormInitialValues: yup.InferType<typeof DeploymentStartFormYupSchema> = {
   attachment_start_date: null as unknown as string,
   attachment_start_time: null,
-  critterbase_start_capture_id: null as unknown as string
+  critterbase_start_capture_id: ''
 };
 
 export const DeploymentStartFormYupSchema = yup.object({
   attachment_start_date: yup.string().nullable().required('Start date is required'),
   attachment_start_time: yup.string().nullable().default(null),
 
-  critterbase_start_capture_id: yup.string().nullable().required('You must select the initial capture event')
+  critterbase_start_capture_id: yup.string().required('You must select the initial capture event')
 });
 
 interface IDeploymentStartFormProps {

--- a/app/src/features/surveys/telemetry/manage/deployments/table/DeploymentsTable.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/table/DeploymentsTable.tsx
@@ -38,7 +38,7 @@ export interface IDeploymentRowData {
   attachment_start_time: string | null;
   attachment_end_date: string | null;
   attachment_end_time: string | null;
-  critterbase_start_capture_id: string;
+  critterbase_start_capture_id: string | null;
   critterbase_end_capture_id: string | null;
   critterbase_end_mortality_id: string | null;
 }

--- a/app/src/hooks/api/useTelemetryDeploymentApi.ts
+++ b/app/src/hooks/api/useTelemetryDeploymentApi.ts
@@ -2,6 +2,8 @@ import { AxiosInstance } from 'axios';
 import {
   CreateTelemetryDeployment,
   GetSurveyDeploymentsResponse,
+  IAllDeploymentAdvancedFilters,
+  IFindTelemetryDeploymentResponse,
   TelemetryDeployment,
   UpdateTelemetryDeployment
 } from 'interfaces/useTelemetryDeploymentApi.interface';
@@ -132,12 +134,37 @@ export const useTelemetryDeploymentApi = (axios: AxiosInstance) => {
     return data;
   };
 
+  /**
+   * Get deployments for a system user id.
+   *
+   * @param {ApiPaginationRequestOptions} [pagination]
+   * @param {IAllDeploymentAdvancedFilters} filterFieldData
+   * @return {*} {Promise<IFindTelemetryDeploymentResponse>}
+   */
+  const findTelemetryDeployment = async (
+    pagination?: ApiPaginationRequestOptions,
+    filterFieldData?: IAllDeploymentAdvancedFilters
+  ): Promise<IFindTelemetryDeploymentResponse> => {
+    const params = {
+      ...pagination,
+      ...filterFieldData
+    };
+
+    const { data } = await axios.get('/api/deployments', {
+      params,
+      paramsSerializer: (params) => qs.stringify(params)
+    });
+
+    return data;
+  };
+
   return {
     createDeployment,
     updateDeployment,
     getDeploymentById,
     getDeploymentsInSurvey,
     deleteDeployment,
-    deleteDeployments
+    deleteDeployments,
+    findTelemetryDeployment
   };
 };

--- a/app/src/hooks/api/useTelemetryDeploymentApi.ts
+++ b/app/src/hooks/api/useTelemetryDeploymentApi.ts
@@ -1,8 +1,8 @@
 import { AxiosInstance } from 'axios';
+import { IAllDeploymentAdvancedFilters } from 'features/summary/tabular-data/deployments/DeploymentListFilterForm';
 import {
   CreateTelemetryDeployment,
   GetSurveyDeploymentsResponse,
-  IAllDeploymentAdvancedFilters,
   IFindTelemetryDeploymentResponse,
   TelemetryDeployment,
   UpdateTelemetryDeployment
@@ -150,7 +150,7 @@ export const useTelemetryDeploymentApi = (axios: AxiosInstance) => {
       ...filterFieldData
     };
 
-    const { data } = await axios.get('/api/deployments', {
+    const { data } = await axios.get('/api/deployment', {
       params,
       paramsSerializer: (params) => qs.stringify(params)
     });

--- a/app/src/interfaces/useTelemetryDeploymentApi.interface.ts
+++ b/app/src/interfaces/useTelemetryDeploymentApi.interface.ts
@@ -74,7 +74,7 @@ export type CreateTelemetryDeployment = {
   attachment_start_time: string | null;
   attachment_end_date: string | null;
   attachment_end_time: string | null;
-  critterbase_start_capture_id: string;
+  critterbase_start_capture_id: string | null;
   critterbase_end_capture_id: string | null;
   critterbase_end_mortality_id: string | null;
 };
@@ -91,7 +91,7 @@ export type UpdateTelemetryDeployment = {
   attachment_start_time: string | null;
   attachment_end_date: string | null;
   attachment_end_time: string | null;
-  critterbase_start_capture_id: string;
+  critterbase_start_capture_id: string | null;
   critterbase_end_capture_id: string | null;
   critterbase_end_mortality_id: string | null;
 };
@@ -114,7 +114,7 @@ export type TelemetryDeployment = {
   attachment_end_date: string | null;
   attachment_end_time: string | null;
   attachment_end_timestamp: string | null;
-  critterbase_start_capture_id: string;
+  critterbase_start_capture_id: string | null;
   critterbase_end_capture_id: string | null;
   critterbase_end_mortality_id: string | null;
   // device data

--- a/app/src/interfaces/useTelemetryDeploymentApi.interface.ts
+++ b/app/src/interfaces/useTelemetryDeploymentApi.interface.ts
@@ -1,6 +1,69 @@
 import { ApiPaginationResponseParams } from 'types/misc';
 
 /**
+ * Advanced filters for deployment search.
+ */
+export interface IAllDeploymentAdvancedFilters {
+  /**
+   * Filter results by system user id.
+   *
+   * @type {number}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  system_user_id?: number;
+  /**
+   * Filter results by deployment ids.
+   *
+   * @type {number[]}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  deployment_ids?: number[];
+  /**
+   * Filter results by survey ids.
+   *
+   * @type {number[]}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  survey_ids?: number[];
+  /**
+   * Filter results by keyword.
+   *
+   * @type {string}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  keyword?: string;
+  /**
+   * Filter results by device serial number.
+   *
+   * @type {string}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  device_serial?: string;
+  /**
+   * Filter results by species (ITIS TSN).
+   *
+   * @type {number}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  species?: number;
+  /**
+   * Filter results by animal alias/nickname.
+   *
+   * @type {string}
+   * @memberof IAllDeploymentAdvancedFilters
+   */
+  animal_alias?: string;
+}
+
+/**
+ * Response object for findTelemetryDeployment.
+ */
+export interface IFindTelemetryDeploymentResponse {
+  deployments: TelemetryDeployment[];
+  pagination: ApiPaginationResponseParams;
+}
+
+/**
  * Create telemetry deployment record.
  */
 export type CreateTelemetryDeployment = {

--- a/database/.gitignore
+++ b/database/.gitignore
@@ -24,3 +24,5 @@ coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+**/.vscode


### PR DESCRIPTION
## Links to Jira Tickets

- {Include a link to all applicable Jira tickets}

## Description of Changes

- Added deployments tab to the tabular data overview 

## Testing Notes

- Animals are not rendering in the animals overview table, and the mapping from critterbase critter id to animal alias are not working. unsure if this is a critterbase issue, it seems to not be returning data requested underneath any critterbase critter ids
- this also means we can't test the filtering on the alias' right now, or species
- future techdebt once collections is into dev and projects disappear out of the urls, we will make the surveyid columns into links 
- NOTE: do we like the way the table is displayed as a tab beside the other data types, or should it be nested inside telemetry? 
