### PR TITLE
SIMSBIOHUB-752: Include Sampling Data in Habitat Feature Table

### DIFF
--- a/api/src/openapi/schemas/survey-habitat-feature.ts
+++ b/api/src/openapi/schemas/survey-habitat-feature.ts
@@ -286,12 +286,108 @@ export const SurveyHabitatFeaturesWithTaxonsSchema: OpenAPIV3.SchemaObject = {
 export const SurveyHabitatFeaturesSupplementaryDataSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   additionalProperties: false,
-  required: ['count', 'habitatFeatureQuantitativeDefinitions', 'habitatFeatureQualitativeDefinitions'],
+  required: ['count', 'habitatFeatureQuantitativeDefinitions', 'habitatFeatureQualitativeDefinitions', 'sampling_data'],
   properties: {
     count: {
       description: 'The total count of survey habitat features for the survey.',
       type: 'integer',
       minimum: 0
+    },
+    sampling_data: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: [
+          'survey_sample_period_id',
+          'survey_id',
+          'survey_sample_site_id',
+          'method_technique_id',
+          'start_date',
+          'start_time',
+          'end_date',
+          'end_time',
+          'method_technique',
+          'survey_sample_site'
+        ],
+        additionalProperties: false,
+        properties: {
+          survey_sample_period_id: {
+            type: 'integer',
+            minimum: 1
+          },
+          survey_id: {
+            type: 'integer',
+            minimum: 1
+          },
+          survey_sample_site_id: {
+            type: 'integer',
+            minimum: 1,
+            nullable: true
+          },
+          method_technique_id: {
+            type: 'integer',
+            minimum: 1,
+            nullable: true
+          },
+          start_date: {
+            type: 'string',
+            nullable: true
+          },
+          start_time: {
+            type: 'string',
+            nullable: true
+          },
+          end_date: {
+            type: 'string',
+            nullable: true
+          },
+          end_time: {
+            type: 'string',
+            nullable: true
+          },
+          survey_sample_site: {
+            type: 'object',
+            required: ['survey_sample_site_id', 'name'],
+            additionalProperties: false,
+            properties: {
+              survey_sample_site_id: {
+                type: 'integer',
+                minimum: 1
+              },
+              name: {
+                type: 'string'
+              }
+            },
+            nullable: true
+          },
+          method_technique: {
+            type: 'object',
+            description: 'Details about the technique of the survey sample period',
+            required: ['method_technique_id', 'name', 'description', 'method_response_metric_id'],
+            properties: {
+              method_technique_id: {
+                type: 'integer',
+                minimum: 1,
+                description: 'Primary key of the method technique record'
+              },
+              name: {
+                type: 'string',
+                description: 'Name of the method technique'
+              },
+              description: {
+                type: 'string',
+                description: 'Description of the method technique',
+                nullable: true
+              },
+              method_response_metric_id: {
+                type: 'integer',
+                minimum: 1
+              }
+            },
+            nullable: true
+          }
+        }
+      }
     },
     habitatFeatureQuantitativeDefinitions: {
       description: 'All quantitative habitat feature definitions for the survey habitat features.',

--- a/api/src/openapi/schemas/survey-habitat-feature.ts
+++ b/api/src/openapi/schemas/survey-habitat-feature.ts
@@ -286,14 +286,19 @@ export const SurveyHabitatFeaturesWithTaxonsSchema: OpenAPIV3.SchemaObject = {
 export const SurveyHabitatFeaturesSupplementaryDataSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
   additionalProperties: false,
-  required: ['count', 'habitatFeatureQuantitativeDefinitions', 'habitatFeatureQualitativeDefinitions', 'sampling_data'],
+  required: [
+    'count',
+    'habitatFeatureQuantitativeDefinitions',
+    'habitatFeatureQualitativeDefinitions',
+    'sampling_periods'
+  ],
   properties: {
     count: {
       description: 'The total count of survey habitat features for the survey.',
       type: 'integer',
       minimum: 0
     },
-    sampling_data: {
+    sampling_periods: {
       type: 'array',
       items: {
         type: 'object',

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.test.ts
@@ -192,6 +192,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       }
@@ -272,6 +273,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       },
@@ -347,6 +349,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       }
@@ -425,6 +428,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       },
@@ -500,6 +504,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       }
@@ -568,6 +573,7 @@ describe('getSurveyHabitatFeatures', () => {
       ],
       supplementaryData: {
         count: 59,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       },

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/{surveyHabitatFeatureId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/{surveyHabitatFeatureId}/index.test.ts
@@ -185,6 +185,7 @@ describe('getSurveyHabitatFeature', () => {
       surveyHabitatFeature: mockHabitatFeatureRecord,
       supplementaryData: {
         count: 1,
+        sampling_periods: [],
         habitatFeatureQuantitativeDefinitions: [],
         habitatFeatureQualitativeDefinitions: []
       }

--- a/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
+++ b/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
@@ -4,6 +4,7 @@ import { SurveyHabitatFeatureRecord } from '../../database-models/survey_habitat
 import { SurveyHabitatFeatureTaxonRecord } from '../../database-models/survey_habitat_feature_taxon';
 import { SurveySampleSiteRecord } from '../../database-models/survey_sample_site';
 import { GeoJSONPointZodSchema } from '../../zod-schema/geoJsonZodSchema';
+import { SurveySamplePeriodDetails } from '../sample-period-repository';
 import { FindHabitatFeatureDefinitions } from './habitat-feature-repository.interface';
 
 export type InsertSurveyHabitatFeatureTaxon = Pick<
@@ -42,7 +43,10 @@ export const SurveyHabitatFeatureCount = z.object({
 });
 export type SurveyHabitatFeatureCount = z.infer<typeof SurveyHabitatFeatureCount>;
 
-export type SurveyHabitatFeaturesSupplementaryData = SurveyHabitatFeatureCount & FindHabitatFeatureDefinitions;
+export type SurveyHabitatFeaturesSupplementaryData = SurveyHabitatFeatureCount &
+  FindHabitatFeatureDefinitions & {
+    sampling_data: SurveySamplePeriodDetails[];
+  };
 
 /**
  * An array of survey habitat features with supplementary data.

--- a/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
+++ b/api/src/repositories/habitat-feature-repository/survey-habitat-feature-repository.interface.ts
@@ -45,7 +45,7 @@ export type SurveyHabitatFeatureCount = z.infer<typeof SurveyHabitatFeatureCount
 
 export type SurveyHabitatFeaturesSupplementaryData = SurveyHabitatFeatureCount &
   FindHabitatFeatureDefinitions & {
-    sampling_data: SurveySamplePeriodDetails[];
+    sampling_periods: SurveySamplePeriodDetails[];
   };
 
 /**

--- a/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
+++ b/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
@@ -127,7 +127,7 @@ export class SurveyHabitatFeatureService extends DBService {
       surveyHabitatFeature: surveyHabitatFeature,
       supplementaryData: {
         count: 1,
-        sampling_data: samplePeriods,
+        sampling_periods: samplePeriods,
         habitatFeatureQuantitativeDefinitions:
           surveyHabitatFeatureTypeDefinitions.habitatFeatureQuantitativeDefinitions,
         habitatFeatureQualitativeDefinitions: surveyHabitatFeatureTypeDefinitions.habitatFeatureQualitativeDefinitions
@@ -189,7 +189,7 @@ export class SurveyHabitatFeatureService extends DBService {
       surveyHabitatFeatures: surveyHabitatFeatures,
       supplementaryData: {
         count: surveyHabitatFeaturesCount,
-        sampling_data: samplePeriods,
+        sampling_periods: samplePeriods,
         habitatFeatureQuantitativeDefinitions:
           surveyHabitatFeatureTypeDefinitions.habitatFeatureQuantitativeDefinitions,
         habitatFeatureQualitativeDefinitions: surveyHabitatFeatureTypeDefinitions.habitatFeatureQualitativeDefinitions

--- a/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
+++ b/api/src/services/habitat-feature-services/survey-habitat-feature-service.ts
@@ -16,6 +16,7 @@ import { getLogger } from '../../utils/logger';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 import { PlatformService } from '../platform-service';
+import { SamplePeriodService } from '../sample-period-service';
 import { HabitatFeatureService } from './habitat-feature-service';
 
 const defaultLog = getLogger('survey-habitat-feature-service');
@@ -30,11 +31,13 @@ const defaultLog = getLogger('survey-habitat-feature-service');
 export class SurveyHabitatFeatureService extends DBService {
   surveyHabitatFeatureRepository: SurveyHabitatFeatureRepository;
   platformService: PlatformService;
+  samplePeriodService: SamplePeriodService;
 
   constructor(connection: IDBConnection) {
     super(connection);
     this.surveyHabitatFeatureRepository = new SurveyHabitatFeatureRepository(connection);
     this.platformService = new PlatformService(connection);
+    this.samplePeriodService = new SamplePeriodService(connection);
   }
 
   /**
@@ -118,10 +121,13 @@ export class SurveyHabitatFeatureService extends DBService {
       this.getSurveyHabitatFeatureDefinitions(surveyId)
     ]);
 
+    const samplePeriods = await this.samplePeriodService.getSamplePeriodsForSurvey(surveyId);
+
     return {
       surveyHabitatFeature: surveyHabitatFeature,
       supplementaryData: {
         count: 1,
+        sampling_data: samplePeriods,
         habitatFeatureQuantitativeDefinitions:
           surveyHabitatFeatureTypeDefinitions.habitatFeatureQuantitativeDefinitions,
         habitatFeatureQualitativeDefinitions: surveyHabitatFeatureTypeDefinitions.habitatFeatureQualitativeDefinitions
@@ -167,19 +173,23 @@ export class SurveyHabitatFeatureService extends DBService {
     surveyId: number,
     pagination?: ApiPaginationOptions
   ): Promise<SurveyHabitatFeaturesWithSupplementaryData> {
-    const [surveyHabitatFeatures, surveyHabitatFeaturesCount, surveyHabitatFeatureTypeDefinitions] = await Promise.all([
-      // Fetch survey habitat feature records
-      this.getSurveyHabitatFeatures(surveyId, pagination),
-      // Fetch pagination count data
-      this.getSurveyHabitatFeaturesCount(surveyId),
-      // Fetch habitat feature definitions applicable to this survey
-      this.getSurveyHabitatFeatureDefinitions(surveyId)
-    ]);
+    const [surveyHabitatFeatures, surveyHabitatFeaturesCount, surveyHabitatFeatureTypeDefinitions, samplePeriods] =
+      await Promise.all([
+        // Fetch survey habitat feature records
+        this.getSurveyHabitatFeatures(surveyId, pagination),
+        // Fetch pagination count data
+        this.getSurveyHabitatFeaturesCount(surveyId),
+        // Fetch habitat feature definitions applicable to this survey
+        this.getSurveyHabitatFeatureDefinitions(surveyId),
+        // Fetch sampling periods applicable to this survey
+        this.samplePeriodService.getSamplePeriodsForSurvey(surveyId)
+      ]);
 
     return {
       surveyHabitatFeatures: surveyHabitatFeatures,
       supplementaryData: {
         count: surveyHabitatFeaturesCount,
+        sampling_data: samplePeriods,
         habitatFeatureQuantitativeDefinitions:
           surveyHabitatFeatureTypeDefinitions.habitatFeatureQuantitativeDefinitions,
         habitatFeatureQualitativeDefinitions: surveyHabitatFeatureTypeDefinitions.habitatFeatureQualitativeDefinitions

--- a/app/src/contexts/habitatFeatureTableContext.tsx
+++ b/app/src/contexts/habitatFeatureTableContext.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/x-data-grid';
 import { GridApiCommunity } from '@mui/x-data-grid/internals';
 import { SIMS_HABITAT_FEATURES_HIDDEN_COLUMNS } from 'constants/session-storage';
+import { useSamplingInformationCache } from 'features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache';
 import { HABITAT_FEATURE_TABLE_PAGE_SIZES } from 'features/surveys/habitat-features/components/tables/SurveyHabitatFeatureTable';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useSurveyContext } from 'hooks/useContext';
@@ -120,6 +121,7 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
   const { projectId, surveyId } = useSurveyContext();
 
   const [rowSelectionModel, setRowSelectionModel] = useState<GridRowSelectionModel>([]);
+  const samplingInformationCache = useSamplingInformationCache();
 
   // Stores the column visibility state in local storage
   const [columnVisibilityModel, setColumnVisibilityModel] = usePersistentState<GridColumnVisibilityModel>(
@@ -241,6 +243,16 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
     }));
   }, [habitatFeatureDataLoader.data]);
 
+  useEffect(() => {
+    if (!habitatFeatureDataLoader.data?.supplementaryData.sampling_data?.length) {
+      return;
+    }
+
+    samplingInformationCache.initCachedSamplingInformationRef({
+      periods: habitatFeatureDataLoader.data.supplementaryData.sampling_data
+    });
+  }, [habitatFeatureDataLoader.data?.supplementaryData.sampling_data, samplingInformationCache]);
+
   // Create the columns for the table
   const habitatFeatureTableColumns: GridColDef<IHabitatFeatureRow>[] = useMemo(() => {
     const quantitativeColumns: GridColDef<IHabitatFeatureRow>[] =
@@ -298,7 +310,20 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
         headerName: 'Sample Period',
         align: 'left',
         minWidth: 200,
-        flex: 1
+        flex: 1,
+        valueGetter: (params) => {
+          const periodId = params.row.survey_sample_period_id;
+
+          if (!periodId) {
+            return '';
+          }
+
+          return (
+            samplingInformationCache.getCurrentPeriod(periodId)?.label ??
+            params.row.survey_sample_period_start_datetime ??
+            ''
+          );
+        }
       },
       {
         field: 'count',
@@ -344,7 +369,8 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
   }, [
     habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQualitativeDefinitions,
     habitatFeatureDataLoader.data?.supplementaryData.habitatFeatureQuantitativeDefinitions,
-    habitatFeatureTypeMap
+    habitatFeatureTypeMap,
+    samplingInformationCache
   ]);
 
   // Create the memoized context object

--- a/app/src/contexts/habitatFeatureTableContext.tsx
+++ b/app/src/contexts/habitatFeatureTableContext.tsx
@@ -244,14 +244,14 @@ export const HabitatFeatureTableContextProvider = (props: IHabitatFeatureTableCo
   }, [habitatFeatureDataLoader.data]);
 
   useEffect(() => {
-    if (!habitatFeatureDataLoader.data?.supplementaryData.sampling_data?.length) {
+    if (!habitatFeatureDataLoader.data?.supplementaryData.sampling_periods?.length) {
       return;
     }
 
     samplingInformationCache.initCachedSamplingInformationRef({
-      periods: habitatFeatureDataLoader.data.supplementaryData.sampling_data
+      periods: habitatFeatureDataLoader.data.supplementaryData.sampling_periods
     });
-  }, [habitatFeatureDataLoader.data?.supplementaryData.sampling_data, samplingInformationCache]);
+  }, [habitatFeatureDataLoader.data?.supplementaryData.sampling_periods, samplingInformationCache]);
 
   // Create the columns for the table
   const habitatFeatureTableColumns: GridColDef<IHabitatFeatureRow>[] = useMemo(() => {

--- a/app/src/features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache.test.tsx
+++ b/app/src/features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { useSamplingInformationCache } from 'features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache';
+import { GetSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
+
+const mockPeriod: GetSamplingPeriod = {
+  survey_sample_period_id: 1,
+  survey_id: 1,
+  survey_sample_site_id: 10,
+  method_technique_id: 20,
+  start_date: '2024-01-01',
+  start_time: '08:00:00',
+  end_date: '2024-01-02',
+  end_time: '17:00:00',
+  survey_sample_site: { survey_sample_site_id: 10, name: 'Site A' },
+  method_technique: {
+    method_technique_id: 20,
+    name: 'Technique A',
+    description: null,
+    method_response_metric_id: 1
+  }
+};
+
+describe('useSamplingInformationCache', () => {
+  describe('reference stability', () => {
+    it('returns the same object reference across re-renders', () => {
+      const { result, rerender } = renderHook(() => useSamplingInformationCache());
+
+      const first = result.current;
+      expect(first).toBeDefined();
+
+      rerender();
+      const second = result.current;
+      rerender();
+      const third = result.current;
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('returns the same function references across re-renders', () => {
+      const { result, rerender } = renderHook(() => useSamplingInformationCache());
+
+      const init1 = result.current.initCachedSamplingInformationRef;
+      const getPeriod1 = result.current.getCurrentPeriod;
+
+      rerender();
+      const init2 = result.current.initCachedSamplingInformationRef;
+      const getPeriod2 = result.current.getCurrentPeriod;
+
+      expect(init2).toBe(init1);
+      expect(getPeriod2).toBe(getPeriod1);
+    });
+  });
+
+  describe('behavior', () => {
+    it('initializes cache and getCurrentPeriod returns expected label', () => {
+      const { result } = renderHook(() => useSamplingInformationCache());
+
+      result.current.initCachedSamplingInformationRef({ periods: [mockPeriod] });
+
+      const period = result.current.getCurrentPeriod(1);
+      expect(period).not.toBeNull();
+      expect(period?.survey_sample_period_id).toBe(1);
+      expect(period?.label).toBeDefined();
+    });
+  });
+});

--- a/app/src/features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache.tsx
+++ b/app/src/features/surveys/habitat-features/components/forms/sampling-information/hooks/useSamplingInformationCache.tsx
@@ -1,11 +1,32 @@
 import { IAutocompleteFieldOption } from 'components/fields/AutocompleteField';
 import { GetSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
-import { MutableRefObject, useRef } from 'react';
+import { MutableRefObject, useMemo, useRef } from 'react';
 import { getDateTimeLabel } from 'utils/datetime';
 
 // TODO: Update to use the logic from the other useSamplingInformationCache file (deprecate this one?).
 // It has improved logic and is more up-to-date. Both caches could probably be merged, with the context specific
 // functions being moved to separate utils file or something similar.
+
+function _isValidSamplingSite(period: GetSamplingPeriod): period is GetSamplingPeriod & {
+  survey_sample_site_id: NonNullable<GetSamplingPeriod['survey_sample_site_id']>;
+  survey_sample_site: NonNullable<GetSamplingPeriod['survey_sample_site']>;
+} {
+  return period.survey_sample_site_id !== null && period.survey_sample_site !== null;
+}
+
+function _isValidMethodTechnique(period: GetSamplingPeriod): period is GetSamplingPeriod & {
+  method_technique_id: NonNullable<GetSamplingPeriod['method_technique_id']>;
+  method_technique: NonNullable<GetSamplingPeriod['method_technique']>;
+} {
+  return period.method_technique_id !== null && period.method_technique !== null;
+}
+
+function _isValidSamplingPeriod(period: GetSamplingPeriod): period is GetSamplingPeriod & {
+  start_date: NonNullable<GetSamplingPeriod['start_date']>;
+  end_date: NonNullable<GetSamplingPeriod['end_date']>;
+} {
+  return period.start_date !== null && period.end_date !== null;
+}
 
 export type SamplingInformationCachedSite = IAutocompleteFieldOption<number> & {
   survey_sample_site_id: number;
@@ -55,291 +76,134 @@ export type SamplingInformationCache = {
 export const useSamplingInformationCache = (): SamplingInformationCache => {
   const cachedSamplingInformationRef = useRef<SamplingInformationCacheRef>();
 
-  /**
-   * Initialize the cache with the provided sampling periods.
-   *
-   * @param {{ periods?: GetSamplingPeriod[] }} params
-   * @return {*}
-   */
-  const initCachedSamplingInformationRef = (params: { periods?: GetSamplingPeriod[] }) => {
-    if (!params.periods?.length) {
+  return useMemo(() => {
+    const initCachedSamplingInformationRef = (params: { periods?: GetSamplingPeriod[] }) => {
+      if (!params.periods?.length) {
+        cachedSamplingInformationRef.current = {
+          sites: new Map(),
+          techniques: new Map(),
+          periods: new Map()
+        };
+        return;
+      }
+      const sitesMap: Map<number, SamplingInformationCachedSite> = new Map();
+      const techniquesMap: Map<number, SamplingInformationCachedTechnique> = new Map();
+      const periodsMap: Map<number, SamplingInformationCachedPeriod> = new Map();
+      params.periods.forEach((period) => {
+        if (_isValidSamplingSite(period) && !sitesMap.has(period.survey_sample_site_id)) {
+          sitesMap.set(period.survey_sample_site_id, {
+            survey_sample_site_id: period.survey_sample_site_id,
+            value: period.survey_sample_site_id,
+            label: period.survey_sample_site.name
+          });
+        }
+        if (_isValidMethodTechnique(period) && !techniquesMap.has(period.method_technique.method_technique_id)) {
+          techniquesMap.set(period.method_technique.method_technique_id, {
+            method_technique_id: period.method_technique.method_technique_id,
+            survey_sample_site_id: period.survey_sample_site_id,
+            method_response_metric_id: period.method_technique.method_response_metric_id,
+            value: period.method_technique.method_technique_id,
+            label: period.method_technique.name
+          });
+        }
+        if (_isValidSamplingPeriod(period) && !periodsMap.has(period.survey_sample_period_id)) {
+          periodsMap.set(period.survey_sample_period_id, {
+            survey_sample_period_id: period.survey_sample_period_id,
+            survey_sample_site_id: period.survey_sample_site_id,
+            method_technique_id: period.method_technique_id,
+            value: period.survey_sample_period_id,
+            label: getDateTimeLabel(period.start_date, period.start_time, period.end_date, period.end_time)
+          });
+        }
+      });
+      cachedSamplingInformationRef.current = { sites: sitesMap, techniques: techniquesMap, periods: periodsMap };
+    };
+
+    const updateCachedSamplingSites = (sites: SamplingInformationCachedSite[]) => {
+      if (!cachedSamplingInformationRef.current) {
+        return;
+      }
+      const newSitesMap = cachedSamplingInformationRef.current.sites;
+      for (const site of sites) {
+        if (!newSitesMap.has(site.survey_sample_site_id)) {
+          newSitesMap.set(site.survey_sample_site_id, site);
+        }
+      }
       cachedSamplingInformationRef.current = {
-        sites: new Map(),
-        techniques: new Map(),
-        periods: new Map()
+        sites: newSitesMap,
+        techniques: cachedSamplingInformationRef.current.techniques,
+        periods: cachedSamplingInformationRef.current.periods
       };
-
-      return;
-    }
-
-    const sitesMap: Map<number, SamplingInformationCachedSite> = new Map();
-    const techniquesMap: Map<number, SamplingInformationCachedTechnique> = new Map();
-    const periodsMap: Map<number, SamplingInformationCachedPeriod> = new Map();
-
-    params.periods.forEach((period) => {
-      if (_isValidSamplingSite(period) && !sitesMap.has(period.survey_sample_site_id)) {
-        sitesMap.set(period.survey_sample_site_id, {
-          survey_sample_site_id: period.survey_sample_site_id,
-          // Satisfy the IAutocompleteDataGridOption interface
-          value: period.survey_sample_site_id,
-          label: period.survey_sample_site.name
-        });
-      }
-
-      if (_isValidMethodTechnique(period) && !techniquesMap.has(period.method_technique.method_technique_id)) {
-        techniquesMap.set(period.method_technique.method_technique_id, {
-          method_technique_id: period.method_technique.method_technique_id,
-          survey_sample_site_id: period.survey_sample_site_id,
-          method_response_metric_id: period.method_technique.method_response_metric_id,
-          // Satisfy the IAutocompleteDataGridOption interface
-          value: period.method_technique.method_technique_id,
-          label: period.method_technique.name
-        });
-      }
-
-      if (_isValidSamplingPeriod(period) && !periodsMap.has(period.survey_sample_period_id)) {
-        periodsMap.set(period.survey_sample_period_id, {
-          survey_sample_period_id: period.survey_sample_period_id,
-          survey_sample_site_id: period.survey_sample_site_id,
-          method_technique_id: period.method_technique_id,
-          // Satisfy the IAutocompleteDataGridOption interface
-          value: period.survey_sample_period_id,
-          label: getDateTimeLabel(period.start_date, period.start_time, period.end_date, period.end_time)
-        });
-      }
-    });
-
-    cachedSamplingInformationRef.current = {
-      sites: sitesMap,
-      techniques: techniquesMap,
-      periods: periodsMap
     };
-  };
 
-  /**
-   * Update the cache with new sampling sites. Will ignore sites that are already in the cache.
-   *
-   * @param {SamplingInformationCachedSite[]} sites
-   * @return {*}
-   */
-  const updateCachedSamplingSites = (sites: SamplingInformationCachedSite[]) => {
-    if (!cachedSamplingInformationRef.current) {
-      return;
-    }
-
-    const newSitesMap = cachedSamplingInformationRef.current.sites;
-
-    for (const site of sites) {
-      if (!newSitesMap.has(site.survey_sample_site_id)) {
-        newSitesMap.set(site.survey_sample_site_id, site);
+    const updateCachedMethodTechniques = (techniques: SamplingInformationCachedTechnique[]) => {
+      if (!cachedSamplingInformationRef.current) {
+        return;
       }
-    }
-
-    // Update the cache
-    cachedSamplingInformationRef.current = {
-      sites: newSitesMap,
-      techniques: cachedSamplingInformationRef.current.techniques,
-      periods: cachedSamplingInformationRef.current.periods
-    };
-  };
-
-  /**
-   * Update the cache with new method techniques. Will ignore techniques that are already in the cache.
-   *
-   * @param {SamplingInformationCachedTechnique[]} techniques
-   * @return {*}
-   */
-  const updateCachedMethodTechniques = (techniques: SamplingInformationCachedTechnique[]) => {
-    if (!cachedSamplingInformationRef.current) {
-      return;
-    }
-
-    const newTechniquesMap = cachedSamplingInformationRef.current.techniques;
-
-    for (const technique of techniques) {
-      if (!newTechniquesMap.has(technique.method_technique_id)) {
-        newTechniquesMap.set(technique.method_technique_id, technique);
+      const newTechniquesMap = cachedSamplingInformationRef.current.techniques;
+      for (const technique of techniques) {
+        if (!newTechniquesMap.has(technique.method_technique_id)) {
+          newTechniquesMap.set(technique.method_technique_id, technique);
+        }
       }
-    }
-
-    // Update the cache
-    cachedSamplingInformationRef.current = {
-      sites: cachedSamplingInformationRef.current.sites,
-      techniques: newTechniquesMap,
-      periods: cachedSamplingInformationRef.current.periods
+      cachedSamplingInformationRef.current = {
+        sites: cachedSamplingInformationRef.current.sites,
+        techniques: newTechniquesMap,
+        periods: cachedSamplingInformationRef.current.periods
+      };
     };
-  };
 
-  /**
-   * Update the cache with new sampling periods. Will ignore periods that are already in the cache.
-   *
-   * @param {SamplingInformationCachedPeriod[]} periods
-   * @return {*}
-   */
-  const updateCachedSamplingPeriods = (periods: SamplingInformationCachedPeriod[]) => {
-    if (!cachedSamplingInformationRef.current) {
-      return;
-    }
-
-    const newPeriodsMap = cachedSamplingInformationRef.current.periods;
-
-    for (const period of periods) {
-      if (!newPeriodsMap.has(period.survey_sample_period_id)) {
-        newPeriodsMap.set(period.survey_sample_period_id, period);
+    const updateCachedSamplingPeriods = (periods: SamplingInformationCachedPeriod[]) => {
+      if (!cachedSamplingInformationRef.current) {
+        return;
       }
-    }
-
-    // Update the cache
-    cachedSamplingInformationRef.current = {
-      sites: cachedSamplingInformationRef.current.sites,
-      techniques: cachedSamplingInformationRef.current.techniques,
-      periods: newPeriodsMap
+      const newPeriodsMap = cachedSamplingInformationRef.current.periods;
+      for (const period of periods) {
+        if (!newPeriodsMap.has(period.survey_sample_period_id)) {
+          newPeriodsMap.set(period.survey_sample_period_id, period);
+        }
+      }
+      cachedSamplingInformationRef.current = {
+        sites: cachedSamplingInformationRef.current.sites,
+        techniques: cachedSamplingInformationRef.current.techniques,
+        periods: newPeriodsMap
+      };
     };
-  };
 
-  /**
-   * Return the site object for the provided site id.
-   *
-   * @param {(number | null)} [siteId]
-   * @return {*}  {(SamplingInformationCachedSite | null)}
-   */
-  const findSite = (siteId?: number | null): SamplingInformationCachedSite | null => {
-    if (!siteId) {
-      return null;
-    }
+    const getCurrentSite = (surveySampleSiteId: number): SamplingInformationCachedSite | null =>
+      cachedSamplingInformationRef.current?.sites.get(surveySampleSiteId) ?? null;
 
-    return cachedSamplingInformationRef.current?.sites.get(siteId) ?? null;
-  };
+    const getCurrentTechnique = (methodTechniqueId: number): SamplingInformationCachedTechnique | null =>
+      cachedSamplingInformationRef.current?.techniques.get(methodTechniqueId) ?? null;
 
-  /**
-   * Return the technique object for the provided technique id.
-   *
-   * @param {(number | null)} [techniqueId]
-   * @return {*}  {(SamplingInformationCachedTechnique | null)}
-   */
-  const findTechnique = (techniqueId?: number | null): SamplingInformationCachedTechnique | null => {
-    if (!techniqueId) {
-      return null;
-    }
+    const getCurrentPeriod = (surveySamplePeriodId: number): SamplingInformationCachedPeriod | null =>
+      cachedSamplingInformationRef.current?.periods.get(surveySamplePeriodId) ?? null;
 
-    return cachedSamplingInformationRef.current?.techniques.get(techniqueId) ?? null;
-  };
+    const getTechniquesForRow = (surveySampleSiteId?: number | null): SamplingInformationCachedTechnique[] =>
+      surveySampleSiteId
+        ? Array.from(cachedSamplingInformationRef.current?.techniques.values() ?? []).filter(
+            (t) => t.survey_sample_site_id === surveySampleSiteId
+          )
+        : [];
 
-  /**
-   * Return the period object for the provided period id.
-   *
-   * @param {(number | null)} [periodId]
-   * @return {*}  {(SamplingInformationCachedPeriod | null)}
-   */
-  const findPeriod = (periodId?: number | null): SamplingInformationCachedPeriod | null => {
-    if (!periodId) {
-      return null;
-    }
+    const getPeriodsForRow = (methodTechniqueId?: number | null): SamplingInformationCachedPeriod[] =>
+      methodTechniqueId
+        ? Array.from(cachedSamplingInformationRef.current?.periods.values() ?? []).filter(
+            (p) => p.method_technique_id === methodTechniqueId
+          )
+        : [];
 
-    return cachedSamplingInformationRef.current?.periods.get(periodId) ?? null;
-  };
-
-  /**
-   * Get the currently selected site for the row.
-   *
-   * @template DataGridType
-   * @param {GridRenderCellParams<DataGridType>} dataGridProps
-   * @param {(MutableRefObject<SamplingInformationCacheRef | undefined>)} cachedSamplingInformationRef
-   * @return {*}  {(SamplingInformationCachedSite | null)}
-   */
-  const getCurrentSite = (surveySampleSiteId: number): SamplingInformationCachedSite | null => {
-    return findSite(surveySampleSiteId) ?? null;
-  };
-
-  /**
-   * Get the currently selected method technique for the row.
-   *
-   * @param {number} methodTechniqueId
-   * @return {*}  {(SamplingInformationCachedTechnique | null)}
-   */
-  const getCurrentTechnique = (methodTechniqueId: number): SamplingInformationCachedTechnique | null => {
-    return findTechnique(methodTechniqueId) ?? null;
-  };
-
-  /**
-   * Get the currently selected period for the row.
-   *
-   * @param {number} surveySamplePeriodId
-   * @return {*}  {(SamplingInformationCachedPeriod | null)}
-   */
-  const getCurrentPeriod = (surveySamplePeriodId: number): SamplingInformationCachedPeriod | null => {
-    return findPeriod(surveySamplePeriodId) ?? null;
-  };
-
-  /**
-   * Get all valid techniques for the currently selected site.
-   *
-   * @param {(number | null)} [surveySampleSiteId]
-   * @return {*}  {SamplingInformationCachedTechnique[]}
-   */
-  const getTechniquesForRow = (surveySampleSiteId?: number | null): SamplingInformationCachedTechnique[] => {
-    if (!surveySampleSiteId) {
-      return [];
-    }
-
-    return Array.from(cachedSamplingInformationRef.current?.techniques.values() ?? []).filter((technique) => {
-      return technique.survey_sample_site_id === surveySampleSiteId;
-    });
-  };
-
-  /**
-   * Get all valid periods for the currently selected site and technique.
-   *
-   * @param {(number | null)} [methodTechniqueId]
-   * @return {*}  {SamplingInformationCachedPeriod[]}
-   */
-  const getPeriodsForRow = (methodTechniqueId?: number | null): SamplingInformationCachedPeriod[] => {
-    if (!methodTechniqueId) {
-      return [];
-    }
-
-    return Array.from(cachedSamplingInformationRef.current?.periods.values() ?? []).filter((period) => {
-      return period.method_technique_id === methodTechniqueId;
-    });
-  };
-
-  const _isValidSamplingSite = (
-    period: GetSamplingPeriod
-  ): period is GetSamplingPeriod & {
-    survey_sample_site_id: NonNullable<GetSamplingPeriod['survey_sample_site_id']>;
-    survey_sample_site: NonNullable<GetSamplingPeriod['survey_sample_site']>;
-  } => {
-    return period.survey_sample_site_id !== null && period.survey_sample_site !== null;
-  };
-
-  const _isValidMethodTechnique = (
-    period: GetSamplingPeriod
-  ): period is GetSamplingPeriod & {
-    method_technique_id: NonNullable<GetSamplingPeriod['method_technique_id']>;
-    method_technique: NonNullable<GetSamplingPeriod['method_technique']>;
-  } => {
-    return period.method_technique_id !== null && period.method_technique !== null;
-  };
-
-  const _isValidSamplingPeriod = (
-    period: GetSamplingPeriod
-  ): period is GetSamplingPeriod & {
-    start_date: NonNullable<GetSamplingPeriod['start_date']>;
-    end_date: NonNullable<GetSamplingPeriod['end_date']>;
-  } => {
-    return period.start_date !== null && period.end_date !== null;
-  };
-
-  return {
-    cachedSamplingInformationRef,
-    initCachedSamplingInformationRef,
-    updateCachedSamplingSites,
-    updateCachedMethodTechniques,
-    updateCachedSamplingPeriods,
-    getCurrentSite,
-    getCurrentTechnique,
-    getCurrentPeriod,
-    getTechniquesForRow,
-    getPeriodsForRow
-  };
+    return {
+      cachedSamplingInformationRef,
+      initCachedSamplingInformationRef,
+      updateCachedSamplingSites,
+      updateCachedMethodTechniques,
+      updateCachedSamplingPeriods,
+      getCurrentSite,
+      getCurrentTechnique,
+      getCurrentPeriod,
+      getTechniquesForRow,
+      getPeriodsForRow
+    };
+  }, [cachedSamplingInformationRef]);
 };

--- a/app/src/interfaces/useSurveyHabitatFeatureApi.interface.ts
+++ b/app/src/interfaces/useSurveyHabitatFeatureApi.interface.ts
@@ -1,5 +1,6 @@
 import { Point } from 'geojson';
 import { ApiPaginationResponseParams } from 'types/misc';
+import { GetSamplingPeriod } from './useSamplingPeriodApi.interface';
 
 export type HabitatFeatureQuantitativeDefinition = {
   habitat_feature_quantitative_definition_id: string;
@@ -61,6 +62,7 @@ export type SurveyHabitatFeature = {
 
 export type SurveyHabitatFeatureSupplementaryData = {
   count: number;
+  sampling_data: GetSamplingPeriod[];
   habitatFeatureQuantitativeDefinitions: HabitatFeatureQuantitativeDefinition[];
   habitatFeatureQualitativeDefinitions: HabitatFeatureQualitativeDefinition[];
 };

--- a/app/src/interfaces/useSurveyHabitatFeatureApi.interface.ts
+++ b/app/src/interfaces/useSurveyHabitatFeatureApi.interface.ts
@@ -62,7 +62,7 @@ export type SurveyHabitatFeature = {
 
 export type SurveyHabitatFeatureSupplementaryData = {
   count: number;
-  sampling_data: GetSamplingPeriod[];
+  sampling_periods: GetSamplingPeriod[];
   habitatFeatureQuantitativeDefinitions: HabitatFeatureQuantitativeDefinition[];
   habitatFeatureQualitativeDefinitions: HabitatFeatureQualitativeDefinition[];
 };


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-752

## Description of Changes

- Adds sampling period data to the habitat feature API responses (list and single feature endpoints).
- Displays start and end date of the sampling period for each habitat feature observation in the Habitat Feature table (Sample Period column now shows a formatted date range when available, with fallback to raw datetime).
- Reuses existing sampling information cache and `getDateTimeLabel` so the table matches the format used elsewhere (e.g. observations).

## Testing Notes

- **Where:** Survey → Sampling → Habitat Features table (or the habitat features view that uses the same table).
- **Pre-reqs:** A survey with at least one habitat feature that has a sampling period (start/end date and optionally time).
- **Verify:**
  - Load the habitat feature table and confirm the **Sample Period** column shows a readable date range (e.g. start–end) for rows with a sampling period.
  - Rows without a sampling period or with null dates still show the raw `survey_sample_period_start_datetime` when present, or an empty cell.
  - Single habitat feature fetch (e.g. edit flow) returns `supplementaryData.sampling_periods` and the UI behaves correctly when opening that context.