### PR TITLE
SIMSBIOHUB-756: Show Vantage Accordion for Techniques

### DIFF
--- a/api/src/repositories/code-repository.ts
+++ b/api/src/repositories/code-repository.ts
@@ -551,7 +551,7 @@ export class CodeRepository extends BaseRepository {
   }
 
   /**
-   * Fetch vantages associated with vantages
+   * Fetch vantage methods as codes (id = vantage_method_id) for lookup by technique vantage_method_id.
    *
    * @return {*} {Promise<ICodeDescription[]>}
    * @memberof CodeRepository
@@ -559,11 +559,14 @@ export class CodeRepository extends BaseRepository {
   async getVantages(): Promise<ICodeDescription[]> {
     const sqlStatement = SQL`
       SELECT
-        vantage_category_id AS id,
-        name,
-        description
-      FROM vantage
-      WHERE record_end_date IS null;
+        vm.vantage_method_id AS id,
+        v.name,
+        COALESCE(v.description, '') AS description
+      FROM vantage_method vm
+      JOIN vantage v ON vm.vantage_id = v.vantage_id
+      WHERE v.record_end_date IS NULL
+        AND (vm.record_end_date IS NULL OR vm.record_end_date > CURRENT_DATE)
+      ORDER BY v.name ASC;
     `;
 
     const response = await this.connection.sql(sqlStatement, CodeDescription);

--- a/app/src/features/surveys/view/survey-sampling/components/technique/components/SurveyTechniqueCard.tsx
+++ b/app/src/features/surveys/view/survey-sampling/components/technique/components/SurveyTechniqueCard.tsx
@@ -37,6 +37,7 @@ export const SurveyTechniqueCard = ({
   const attributesCount =
     technique.attributes.qualitative_attributes.length + technique.attributes.quantitative_attributes.length;
   const attractantsCount = technique.attractants.length;
+  const vantageCount = technique.vantage_methods.length;
 
   return (
     <AccordionStandardCard
@@ -116,6 +117,29 @@ export const SurveyTechniqueCard = ({
           </Typography>
         )}
       </AccordionStandardCard>
+
+      {technique.vantage_methods.length > 0 ? (
+        <AccordionStandardCard
+          label={
+            <>
+              Vantage&nbsp;
+              <Typography component="span">({vantageCount})</Typography>
+            </>
+          }
+          colour={grey[200]}
+          sx={{ my: 2 }}>
+          <Stack gap={1} mb={2}>
+            {technique.vantage_methods.map((vantage) => {
+              const vantageLookupName =
+                codesDataLoader.data?.vantages.find((lookup) => lookup.id === vantage.vantage_method_id)?.name ?? '';
+
+              return (
+                <AccordionStandardCard key={vantage.vantage_method_id} label={vantageLookupName} colour={grey[300]} />
+              );
+            })}
+          </Stack>
+        </AccordionStandardCard>
+      ) : null}
     </AccordionStandardCard>
   );
 };


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-756?

## Description of Changes

- **Survey Technique card (Techniques section):** Added a Vantage accordion that appears when a technique has one or more vantage methods. The accordion shows the count in the header (e.g. "Vantage (2)") and lists each vantage method by name, resolved from the codes lookup. Uses the same styling and pattern as the existing Attributes and Attractants accordions in `SurveyTechniqueCard.tsx`.
- **Codes API fix:** Vantage names were not resolving because the codes API returned vantages with `id` = vantage_category_id while the UI looks up by vantage_method_id. Updated `getVantages()` in `api/src/repositories/code-repository.ts` to return vantages keyed by vantage_method_id (join vantage_method + vantage) so the technique card lookup works.
- **Files changed:** `app/src/features/surveys/view/survey-sampling/components/technique/components/SurveyTechniqueCard.tsx`, `api/src/repositories/code-repository.ts`.

## Testing Notes

- **Where to test:** Survey details → Techniques tab (first block). Expand a technique that has vantage methods assigned.
- **How to verify:** Confirm the "Vantage (n)" accordion appears below Attractants and shows vantage method names (e.g. helicopter, stationary fixture). When a technique has no vantage methods, the Vantage section does not appear.
- **Note:** After deploying, ensure the API is restarted so the updated codes response is used; the app refetches codes on full page load.