### PR TITLE
SIMSBIOHUB-727: Update dockerfile to support Apple silicon

### DIFF
--- a/database/.docker/db/Dockerfile.setup
+++ b/database/.docker/db/Dockerfile.setup
@@ -10,14 +10,22 @@ ENV HOME=/opt/app-root/src
 
 RUN mkdir -p $HOME
 
-RUN chgrp -R 0 $HOME && \
-    chmod -R g+rwX $HOME
+# Local dev user (OpenShift will ignore USER at runtime anyway)
+RUN groupadd -g 1001 appuser || true && \
+    useradd -u 1001 -g 1001 -d "$HOME" appuser || true
 
 WORKDIR $HOME
 
 COPY . ./
 
-RUN npm ci --include=dev
+# Make everything owned by uid 1001, group 0, and group-writable
+RUN chown -R 1001:0 "$HOME" && \
+    chmod -R g+rwX "$HOME" && \
+    find "$HOME" -type d -exec chmod g+s {} \;
+
+# Install deps as root, then fix ownership again (node_modules etc.)
+RUN npm ci --include=dev && \
+    chown -R 1001:0 "$HOME"
 
 USER 1001
 


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-727](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-727)

## Description of Changes

Adjust DB Setup dockerfile to work with Apple silicon. I was encountering the following permissions error on a M4 Pro mac.

```
code EACCES
syscall open
path /opt/app-root/src/package.json
errno -13
Error: Could not read package.json: Error: EACCES: permission denied, open '/opt/app-root/src/package.json'
    at async open (node:internal/fs/promises:639:25)
    at async readFile (node:internal/fs/promises:1246:14)
    at async read (/usr/local/lib/node_modules/npm/node_modules/@npmcli/package-json/lib/read-package.js:9:18)
    at async PackageJson.load (/usr/local/lib/node_modules/npm/node_modules/@npmcli/package-json/lib/index.js:130:31)
    at async PackageJson.normalize (/usr/local/lib/node_modules/npm/node_modules/@npmcli/package-json/lib/index.js:116:5)
    at async #run (/usr/local/lib/node_modules/npm/lib/commands/run-script.js:85:13)
    at async RunScript.exec (/usr/local/lib/node_modules/npm/lib/commands/run-script.js:39:7)
    at async Npm.exec (/usr/local/lib/node_modules/npm/lib/npm.js:207:9)
    at async module.exports (/usr/local/lib/node_modules/npm/lib/cli/entry.js:74:5) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/opt/app-root/src/package.json'
}

npm error
The operation was rejected by your operating system.
It is likely you do not have the permissions to access this file as the current user

npm error
If you believe this might be a permissions issue, please double-check the
permissions of the file and its containing directories, or try running
the command again as root/Administrator.
Log files were not written due to an error writing to the directory: /opt/app-root/src/.npm/_logs
You can rerun the command with '--loglevel=verbose' to see the logs in your terminal
```

## Testing Notes

- Needs to be tested on a Windows machine to confirm compatibility
- Has been tested on an Intel and M4 Pro Mac
