### PR TITLE
SIMSBIOHUB-851: Fix UUID casting error in survey publishing

### DIFF
--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -888,9 +888,9 @@ export class PostSampleTechniqueDetailToBiohubObject implements BioHubSubmission
   child_features: BioHubSubmissionFeature[];
 
   constructor(
-    techniqueAttributeQualitativeId: number | null,
+    techniqueAttributeQualitativeId: string | null,
     techniqueAttributeQualitativeOptionId: number | null,
-    techniqueAttributeQuantitativeId: number | null
+    techniqueAttributeQuantitativeId: string | null
   ) {
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.SAMPLE_TECHNIQUE_DETAIL;

--- a/api/src/models/sampling-technique-features.test.ts
+++ b/api/src/models/sampling-technique-features.test.ts
@@ -20,14 +20,14 @@ describe('Sampling Technique Features BioHub Integration', () => {
           {
             attribute_header: 'Duration',
             attribute_value: '30 days',
-            technique_attribute_qualitative_id: 10,
+            technique_attribute_qualitative_id: 'e0479006-f5ee-40cf-a33b-c1ffce393bf4',
             technique_attribute_qualitative_option_id: 20,
             technique_attribute_quantitative_id: null
           },
           {
             attribute_header: 'Flash Type',
             attribute_value: 'Infrared',
-            technique_attribute_qualitative_id: 11,
+            technique_attribute_qualitative_id: 'a1599008-f7ff-42ef-c55d-e3ffef5a5df6',
             technique_attribute_qualitative_option_id: 21,
             technique_attribute_quantitative_id: null
           }
@@ -96,7 +96,7 @@ describe('Sampling Technique Features BioHub Integration', () => {
             attribute_value: '20-20000 Hz',
             technique_attribute_qualitative_id: null,
             technique_attribute_qualitative_option_id: null,
-            technique_attribute_quantitative_id: 15
+            technique_attribute_quantitative_id: 'c3719010-f9ff-44ff-e77f-f5ffff7c7ff8'
           }
         ],
         vantage_data: [

--- a/api/src/models/sampling-technique-unit.test.ts
+++ b/api/src/models/sampling-technique-unit.test.ts
@@ -19,14 +19,14 @@ describe('PostSampleTechniqueToBiohubObject Unit Test', () => {
         {
           attribute_header: 'Duration',
           attribute_value: '30 days',
-          technique_attribute_qualitative_id: 10,
+          technique_attribute_qualitative_id: 'e0479006-f5ee-40cf-a33b-c1ffce393bf4',
           technique_attribute_qualitative_option_id: 20,
           technique_attribute_quantitative_id: null
         },
         {
           attribute_header: 'Flash Type',
           attribute_value: 'Infrared',
-          technique_attribute_qualitative_id: 11,
+          technique_attribute_qualitative_id: 'a1599008-f7ff-42ef-c55d-e3ffef5a5df6',
           technique_attribute_qualitative_option_id: 21,
           technique_attribute_quantitative_id: null
         }

--- a/api/src/models/telemetry-features.test.ts
+++ b/api/src/models/telemetry-features.test.ts
@@ -510,7 +510,7 @@ describe('Telemetry Features BioHub Integration', () => {
               attribute_value: '30 days',
               technique_attribute_qualitative_id: null,
               technique_attribute_qualitative_option_id: null,
-              technique_attribute_quantitative_id: 1
+              technique_attribute_quantitative_id: 'e0479006-f5ee-40cf-a33b-c1ffce393bf4'
             }
           ],
           vantage_data: [

--- a/api/src/repositories/survey-repository.ts
+++ b/api/src/repositories/survey-repository.ts
@@ -1489,7 +1489,7 @@ export class SurveyRepository extends BaseRepository {
                           NULL  -- If no value found, assign null
                       ),
                       'technique_attribute_qualitative_id', COALESCE(
-                          (SELECT (e2->>'technique_attribute_qualitative_id')::int FROM jsonb_array_elements(ad.attrib_qual_data) AS e2 WHERE e2->>'ah' = aa.attribute_name LIMIT 1),
+                          (SELECT e2->>'technique_attribute_qualitative_id' FROM jsonb_array_elements(ad.attrib_qual_data) AS e2 WHERE e2->>'ah' = aa.attribute_name LIMIT 1),
                           NULL
                       ),
                       'technique_attribute_qualitative_option_id', COALESCE(
@@ -1497,7 +1497,7 @@ export class SurveyRepository extends BaseRepository {
                           NULL
                       ),
                       'technique_attribute_quantitative_id', COALESCE(
-                          (SELECT (e2->>'technique_attribute_quantitative_id')::int FROM jsonb_array_elements(ad.attrib_quan_data) AS e2 WHERE e2->>'ah' = aa.attribute_name LIMIT 1),
+                          (SELECT e2->>'technique_attribute_quantitative_id' FROM jsonb_array_elements(ad.attrib_quan_data) AS e2 WHERE e2->>'ah' = aa.attribute_name LIMIT 1),
                           NULL
                       )
                   )

--- a/api/src/services/sample-technique-service.ts
+++ b/api/src/services/sample-technique-service.ts
@@ -18,9 +18,9 @@ export interface SampleTechniqueRecord {
   attribute_data: Array<{
     attribute_header: string;
     attribute_value: string;
-    technique_attribute_qualitative_id: number | null;
+    technique_attribute_qualitative_id: string | null;
     technique_attribute_qualitative_option_id: number | null;
-    technique_attribute_quantitative_id: number | null;
+    technique_attribute_quantitative_id: string | null;
   }>;
   vantage_data: Array<{
     vantage_header: string;


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-851](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-851)

## Description of Changes

- Fixed SQL query in `SurveyRepository.getSampleTechniquesBySurveyId()` that was incorrectly casting UUID fields to integers
  - Removed `::int` cast from `technique_attribute_qualitative_id` (UUID field)
  - Removed `::int` cast from `technique_attribute_quantitative_id` (UUID field)
  - Kept `::int` cast for `technique_attribute_qualitative_option_id` (INTEGER field, as per database schema)
- Updated TypeScript interfaces to match actual database schema:
  - `SampleTechniqueService.attribute_data`: Changed `technique_attribute_qualitative_id` and `technique_attribute_quantitative_id` from `number | null` to `string | null` (UUIDs)
  - `PostSampleTechniqueDetailToBiohubObject` constructor: Updated parameter types to accept `string | null` for UUID fields and `number | null` for integer field
- Updated test files to use correct data types (UUID strings for UUID fields, integers for integer fields)

The error occurred because the database schema uses UUIDs for `technique_attribute_qualitative_id` and `technique_attribute_quantitative_id`, but the SQL query was attempting to cast these UUID strings to integers, causing the error: `invalid input syntax for type integer: "e0479006-f5ee-40cf-a33b-c1ffce393bf4"`.

## Testing Notes

- All existing tests pass, including:
  - `PostSampleTechniqueToBiohubObject` unit tests
  - Sampling Technique Features BioHub Integration tests
  - `publishesSurvey` test (the main functionality affected)
  - Export Observation Strategy test (uses the same SQL query)
- The fix correctly handles:
  - UUID fields (`technique_attribute_qualitative_id`, `technique_attribute_quantitative_id`) as strings
  - Integer field (`technique_attribute_qualitative_option_id`) as numbers
- The codeset feature type does not need updates as it already handles both UUIDs and integers correctly by converting all IDs to strings
- Seed data is correct and does not need changes
- To test: Attempt to publish a survey that has sampling techniques with qualitative/quantitative attributes - it should now succeed without the UUID casting error