### PR TITLE
SIMSBIOHUB-791: Fix capture attachment API schema validation and S3 delete errors

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
@@ -22,7 +22,7 @@ describe('deleteCritterCaptureAttachments', () => {
     const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const mockFindAttachments = sinon.stub(CritterAttachmentService.prototype, 'findAllCritterCaptureAttachments');
     const mockDeleteAttachments = sinon.stub(CritterAttachmentService.prototype, 'deleteCritterCaptureAttachments');
-    const mockBulkDeleteFilesFromS3 = sinon.stub(S3, 'bulkDeleteFilesFromS3');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3').resolves({} as any);
 
     mockFindAttachments.resolves([{ critter_capture_attachment_id: 1, key: 'DELETE_S3_KEY' }] as any[]);
     mockDeleteAttachments.resolves(['DELETE_S3_KEY']);
@@ -46,7 +46,7 @@ describe('deleteCritterCaptureAttachments', () => {
     expect(mockFindAttachments).to.have.been.calledOnceWithExactly(2, '123e4567-e89b-12d3-a456-426614174000');
     expect(mockDeleteAttachments).to.have.been.calledOnceWithExactly(2, [1]);
 
-    expect(mockBulkDeleteFilesFromS3).to.have.been.calledOnceWithExactly(['DELETE_S3_KEY']);
+    expect(mockDeleteFileFromS3).to.have.been.calledOnceWithExactly('DELETE_S3_KEY');
 
     expect(mockRes.status).to.have.been.calledWith(200);
     expect(mockRes.send).to.have.been.calledWith();

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
@@ -55,4 +55,128 @@ describe('deleteCritterCaptureAttachments', () => {
     expect(mockDBConnection.release).to.have.been.calledOnce;
     expect(mockDBConnection.rollback).to.not.have.been.called;
   });
+
+  it('deletes multiple attachments for a critter capture', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockFindAttachments = sinon.stub(CritterAttachmentService.prototype, 'findAllCritterCaptureAttachments');
+    const mockDeleteAttachments = sinon.stub(CritterAttachmentService.prototype, 'deleteCritterCaptureAttachments');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3').resolves({} as any);
+
+    mockFindAttachments.resolves([
+      { critter_capture_attachment_id: 1, key: 'DELETE_S3_KEY_1' },
+      { critter_capture_attachment_id: 2, key: 'DELETE_S3_KEY_2' }
+    ] as any[]);
+    mockDeleteAttachments.resolves(['DELETE_S3_KEY_1', 'DELETE_S3_KEY_2']);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = deleteCritterCaptureAttachments();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getDBConnectionStub).to.have.been.calledOnce;
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockFindAttachments).to.have.been.calledOnceWithExactly(2, '123e4567-e89b-12d3-a456-426614174000');
+    expect(mockDeleteAttachments).to.have.been.calledOnceWithExactly(2, [1, 2]);
+    expect(mockDeleteFileFromS3).to.have.been.calledTwice;
+    expect(mockDeleteFileFromS3).to.have.been.calledWith('DELETE_S3_KEY_1');
+    expect(mockDeleteFileFromS3).to.have.been.calledWith('DELETE_S3_KEY_2');
+    expect(mockRes.status).to.have.been.calledWith(200);
+    expect(mockRes.send).to.have.been.calledWith();
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('handles empty attachments array', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockFindAttachments = sinon.stub(CritterAttachmentService.prototype, 'findAllCritterCaptureAttachments');
+    const mockDeleteAttachments = sinon.stub(CritterAttachmentService.prototype, 'deleteCritterCaptureAttachments');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3');
+
+    mockFindAttachments.resolves([]);
+    mockDeleteAttachments.resolves([]);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = deleteCritterCaptureAttachments();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getDBConnectionStub).to.have.been.calledOnce;
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockFindAttachments).to.have.been.calledOnceWithExactly(2, '123e4567-e89b-12d3-a456-426614174000');
+    expect(mockDeleteAttachments).to.have.been.calledOnceWithExactly(2, []);
+    expect(mockDeleteFileFromS3).to.not.have.been.called;
+    expect(mockRes.status).to.have.been.calledWith(200);
+    expect(mockRes.send).to.have.been.calledWith();
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('catches and re-throws errors', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockError = new Error('test error');
+    const mockFindAttachments = sinon
+      .stub(CritterAttachmentService.prototype, 'findAllCritterCaptureAttachments')
+      .rejects(mockError);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = deleteCritterCaptureAttachments();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (err: any) {
+      expect(err.message).to.equal('test error');
+      expect(getDBConnectionStub).to.have.been.calledOnce;
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+      expect(mockFindAttachments).to.have.been.calledOnce;
+      expect(mockDBConnection.rollback).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+      expect(mockDBConnection.commit).to.not.have.been.called;
+    }
+  });
 });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.ts
@@ -4,7 +4,7 @@ import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../../../../../c
 import { getDBConnection } from '../../../../../../../../../../database/db';
 import { authorizeRequestHandler } from '../../../../../../../../../../request-handlers/security/authorization';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
-import { bulkDeleteFilesFromS3 } from '../../../../../../../../../../utils/file-utils';
+import { deleteFileFromS3 } from '../../../../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../../../../utils/logger';
 
 const defaultLog = getLogger(
@@ -119,8 +119,8 @@ export function deleteCritterCaptureAttachments(): RequestHandler {
       // Delete the attachments from the database
       await critterAttachmentService.deleteCritterCaptureAttachments(surveyId, attachmentIds);
 
-      // Delete the attachments from S3
-      await bulkDeleteFilesFromS3(s3Keys);
+      // Delete the attachments from S3 individually (using individual deletes to avoid Content-MD5 requirement)
+      await Promise.all(s3Keys.map((key) => deleteFileFromS3(key)));
 
       await connection.commit();
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
@@ -87,4 +87,184 @@ describe('uploadCaptureAttachments', () => {
     expect(mockDBConnection.release).to.have.been.calledOnce;
     expect(mockDBConnection.rollback).to.not.have.been.called;
   });
+
+  it('creates attachments without deleting any', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockUpsertAttachment = sinon.stub(CritterAttachmentService.prototype, 'upsertCritterCaptureAttachment');
+    const mockS3UploadFileToS3 = sinon.stub(S3, 'uploadFileToS3');
+    const mockS3GenerateS3FileKey = sinon.stub(S3, 'generateS3FileKey').returns('S3KEY');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3');
+
+    mockUpsertAttachment.resolves({ critter_capture_attachment_id: 1, key: 'S3KEY' });
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.files = [mockFile as Express.Multer.File];
+    mockReq.body = {};
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = uploadCaptureAttachments();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getDBConnectionStub).to.have.been.calledOnce;
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockDeleteFileFromS3).to.not.have.been.called;
+    expect(mockS3GenerateS3FileKey).to.have.been.calledOnce;
+    expect(mockUpsertAttachment).to.have.been.calledOnce;
+    expect(mockS3UploadFileToS3).to.have.been.calledOnce;
+    expect(mockRes.status).to.have.been.calledWith(200);
+    expect(mockRes.json).to.have.been.calledWith({ attachment_ids: [1] });
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('deletes attachments without uploading any', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockDeleteAttachments = sinon.stub(CritterAttachmentService.prototype, 'deleteCritterCaptureAttachments');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3').resolves({} as any);
+
+    mockDeleteAttachments.resolves(['DELETE_S3_KEY_1', 'DELETE_S3_KEY_2']);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.files = [];
+    mockReq.body = {
+      delete_ids: ['1', '2']
+    };
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = uploadCaptureAttachments();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getDBConnectionStub).to.have.been.calledOnce;
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockDeleteAttachments).to.have.been.calledOnceWithExactly(2, [1, 2]);
+    expect(mockDeleteFileFromS3).to.have.been.calledTwice;
+    expect(mockDeleteFileFromS3).to.have.been.calledWith('DELETE_S3_KEY_1');
+    expect(mockDeleteFileFromS3).to.have.been.calledWith('DELETE_S3_KEY_2');
+    expect(mockRes.status).to.have.been.calledWith(200);
+    expect(mockRes.json).to.have.been.calledWith({ attachment_ids: [] });
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('handles multiple file uploads', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockUpsertAttachment = sinon.stub(CritterAttachmentService.prototype, 'upsertCritterCaptureAttachment');
+    const mockS3UploadFileToS3 = sinon.stub(S3, 'uploadFileToS3');
+    const mockS3GenerateS3FileKey = sinon.stub(S3, 'generateS3FileKey');
+
+    mockS3GenerateS3FileKey.onFirstCall().returns('S3KEY1').onSecondCall().returns('S3KEY2');
+    mockUpsertAttachment
+      .onFirstCall()
+      .resolves({ critter_capture_attachment_id: 1, key: 'S3KEY1' })
+      .onSecondCall()
+      .resolves({ critter_capture_attachment_id: 2, key: 'S3KEY2' });
+
+    const mockFile2 = {
+      ...mockFile,
+      originalname: 'test2.txt'
+    };
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.files = [mockFile as Express.Multer.File, mockFile2 as Express.Multer.File];
+    mockReq.body = {};
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = uploadCaptureAttachments();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getDBConnectionStub).to.have.been.calledOnce;
+    expect(mockDBConnection.open).to.have.been.calledOnce;
+    expect(mockS3GenerateS3FileKey).to.have.been.calledTwice;
+    expect(mockUpsertAttachment).to.have.been.calledTwice;
+    expect(mockS3UploadFileToS3).to.have.been.calledTwice;
+    expect(mockRes.status).to.have.been.calledWith(200);
+    expect(mockRes.json).to.have.been.calledWith({ attachment_ids: [1, 2] });
+    expect(mockDBConnection.commit).to.have.been.calledOnce;
+    expect(mockDBConnection.release).to.have.been.calledOnce;
+  });
+
+  it('catches and re-throws errors', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: sinon.stub(),
+      commit: sinon.stub(),
+      release: sinon.stub(),
+      rollback: sinon.stub()
+    });
+
+    const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const mockError = new Error('test error');
+    const mockUpsertAttachment = sinon
+      .stub(CritterAttachmentService.prototype, 'upsertCritterCaptureAttachment')
+      .rejects(mockError);
+    const mockS3GenerateS3FileKey = sinon.stub(S3, 'generateS3FileKey').returns('S3KEY');
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.files = [mockFile as Express.Multer.File];
+    mockReq.body = {};
+    mockReq.params = {
+      projectId: '1',
+      surveyId: '2',
+      critterId: '3',
+      critterbaseCaptureId: '123e4567-e89b-12d3-a456-426614174000'
+    };
+
+    const requestHandler = uploadCaptureAttachments();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (err: any) {
+      expect(err.message).to.equal('test error');
+      expect(getDBConnectionStub).to.have.been.calledOnce;
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+      expect(mockS3GenerateS3FileKey).to.have.been.calledOnce;
+      expect(mockUpsertAttachment).to.have.been.calledOnce;
+      expect(mockDBConnection.rollback).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+      expect(mockDBConnection.commit).to.not.have.been.called;
+    }
+  });
 });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
@@ -33,7 +33,7 @@ describe('uploadCaptureAttachments', () => {
     const mockDeleteAttachments = sinon.stub(CritterAttachmentService.prototype, 'deleteCritterCaptureAttachments');
     const mockS3UploadFileToS3 = sinon.stub(S3, 'uploadFileToS3');
     const mockS3GenerateS3FileKey = sinon.stub(S3, 'generateS3FileKey').returns('S3KEY');
-    const mockBulkDeleteFilesFromS3 = sinon.stub(S3, 'bulkDeleteFilesFromS3');
+    const mockDeleteFileFromS3 = sinon.stub(S3, 'deleteFileFromS3').resolves({} as any);
 
     mockUpsertAttachment.resolves({ critter_capture_attachment_id: 1, key: 'S3KEY' });
     mockDeleteAttachments.resolves(['DELETE_S3_KEY']);
@@ -59,7 +59,7 @@ describe('uploadCaptureAttachments', () => {
     expect(mockDBConnection.open).to.have.been.calledOnce;
 
     expect(mockDeleteAttachments).to.have.been.calledOnceWithExactly(2, [1, 2]);
-    expect(mockBulkDeleteFilesFromS3).to.have.been.calledOnceWithExactly(['DELETE_S3_KEY']);
+    expect(mockDeleteFileFromS3).to.have.been.calledOnceWithExactly('DELETE_S3_KEY');
 
     expect(mockS3GenerateS3FileKey).to.have.been.calledOnceWithExactly({
       projectId: 1,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
@@ -6,7 +6,7 @@ import { fileSchema } from '../../../../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../../../../request-handlers/security/authorization';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
 import {
-  bulkDeleteFilesFromS3,
+  deleteFileFromS3,
   generateS3FileKey,
   uploadFileToS3
 } from '../../../../../../../../../../utils/file-utils';
@@ -167,8 +167,8 @@ export function uploadCaptureAttachments(): RequestHandler {
       if (deleteIds.length) {
         // Delete the attachments from the database and get the S3 keys
         const s3Keys = await critterAttachmentService.deleteCritterCaptureAttachments(surveyId, deleteIds);
-        // Bulk delete the files from S3
-        await bulkDeleteFilesFromS3(s3Keys);
+        // Delete the files from S3 individually (using individual deletes to avoid Content-MD5 requirement)
+        await Promise.all(s3Keys.map((key) => deleteFileFromS3(key)));
       }
 
       // Upload each file to S3 and store the file details in the database

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
@@ -5,11 +5,7 @@ import { getDBConnection } from '../../../../../../../../../../database/db';
 import { fileSchema } from '../../../../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../../../../request-handlers/security/authorization';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
-import {
-  deleteFileFromS3,
-  generateS3FileKey,
-  uploadFileToS3
-} from '../../../../../../../../../../utils/file-utils';
+import { deleteFileFromS3, generateS3FileKey, uploadFileToS3 } from '../../../../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../../../../utils/logger';
 
 const defaultLog = getLogger(

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.test.ts
@@ -134,6 +134,24 @@ describe('getSurveyCritter', () => {
       .stub(CritterAttachmentService.prototype, 'findAllCritterAttachments')
       .resolves(mockAttachments);
 
+    const transformedAttachments = [
+      {
+        attachment_id: 1,
+        attachment_type: 'photo' as const,
+        attachment_url: 'https://s3.example.com/signed-url',
+        critterbase_capture_id: '222-222-222',
+        critter_capture_attachment_id: 1,
+        file_name: 'moose_picture.jpg',
+        file_size: 100,
+        file_type: 'Other',
+        key: 'project/1/survey/1/critter/3/attachment/1'
+      }
+    ];
+
+    const transformCaptureAttachmentsStub = sinon
+      .stub(CritterAttachmentService.prototype, 'transformCaptureAttachmentsForResponse')
+      .resolves(transformedAttachments);
+
     const getCritterStub = sinon.stub(CritterbaseService.prototype, 'getCritter').resolves(mockCritterbaseCritter);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -152,11 +170,12 @@ describe('getSurveyCritter', () => {
 
     expect(getCritterByIdStub).to.have.been.calledOnce;
     expect(findAllCritterAttachmentsStub).to.have.been.calledOnce;
+    expect(transformCaptureAttachmentsStub).to.have.been.calledOnceWithExactly(mockAttachments.captureAttachments);
     expect(getCritterStub).to.have.been.calledOnce;
 
     expect(mockRes.status).to.have.been.calledWith(200);
     expect(mockRes.json).to.have.been.calledWith({
-      attachments: { capture_attachments: mockAttachments.captureAttachments },
+      attachments: { capture_attachments: transformedAttachments },
       ...mockCritterbaseCritter,
       ...mockSimsCritter
     });
@@ -295,6 +314,24 @@ describe('getSurveyCritter', () => {
       .stub(CritterAttachmentService.prototype, 'findAllCritterAttachments')
       .resolves(mockAttachments);
 
+    const transformedAttachments = [
+      {
+        attachment_id: 1,
+        attachment_type: 'photo' as const,
+        attachment_url: 'https://s3.example.com/signed-url',
+        critterbase_capture_id: '222-222-222',
+        critter_capture_attachment_id: 1,
+        file_name: 'moose_picture.jpg',
+        file_size: 100,
+        file_type: 'Other',
+        key: 'project/1/survey/1/critter/3/attachment/1'
+      }
+    ];
+
+    const transformCaptureAttachmentsStub = sinon
+      .stub(CritterAttachmentService.prototype, 'transformCaptureAttachmentsForResponse')
+      .resolves(transformedAttachments);
+
     // Fail to find external critterbase record
     const getCritterStub = sinon.stub(CritterbaseService.prototype, 'getCritter').resolves(undefined);
 
@@ -319,6 +356,7 @@ describe('getSurveyCritter', () => {
 
       expect(getCritterByIdStub).to.have.been.calledOnce;
       expect(findAllCritterAttachmentsStub).to.have.been.calledOnce;
+      expect(transformCaptureAttachmentsStub).to.have.been.calledOnceWithExactly(mockAttachments.captureAttachments);
       expect(getCritterStub).to.have.been.calledOnce;
 
       expect(mockDBConnection.rollback).to.have.been.called;

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.ts
@@ -368,8 +368,9 @@ export function getSurveyCritter(): RequestHandler {
 
       const getAttachmentsPromise = expand.includes('attachments')
         ? critterAttachmentService.findAllCritterAttachments(surveyCritter.critter_id).then(async (response) => {
-            const transformedCaptureAttachments =
-              await critterAttachmentService.transformCaptureAttachmentsForResponse(response.captureAttachments);
+            const transformedCaptureAttachments = await critterAttachmentService.transformCaptureAttachmentsForResponse(
+              response.captureAttachments
+            );
             return {
               attachments: {
                 capture_attachments: transformedCaptureAttachments

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.ts
@@ -265,7 +265,17 @@ GET.apiDoc = {
                     type: 'array',
                     items: {
                       type: 'object',
-                      required: ['attachment_id', 'attachment_type', 'attachment_url'],
+                      required: [
+                        'attachment_id',
+                        'attachment_type',
+                        'attachment_url',
+                        'critterbase_capture_id',
+                        'critter_capture_attachment_id',
+                        'file_name',
+                        'file_size',
+                        'file_type',
+                        'key'
+                      ],
                       additionalProperties: false,
                       properties: {
                         attachment_id: {
@@ -279,6 +289,28 @@ GET.apiDoc = {
                         attachment_url: {
                           type: 'string',
                           format: 'uri'
+                        },
+                        critterbase_capture_id: {
+                          type: 'string',
+                          format: 'uuid'
+                        },
+                        critter_capture_attachment_id: {
+                          type: 'integer',
+                          minimum: 1
+                        },
+                        file_name: {
+                          type: 'string',
+                          nullable: true
+                        },
+                        file_size: {
+                          type: 'integer',
+                          nullable: true
+                        },
+                        file_type: {
+                          type: 'string'
+                        },
+                        key: {
+                          type: 'string'
                         }
                       }
                     }
@@ -335,10 +367,12 @@ export function getSurveyCritter(): RequestHandler {
       }
 
       const getAttachmentsPromise = expand.includes('attachments')
-        ? critterAttachmentService.findAllCritterAttachments(surveyCritter.critter_id).then((response) => {
+        ? critterAttachmentService.findAllCritterAttachments(surveyCritter.critter_id).then(async (response) => {
+            const transformedCaptureAttachments =
+              await critterAttachmentService.transformCaptureAttachmentsForResponse(response.captureAttachments);
             return {
               attachments: {
-                capture_attachments: response.captureAttachments
+                capture_attachments: transformedCaptureAttachments
                 // TODO: add mortality attachments
               }
             };

--- a/api/src/services/critter-attachment-service.test.ts
+++ b/api/src/services/critter-attachment-service.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import * as S3 from '../utils/file-utils';
 import { getMockDBConnection } from '../__mocks__/db';
 import { CritterAttachmentService } from './critter-attachment-service';
 
@@ -99,6 +100,284 @@ describe('CritterCaptureAttachmentService', () => {
 
       expect(mockRepoMethod).to.have.been.calledOnceWithExactly(1);
       expect(result).to.deep.equal({ captureAttachments: [{ critter_attachment_id: 1, key: 'key' }] });
+    });
+  });
+
+  describe('transformCaptureAttachmentsForResponse', () => {
+    it('should transform photo attachments correctly', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/signed-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 1,
+          uuid: '111-111-111',
+          critter_id: 3,
+          critterbase_capture_id: '222-222-222',
+          file_type: 'Other',
+          file_name: 'moose_picture.jpg',
+          file_size: 100,
+          title: 'Moose 1',
+          description: 'Picture of a moose',
+          key: 'project/1/survey/1/critter/3/attachment/1'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/1');
+      expect(result).to.deep.equal([
+        {
+          attachment_id: 1,
+          attachment_type: 'photo',
+          attachment_url: 'https://s3.example.com/signed-url',
+          critterbase_capture_id: '222-222-222',
+          critter_capture_attachment_id: 1,
+          file_name: 'moose_picture.jpg',
+          file_size: 100,
+          file_type: 'Other',
+          key: 'project/1/survey/1/critter/3/attachment/1'
+        }
+      ]);
+    });
+
+    it('should transform video attachments correctly', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/video-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 2,
+          uuid: '222-222-222',
+          critter_id: 3,
+          critterbase_capture_id: '333-333-333',
+          file_type: 'Other',
+          file_name: 'moose_video.mp4',
+          file_size: 5000,
+          title: 'Moose Video',
+          description: 'Video of a moose',
+          key: 'project/1/survey/1/critter/3/attachment/2'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/2');
+      expect(result).to.deep.equal([
+        {
+          attachment_id: 2,
+          attachment_type: 'video',
+          attachment_url: 'https://s3.example.com/video-url',
+          critterbase_capture_id: '333-333-333',
+          critter_capture_attachment_id: 2,
+          file_name: 'moose_video.mp4',
+          file_size: 5000,
+          file_type: 'Other',
+          key: 'project/1/survey/1/critter/3/attachment/2'
+        }
+      ]);
+    });
+
+    it('should handle null file names and default to photo', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/signed-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 3,
+          uuid: '333-333-333',
+          critter_id: 3,
+          critterbase_capture_id: '444-444-444',
+          file_type: 'Other',
+          file_name: null,
+          file_size: 200,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/3'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/3');
+      expect(result[0].attachment_type).to.equal('photo');
+      expect(result[0].file_name).to.be.null;
+    });
+
+    it('should handle files without extensions and default to photo', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/signed-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 4,
+          uuid: '444-444-444',
+          critter_id: 3,
+          critterbase_capture_id: '555-555-555',
+          file_type: 'Other',
+          file_name: 'noextension',
+          file_size: 300,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/4'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/4');
+      expect(result[0].attachment_type).to.equal('photo');
+    });
+
+    it('should handle files with dot but no extension and default to photo', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/signed-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 5,
+          uuid: '555-555-555',
+          critter_id: 3,
+          critterbase_capture_id: '666-666-666',
+          file_type: 'Other',
+          file_name: 'file.',
+          file_size: 400,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/5'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/5');
+      expect(result[0].attachment_type).to.equal('photo');
+    });
+
+    it('should handle null S3 signed URLs', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves(null);
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 6,
+          uuid: '666-666-666',
+          critter_id: 3,
+          critterbase_capture_id: '777-777-777',
+          file_type: 'Other',
+          file_name: 'test.jpg',
+          file_size: 500,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/6'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(mockGetS3SignedURL).to.have.been.calledOnceWithExactly('project/1/survey/1/critter/3/attachment/6');
+      expect(result[0].attachment_url).to.equal('');
+    });
+
+    it('should handle empty attachments array', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const result = await service.transformCaptureAttachmentsForResponse([]);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should handle multiple attachments with different types', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon
+        .stub(S3, 'getS3SignedURL')
+        .onFirstCall()
+        .resolves('https://s3.example.com/photo-url')
+        .onSecondCall()
+        .resolves('https://s3.example.com/video-url');
+
+      const attachments = [
+        {
+          critter_capture_attachment_id: 7,
+          uuid: '777-777-777',
+          critter_id: 3,
+          critterbase_capture_id: '888-888-888',
+          file_type: 'Other',
+          file_name: 'photo.jpg',
+          file_size: 100,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/7'
+        },
+        {
+          critter_capture_attachment_id: 8,
+          uuid: '888-888-888',
+          critter_id: 3,
+          critterbase_capture_id: '999-999-999',
+          file_type: 'Other',
+          file_name: 'video.mov',
+          file_size: 2000,
+          title: null,
+          description: null,
+          key: 'project/1/survey/1/critter/3/attachment/8'
+        }
+      ];
+
+      const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+      expect(result).to.have.length(2);
+      expect(result[0].attachment_type).to.equal('photo');
+      expect(result[1].attachment_type).to.equal('video');
+      expect(mockGetS3SignedURL).to.have.been.calledTwice;
+    });
+
+    it('should handle different video extensions', async () => {
+      const connection = getMockDBConnection();
+      const service = new CritterAttachmentService(connection);
+
+      const mockGetS3SignedURL = sinon.stub(S3, 'getS3SignedURL').resolves('https://s3.example.com/signed-url');
+
+      const videoExtensions = ['test.mp4', 'test.mov', 'test.wmv', 'test.ave'];
+
+      for (const fileName of videoExtensions) {
+        const key = `project/1/survey/1/critter/3/attachment/${fileName}`;
+        const attachments = [
+          {
+            critter_capture_attachment_id: 9,
+            uuid: '999-999-999',
+            critter_id: 3,
+            critterbase_capture_id: 'aaa-aaa-aaa',
+            file_type: 'Other',
+            file_name: fileName,
+            file_size: 1000,
+            title: null,
+            description: null,
+            key: key
+          }
+        ];
+
+        const result = await service.transformCaptureAttachmentsForResponse(attachments);
+
+        expect(mockGetS3SignedURL).to.have.been.calledWith(key);
+        expect(result[0].attachment_type).to.equal('video', `Failed for ${fileName}`);
+      }
+
+      expect(mockGetS3SignedURL).to.have.been.callCount(videoExtensions.length);
     });
   });
 });

--- a/api/src/services/critter-attachment-service.ts
+++ b/api/src/services/critter-attachment-service.ts
@@ -8,6 +8,7 @@ import {
   CritterCaptureAttachmentPayload,
   CritterMortalityAttachmentPayload
 } from '../repositories/critter-attachment-repository.interface';
+import { getS3SignedURL } from '../utils/file-utils';
 import { DBService } from './db-service';
 
 /**
@@ -102,5 +103,82 @@ export class CritterAttachmentService extends DBService {
       this.attachmentRepository.findCaptureAttachmentsByCritterId(critterId)
     ]);
     return { captureAttachments };
+  }
+
+  /**
+   * Video file extensions that map to 'video' attachment type.
+   */
+  private static readonly VIDEO_EXTENSIONS = ['.mp4', '.mov', '.wmv', '.ave'];
+
+  /**
+   * Determines the attachment type (photo or video) based on the file name extension.
+   *
+   * @param {string | null} fileName - The file name
+   * @return {*}  {'photo' | 'video'}
+   */
+  private static getAttachmentType(fileName: string | null): 'photo' | 'video' {
+    if (!fileName) {
+      return 'photo'; // Default to photo if no file name
+    }
+
+    const lowerFileName = fileName.toLowerCase();
+    const lastDotIndex = lowerFileName.lastIndexOf('.');
+
+    // If no extension found, default to photo
+    if (lastDotIndex === -1 || lastDotIndex === lowerFileName.length - 1) {
+      return 'photo';
+    }
+
+    const extension = lowerFileName.substring(lastDotIndex);
+
+    if (CritterAttachmentService.VIDEO_EXTENSIONS.includes(extension)) {
+      return 'video';
+    }
+
+    // Default to photo for image extensions or unknown extensions
+    return 'photo';
+  }
+
+  /**
+   * Transforms capture attachment records to match the API schema.
+   *
+   * @param {CritterCaptureAttachmentRecord[]} attachments - The capture attachment records
+   * @return {*}  {Promise<Array<{attachment_id: number; attachment_type: 'photo' | 'video'; attachment_url: string; critterbase_capture_id: string; critter_capture_attachment_id: number; file_name: string | null; file_size: number | null; file_type: string; key: string}>>}
+   */
+  async transformCaptureAttachmentsForResponse(
+    attachments: CritterCaptureAttachmentRecord[]
+  ): Promise<
+    Array<{
+      attachment_id: number;
+      attachment_type: 'photo' | 'video';
+      attachment_url: string;
+      critterbase_capture_id: string;
+      critter_capture_attachment_id: number;
+      file_name: string | null;
+      file_size: number | null;
+      file_type: string;
+      key: string;
+    }>
+  > {
+    const transformedAttachments = await Promise.all(
+      attachments.map(async (attachment) => {
+        const attachmentUrl = await getS3SignedURL(attachment.key);
+        const attachmentType = CritterAttachmentService.getAttachmentType(attachment.file_name);
+
+        return {
+          attachment_id: attachment.critter_capture_attachment_id,
+          attachment_type: attachmentType,
+          attachment_url: attachmentUrl || '',
+          critterbase_capture_id: attachment.critterbase_capture_id,
+          critter_capture_attachment_id: attachment.critter_capture_attachment_id,
+          file_name: attachment.file_name,
+          file_size: attachment.file_size,
+          file_type: attachment.file_type,
+          key: attachment.key
+        };
+      })
+    );
+
+    return transformedAttachments;
   }
 }

--- a/api/src/services/critter-attachment-service.ts
+++ b/api/src/services/critter-attachment-service.ts
@@ -145,9 +145,7 @@ export class CritterAttachmentService extends DBService {
    * @param {CritterCaptureAttachmentRecord[]} attachments - The capture attachment records
    * @return {*}  {Promise<Array<{attachment_id: number; attachment_type: 'photo' | 'video'; attachment_url: string; critterbase_capture_id: string; critter_capture_attachment_id: number; file_name: string | null; file_size: number | null; file_type: string; key: string}>>}
    */
-  async transformCaptureAttachmentsForResponse(
-    attachments: CritterCaptureAttachmentRecord[]
-  ): Promise<
+  async transformCaptureAttachmentsForResponse(attachments: CritterCaptureAttachmentRecord[]): Promise<
     Array<{
       attachment_id: number;
       attachment_type: 'photo' | 'video';


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-791](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-791)

## Description of Changes

- **Fixed API schema validation error**: The GET endpoint for critter details with attachments was returning database fields that didn't match the expected API schema. The response now properly transforms capture attachments to include:
  - `attachment_id` (mapped from `critter_capture_attachment_id`)
  - `attachment_type` ('photo' or 'video', determined from file extension)
  - `attachment_url` (signed S3 URL)
  - `critterbase_capture_id` (for frontend filtering)
  - Additional required fields: `critter_capture_attachment_id`, `file_name`, `file_size`, `file_type`, `key`

- **Moved transformation logic to service layer**: Following the pattern used by survey attachments, moved the attachment transformation logic from the endpoint handler to `CritterAttachmentService.transformCaptureAttachmentsForResponse()` method. This includes:
  - `getAttachmentType()` helper method to determine photo vs video from file extension
  - Support for video extensions: `.mp4`, `.mov`, `.wmv`, `.ave`
  - Proper handling of null file names and files without extensions (defaults to 'photo')
  - Null S3 URL handling (defaults to empty string)

- **Fixed S3 delete error**: Changed from `bulkDeleteFilesFromS3` (DeleteObjectsCommand) to individual `deleteFileFromS3` (DeleteObjectCommand) calls to avoid the Content-MD5 header requirement that was causing errors when deleting attachments. This matches the pattern used elsewhere in the codebase (e.g., `project-service.ts`).

- **Comprehensive test coverage improvements**: Added extensive test coverage to address Codecov requirements:
  - **`transformCaptureAttachmentsForResponse` method** (9 new test cases):
    - Photo and video attachment transformation
    - Null file name handling
    - Files without extensions
    - Files with dot but no extension
    - Null S3 signed URL handling
    - Empty attachments array
    - Multiple attachments with different types
    - All video extension types (.mp4, .mov, .wmv, .ave)
  - **Upload endpoint** (4 new test cases):
    - Upload without delete
    - Delete without upload (multiple IDs)
    - Multiple file uploads
    - Error handling and rollback
  - **Delete endpoint** (2 new test cases):
    - Multiple attachments deletion
    - Empty attachments array handling
    - Error handling and rollback

## Testing Notes

- **Test Suite**: All 2476 tests passing with comprehensive coverage of new functionality
- **API Endpoint Testing**: 
  - Test GET `/project/{projectId}/survey/{surveyId}/critters/{critterId}?format=detailed&expand[]=attachments`
  - Verify that previously added attachments are returned with all required fields
  - Verify that `attachment_type` is correctly determined ('photo' for images, 'video' for video files)
  - Verify that `attachment_url` contains valid signed URLs
  - Verify that `critterbase_capture_id` is included for frontend filtering

- **Attachment Deletion Testing**:
  - Test removing an existing attachment from a capture and saving
  - Verify that the attachment is successfully deleted from both the database and S3
  - Verify no Content-MD5 errors occur during deletion
  - Test deleting multiple attachments simultaneously

- **Frontend Testing**:
  - Test adding attachments to a capture at `/admin/projects/{projectId}/surveys/{surveyId}/animals/{critterId}/capture/{captureId}/edit`
  - Verify that previously added attachments are displayed correctly in the attachment table
  - Verify that the DataGrid no longer shows the "missing id property" error
  - Verify that attachments can be downloaded and deleted successfully

- **Test Files**: All test files have been updated and are passing:
  - `critter-attachment-service.test.ts` - 9 new test cases for transformation logic
  - `upload.test.ts` - 4 new test cases for upload/delete scenarios
  - `index.test.ts` - 2 new test cases for delete endpoint
  - `index.test.ts` (critter endpoint) - Updated to match new schema