### PR TITLE
SIMSBIOHUB-747: Show Device Key in Deployment Table

### DIFF
--- a/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialDeploymentTable.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialDeploymentTable.tsx
@@ -21,6 +21,7 @@ interface ITelemetryData {
   id: number;
   critter_id: number | null;
   device_id: number;
+  device_key: string;
   frequency: number | null;
   frequency_unit: string | null;
   start_date: string;
@@ -109,6 +110,7 @@ export const SurveySpatialDeploymentTable = () => {
         critter_id: item.critter.critter_id,
         animal_id: item.critter.animal_id,
         device_id: item.deployment.device_id,
+        device_key: item.deployment.device_key,
         start_date: item.deployment.attachment_start_date
           ? dayjs(item.deployment.attachment_start_date).format(DATE_FORMAT.MediumDateFormat)
           : '',
@@ -141,6 +143,7 @@ export const SurveySpatialDeploymentTable = () => {
       renderCell: (param) => {
         return (
           <ScientificNameTypography
+            variant="body2"
             name={param.row.itis_scientific_name}
             textOverflow="ellipsis"
             noWrap
@@ -150,8 +153,8 @@ export const SurveySpatialDeploymentTable = () => {
       }
     },
     {
-      field: 'device_id',
-      headerName: 'Device ID',
+      field: 'device_key',
+      headerName: 'Device',
       flex: 1
     },
     {
@@ -160,7 +163,7 @@ export const SurveySpatialDeploymentTable = () => {
       flex: 1,
       renderCell: (param) => {
         return (
-          <Typography>
+          <Typography variant="body2">
             {param.row.frequency}&nbsp;
             <Typography component="span" color="textSecondary">
               {param.row.frequency_unit}


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-747

## Description of Changes

- Survey Spatial Deployment Table now shows **Device Key** (e.g. `lotek:12345`) instead of numeric Device ID in the deployment table.
- Added `device_key` to the table data interface and row mapping from `item.deployment.device_key`.
- Renamed column header from "Device ID" to "Device" and switched the column field from `device_id` to `device_key`.
- Set `variant="body2"` on ScientificNameTypography (Species) and Typography (Frequency) cells for consistent table typography.

## Testing Notes

- Open a survey with telemetry deployments and go to the Survey Spatial view.
- Confirm the deployment table shows the Device column with device key values (e.g. `lotek:123456`, `vectronic:12345`) instead of numeric device IDs.
- Confirm Species and Frequency cells still render correctly with the updated typography variant.