### PR TITLE
SIMSBIOHUB-761: Fix Sampling Period Yup

### DIFF
--- a/app/src/features/surveys/habitat-features/components/forms/HabitatFeatureFormContainer.tsx
+++ b/app/src/features/surveys/habitat-features/components/forms/HabitatFeatureFormContainer.tsx
@@ -22,6 +22,8 @@ const HabitatFeatureYupSchema = yup
       .max(180, 'Longitude must be between -180 and 180'),
     observed_date: yup.string().nullable(),
     observed_time: yup.string().nullable(),
+    survey_sample_site_id: yup.number().nullable(),
+    method_technique_id: yup.number().nullable(),
     survey_sample_period_id: yup.number().nullable(),
     survey_habitat_feature_taxons: yup.array().of(
       yup.object({
@@ -30,6 +32,50 @@ const HabitatFeatureYupSchema = yup
         comment: yup.string().nullable()
       })
     )
+  })
+  .test('sampling', 'Invalid sampling information', function (_value) {
+    const hasAnySamplingSelection = Boolean(
+      _value.survey_sample_site_id || _value.method_technique_id || _value.survey_sample_period_id
+    );
+
+    if (!hasAnySamplingSelection) {
+      return true;
+    }
+
+    const errors: yup.ValidationError[] = [];
+
+    if (!_value.survey_sample_period_id) {
+      errors.push(
+        this.createError({
+          path: this.path ? `${this.path}.survey_sample_period_id` : 'survey_sample_period_id',
+          message: 'Sampling period is required when any sampling field is selected'
+        })
+      );
+    }
+
+    if (!_value.survey_sample_site_id) {
+      errors.push(
+        this.createError({
+          path: this.path ? `${this.path}.survey_sample_site_id` : 'survey_sample_site_id',
+          message: 'Sampling site is required when a sampling period is selected'
+        })
+      );
+    }
+
+    if (!_value.method_technique_id) {
+      errors.push(
+        this.createError({
+          path: this.path ? `${this.path}.method_technique_id` : 'method_technique_id',
+          message: 'Sampling technique is required when a sampling period is selected'
+        })
+      );
+    }
+
+    if (errors.length) {
+      return new yup.ValidationError(errors);
+    }
+
+    return true;
   })
   .test('conditional-validation', 'Invalid fields based on survey_sample_period_id', function (_value) {
     if (!_value.survey_sample_period_id) {

--- a/app/src/features/surveys/observations/form/components/ObservationForm.tsx
+++ b/app/src/features/surveys/observations/form/components/ObservationForm.tsx
@@ -104,6 +104,50 @@ const ObservationYupSchema = yup.object({
           })
       )
     })
+    .test('sampling', 'Invalid sampling information', function (_value) {
+      const hasAnySamplingSelection = Boolean(
+        _value.survey_sample_site_id || _value.method_technique_id || _value.survey_sample_period_id
+      );
+
+      if (!hasAnySamplingSelection) {
+        return true;
+      }
+
+      const errors: yup.ValidationError[] = [];
+
+      if (!_value.survey_sample_period_id) {
+        errors.push(
+          this.createError({
+            path: `${this.path}.survey_sample_period_id`,
+            message: 'Sampling period is required when any sampling field is selected'
+          })
+        );
+      }
+
+      if (!_value.survey_sample_site_id) {
+        errors.push(
+          this.createError({
+            path: `${this.path}.survey_sample_site_id`,
+            message: 'Sampling site is required when a sampling period is selected'
+          })
+        );
+      }
+
+      if (!_value.method_technique_id) {
+        errors.push(
+          this.createError({
+            path: `${this.path}.method_technique_id`,
+            message: 'Sampling technique is required when a sampling period is selected'
+          })
+        );
+      }
+
+      if (errors.length) {
+        return new yup.ValidationError(errors);
+      }
+
+      return true;
+    })
     .test('conditional-validation', 'Invalid fields based on survey_sample_period_id', function (_value) {
       if (!_value.survey_sample_period_id) {
         if (!_value.observation_date) {


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-761

## Description of Changes

- **Sampling validation (all-or-nothing):** If a sampling site, technique, or period is added for an observation or habitat feature, all three must now be provided. Previously, partial sampling data could be submitted.
- Added a Yup `.test('sampling', ...)` to both **Observation** and **Habitat Feature** forms that:
  - Allows the form to pass when none of the three sampling fields are set.
  - When any of the three is set, requires the other two and surfaces field-level errors (sampling period, sampling site, sampling technique).
- **Observation form:** Validation runs on `standardColumns` in `ObservationForm.tsx`.
- **Habitat feature form:** Validation runs on the root schema in `HabitatFeatureFormContainer.tsx`; schema shape now explicitly includes `survey_sample_site_id` and `method_technique_id` for the test.

## Testing Notes

- **Observations:** In survey observations, try adding only one or two of Site / Technique / Period and submit; expect validation errors requiring all three. Submit with all three set and with all three empty; both should be accepted.
- **Habitat features:** Same flow on the habitat feature form—partial sampling (e.g. only site) should fail validation; all three or none should succeed.
- Confirm error messages appear on the correct fields and that existing behaviour (e.g. date/location rules when no sampling period is set) is unchanged.