### PR TITLE
SIMSBIOHUB-855: Manage ClamAV via Helm

### DIFF
--- a/infrastructure/biohubbc/Chart.yaml
+++ b/infrastructure/biohubbc/Chart.yaml
@@ -20,6 +20,10 @@ dependencies:
     condition: database-setup.enabled
     dependsOn:
       - biohubbc-db
+  - name: biohubbc-clamav
+    repository: file://../clamav
+    version: 0.1.0
+    condition: clamav.enabled
   - name: biohubbc-api
     repository: file://../api
     version: 0.1.0

--- a/infrastructure/biohubbc/values-dev.yaml
+++ b/infrastructure/biohubbc/values-dev.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -104,6 +107,24 @@ biohubbc-db-setup:
   app:
     nodeEnv: development
 
+# Values passed to biohubbc-clamav subchart
+biohubbc-clamav:
+  environment:
+    licensePlate: "af2668"
+    name: dev
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohubbc-api subchart
 biohubbc-api:
   environment:
@@ -119,6 +140,12 @@ biohubbc-api:
     nodeOptions: --max_old_space_size=3000 # 75% of memoryLimit (bytes)
     appHost: dev-biohubbc.apps.silver.devops.gov.bc.ca
     featureFlags: ""
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
 
     # BioHub Platform (aka: Backbone)
     backboneInternalApiHost: "https://api-dev-biohub-platform.apps.silver.devops.gov.bc.ca"

--- a/infrastructure/biohubbc/values-pr.yaml
+++ b/infrastructure/biohubbc/values-pr.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: false  # PR previews share the DEV environment's ClamAV instance
+
 api:
   enabled: true
 
@@ -103,6 +106,12 @@ biohubbc-db-setup:
   app:
     nodeEnv: development
 
+# Values passed to biohubbc-clamav subchart
+# NOTE: ClamAV is DISABLED for PR previews to save resources.
+# PR previews share the DEV environment's ClamAV instance
+biohubbc-clamav:
+  enabled: false
+
 # Values passed to biohubbc-api subchart
 biohubbc-api:
   environment:
@@ -118,6 +127,12 @@ biohubbc-api:
     nodeOptions: --max_old_space_size=3000 # 75% of memoryLimit (bytes)
     # appHost will be dynamically set: "biohubbc-app-1234-af2668-dev.apps.silver.devops.gov.bc.ca"
     featureFlags: "" # Feature flags
+
+    # ClamAV - PR previews share the DEV environment's ClamAV instance
+    clamav:
+      enabled: true
+      host: clamav  # Use the shared DEV ClamAV service
+      port: 3310
     
     # BioHub Platform (aka: Backbone)
     backboneInternalApiHost: "https://api-dev-biohub-platform.apps.silver.devops.gov.bc.ca"

--- a/infrastructure/biohubbc/values-prod.yaml
+++ b/infrastructure/biohubbc/values-prod.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -97,6 +100,24 @@ biohubbc-db-setup:
   app:
     nodeEnv: production
 
+# Values passed to biohubbc-clamav subchart
+biohubbc-clamav:
+  environment:
+    licensePlate: "af2668"
+    name: prod
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohubbc-api subchart
 biohubbc-api:
   environment:
@@ -112,6 +133,12 @@ biohubbc-api:
     nodeOptions: --max_old_space_size=6000  # 75% of 8Gi memory limit
     appHost: sims.nrs.gov.bc.ca  # Vanity URL for prod
     featureFlags: API_FF_SUBMIT_BIOHUB,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK # Feature flags
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
 
     # BioHub Platform (aka: Backbone)
     backboneInternalApiHost: "https://api-biohub-platform.apps.silver.devops.gov.bc.ca"

--- a/infrastructure/biohubbc/values-test.yaml
+++ b/infrastructure/biohubbc/values-test.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -104,6 +107,24 @@ biohubbc-db-setup:
   app:
     nodeEnv: production # This is set to production as test is not a valid name in the Knexfile and to only run the procedures and not seed the database
 
+# Values passed to biohubbc-clamav subchart
+biohubbc-clamav:
+  environment:
+    licensePlate: "af2668"
+    name: test
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohubbc-api subchart
 biohubbc-api:
   environment:
@@ -119,6 +140,12 @@ biohubbc-api:
     nodeOptions: --max_old_space_size=3000 # 75% of memoryLimit (bytes)
     appHost: test-biohubbc.apps.silver.devops.gov.bc.ca
     featureFlags: ""
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
 
     # BioHub Platform (aka: Backbone)
     backboneInternalApiHost: "https://api-test-biohub-platform.apps.silver.devops.gov.bc.ca"

--- a/infrastructure/biohubbc/values.yaml
+++ b/infrastructure/biohubbc/values.yaml
@@ -20,6 +20,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -66,6 +69,18 @@ database-setup:
     changeId: ""
     ts: ""
   # Add any database-setup-specific overrides here
+
+clamav:
+  enabled: true
+  environment:
+    licensePlate: "af2668"
+    name: ""
+    id: ""
+    changeId: ""
+    ts: ""
+  app:
+    name: clamav
+  # Add any clamav-specific overrides here
 
 api:
   enabled: true

--- a/infrastructure/clamav/Chart.yaml
+++ b/infrastructure/clamav/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: biohubbc-clamav
+description: ClamAV antivirus service for SIMS BioHub BC
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infrastructure/clamav/templates/_helpers.tpl
+++ b/infrastructure/clamav/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/*
+Expand the name of the chart
+*/}}
+{{- define "clamav.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Namespace
+*/}}
+{{- define "environment.namespace" -}}
+{{- printf "%s-%s" .Values.environment.licensePlate .Values.environment.name }}
+{{- end }}
+
+{{/*
+Create app suffix
+If environment.id is "deploy" AND environment.name is "dev", the value should be "-dev-deploy"
+If environment.id is "deploy" AND environment.name is not "dev", the value should be "-ENV"
+If environment.id is not "deploy", the value should be "-dev-1234"
+*/}}
+{{- define "clamav.suffix" -}}
+{{- if and .Values.environment.id (eq (toString .Values.environment.id) "deploy") (eq .Values.environment.name "dev") }}
+{{- printf "-%s-%s" .Values.environment.name (toString .Values.environment.id) | trunc 63 | trimSuffix "-" }}
+{{- else if and .Values.environment.id (eq (toString .Values.environment.id) "deploy") (ne .Values.environment.name "dev") }}
+{{- printf "-%s" .Values.environment.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "-%s-%s" .Values.environment.name .Values.environment.changeId | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Note: ClamAV uses a simple name without environment suffix since each environment
+has its own namespace, avoiding any naming conflicts.
+*/}}
+{{- define "clamav.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.app.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label
+*/}}
+{{- define "clamav.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+Stable labels only - no changeId or ts. ClamAV rarely changes between deployments,
+so we avoid including deployment-specific values that would cause unnecessary churn
+in the Deployment object. Rollouts happen only when ClamAV config (image, resources, etc.) changes.
+*/}}
+{{- define "clamav.labels" -}}
+app: {{ include "clamav.fullname" . }}
+app-name: {{ .Values.app.name }}
+env-id: {{ .Values.environment.id | quote }}
+env-name: {{ .Values.environment.name | quote }}
+helm.sh/chart: {{ include "clamav.chart" . }}
+{{ include "clamav.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "clamav.annotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name | quote }}
+meta.helm.sh/release-namespace: {{ include "environment.namespace" . }}
+{{- end }}
+
+{{/*
+Selector labels
+Use stable env name only (dev/test/prod) - never changeId or ts.
+ClamAV pod template stays identical across deployments so no unnecessary rollouts.
+*/}}
+{{- define "clamav.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clamav.name" . }}
+app.kubernetes.io/instance: {{ .Values.environment.name | quote }}
+{{- end }}
+
+{{/*
+Image tag
+For static deployments (id=deploy), we use the environment name
+Otherwise we use the changeId (PR number)
+*/}}
+{{- define "clamav.imageTag" -}}
+{{- .Values.image.tag }}
+{{- end }}

--- a/infrastructure/clamav/templates/deployment.yaml
+++ b/infrastructure/clamav/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  namespace: {{ include "environment.namespace" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+  annotations:
+    {{- include "clamav.annotations" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      deployment: {{ include "clamav.fullname" . | quote }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        deployment: {{ include "clamav.fullname" . | quote }}
+        app: {{ include "clamav.fullname" . }}
+    spec:
+      containers:
+        - name: clamav
+          image: "{{ .Values.image.registry }}/{{ .Values.image.image }}:{{ include "clamav.imageTag" . }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 240
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 240
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/infrastructure/clamav/templates/service.yaml
+++ b/infrastructure/clamav/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  namespace: {{ include "environment.namespace" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+  annotations:
+    {{- include "clamav.annotations" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    deployment: {{ include "clamav.fullname" . | quote }}
+  sessionAffinity: None

--- a/infrastructure/clamav/values-dev.yaml
+++ b/infrastructure/clamav/values-dev.yaml
@@ -1,0 +1,14 @@
+# Development environment values for ClamAV
+environment:
+  name: dev
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values-pr.yaml
+++ b/infrastructure/clamav/values-pr.yaml
@@ -1,0 +1,14 @@
+# PR environment values for ClamAV (not used in static deploys)
+environment:
+  name: dev
+  id: ""
+
+# Openshift Resources - reduced for PR environments
+replicas: 1
+resources:
+  requests:
+    cpu: 50m
+    memory: 250Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi

--- a/infrastructure/clamav/values-prod.yaml
+++ b/infrastructure/clamav/values-prod.yaml
@@ -1,0 +1,14 @@
+# Production environment values for ClamAV
+environment:
+  name: prod
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values-test.yaml
+++ b/infrastructure/clamav/values-test.yaml
@@ -1,0 +1,14 @@
+# Test environment values for ClamAV
+environment:
+  name: test
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values.yaml
+++ b/infrastructure/clamav/values.yaml
@@ -1,0 +1,33 @@
+# Default values for clamav chart
+environment:
+  licensePlate: "af2668" # License plate of the project
+  name: "" # Environment name (dev, test, prod)
+  id: "" # Environment id (PR, deploy)
+  changeId: "" # Change id (PR number)
+  ts: "" # Timestamp of the deployment
+
+image:
+  registry: "image-registry.openshift-image-registry.svc:5000" # The base image registry URL
+  image: af2668-tools/clamav # Always pull from tools namespace
+  tag: "latest" # Use 'latest' tag which references the ImageStreamTag
+
+# ClamAV configuration
+app:
+  name: clamav
+
+# Openshift Resources
+replicas: ""
+resources:
+  requests:
+    cpu: ""
+    memory: ""
+  limits:
+    cpu: ""
+    memory: ""
+
+# Service configuration
+service:
+  type: ClusterIP
+  name: 3310-tcp
+  port: 3310
+  targetPort: 3310


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-855](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-855) – Integrate ClamAV with Helm for static deploys (DEV, TEST, PROD)

## Description of Changes

- **ClamAV Helm subchart** (`infrastructure/clamav/`): New chart that deploys ClamAV as a standard Kubernetes Deployment (replacing deprecated DeploymentConfig). Includes Deployment, Service, values for dev/test/prod/PR, and helpers.
- **Umbrella chart** (`infrastructure/biohubbc/`): Added `biohubbc-clamav` as a dependency; ClamAV is enabled for static deploys (dev, test, prod) and disabled for PR previews so they share the DEV `clamav` service.
- **Service naming**: ClamAV service name is `clamav` in all environments; each env has its own namespace so there are no conflicts.
- **Stable labels**: ClamAV chart does not use `changeId` or `ts` in labels, so ClamAV is not recreated on every deployment—only when ClamAV config (image, resources, etc.) changes.
- **API configuration**: DEV/TEST/PROD and PR values updated so the API connects to `clamav:3310` (and PR previews use the shared DEV instance).

## Testing Notes

- **Static deploy**: After merge to dev/test/prod, verify the static deploy workflow runs and ClamAV is deployed as `clamav` in the target namespace; API pods should have `CLAMAV_HOST=clamav` and `CLAMAV_PORT=3310`.
- **PR preview**: In dev namespace, confirm PR previews do not deploy a separate ClamAV and that PR API pods can reach the shared `clamav` service (e.g. `nc -zv clamav 3310` from an API pod).
- **No unnecessary rollouts**: After a few static deploys, confirm ClamAV pods are not recreated when only app/API changes (e.g. check pod age/restart count).
- **Migration**: When ready, remove existing DeploymentConfig `clamav` in each namespace after confirming the new Helm-managed Deployment is healthy and API connectivity works.
