### PR TITLE
SIMSBIOHUB-858: Add DOP to telemetry response schema

### DIFF
--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/index.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/index.ts
@@ -151,6 +151,11 @@ GET.apiDoc = {
                     temperature: {
                       type: 'number',
                       nullable: true
+                    },
+                    dop: {
+                      type: 'number',
+                      nullable: true,
+                      description: 'Dilution of Precision (pdop for Lotek, dop for Vectronic)'
                     }
                   }
                 }


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-858

## Description of Changes

- Added `dop` (Dilution of Precision) to the OpenAPI response schema for `GET /api/project/:projectId/survey/:surveyId/telemetry`.
- The API already returns `dop` from the telemetry vendor repository (pdop for Lotek, dop for Vectronic); the schema had `additionalProperties: false` but did not list `dop`, causing response validation to fail with 500 ("must NOT have additional properties").
- This fixes the 500 error when the telemetry list is refreshed after adding manual telemetry or after using the Import button on the telemetry details page.

## Testing Notes

- Add manual telemetry on `/admin/projects/1/surveys/1/telemetry/details` and confirm the list refreshes without a 500 (and the success message is accurate).
- Use the Import button to upload a valid telemetry CSV and confirm the list refreshes without a 500.
- Optional: call `GET /api/project/1/survey/1/telemetry?limit=25&sort=acquisition_date&order=desc&page=1` and confirm response is 200 and includes `dop` on telemetry items where applicable.
