### PR TITLE
SIMSBIOHUB-867: Analytics Tab Infinite Load Error

### DIFF
--- a/app/src/contexts/codesContext.tsx
+++ b/app/src/contexts/codesContext.tsx
@@ -1,7 +1,7 @@
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader, { DataLoader } from 'hooks/useDataLoader';
 import { IGetAllCodeSetsResponse } from 'interfaces/useCodesApi.interface';
-import { createContext, PropsWithChildren, useEffect, useMemo } from 'react';
+import { createContext, PropsWithChildren, useEffect, useMemo, useRef } from 'react';
 
 /**
  * Context object that stores information about codes
@@ -27,9 +27,11 @@ export const CodesContextProvider = (props: PropsWithChildren<Record<never, any>
   const biohubApi = useBiohubApi();
   const codesDataLoader = useDataLoader(biohubApi.codes.getAllCodeSets);
 
+  const loadRef = useRef(codesDataLoader.load);
+  loadRef.current = codesDataLoader.load;
   useEffect(() => {
-    codesDataLoader.load();
-  }, [codesDataLoader]);
+    loadRef.current();
+  }, []);
 
   const codesContext: ICodesContext = useMemo(() => ({ codesDataLoader }), [codesDataLoader]);
 

--- a/app/src/features/standards/view/species/ecological-unit/SpeciesStandardsEcologicalUnitCard.tsx
+++ b/app/src/features/standards/view/species/ecological-unit/SpeciesStandardsEcologicalUnitCard.tsx
@@ -2,7 +2,7 @@ import grey from '@mui/material/colors/grey';
 import Stack from '@mui/material/Stack';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { AccordionStandardCard } from '../../components/AccordionStandardCard';
 
 interface ISpeciesStandardsEcologicalUnitCardProps {
@@ -21,9 +21,11 @@ export const SpeciesStandardsEcologicalUnitCard = (props: ISpeciesStandardsEcolo
   const critterbaseApi = useCritterbaseApi();
   const unitsDataLoader = useDataLoader(() => critterbaseApi.xref.getCollectionUnits(collectionCategoryId));
 
+  const loadRef = useRef(unitsDataLoader.load);
+  loadRef.current = unitsDataLoader.load;
   useEffect(() => {
-    unitsDataLoader.load();
-  }, [unitsDataLoader]);
+    loadRef.current();
+  }, [collectionCategoryId]);
 
   const units = unitsDataLoader.data ?? [];
 

--- a/app/src/features/summary/tabular-data/habitat-feature/HabitatFeaturesListFilterForm.tsx
+++ b/app/src/features/summary/tabular-data/habitat-feature/HabitatFeaturesListFilterForm.tsx
@@ -6,7 +6,7 @@ import { FilterFieldsContainer } from 'features/summary/components/FilterFieldsC
 import { Formik } from 'formik';
 import { useCodesContext, useTaxonomyContext } from 'hooks/useContext';
 import { FindSurveyHabitatFeaturesFilters } from 'interfaces/useSurveyHabitatFeatureApi.interface';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export type SurveyHabitatFeaturesAdvancedFilters = Omit<
   FindSurveyHabitatFeaturesFilters,
@@ -45,9 +45,11 @@ export const HabitatFeaturesListFilterForm = (props: IHabitatFeaturesListFilterF
   const codesContext = useCodesContext();
   const taxonomyContext = useTaxonomyContext();
 
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
 
   const habitatFeatureTypeOptions =
     codesContext.codesDataLoader.data?.habitat_feature_types.map((item) => {

--- a/app/src/features/surveys/CreateSurveyPage.tsx
+++ b/app/src/features/surveys/CreateSurveyPage.tsx
@@ -65,15 +65,19 @@ const CreateSurveyPage = () => {
   const history = useHistory();
 
   const codesContext = useContext(CodesContext);
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
   const codes = codesContext.codesDataLoader.data;
 
   const projectContext = useContext(ProjectContext);
+  const projectLoadRef = useRef(projectContext.projectDataLoader.load);
+  projectLoadRef.current = projectContext.projectDataLoader.load;
   useEffect(() => {
-    projectContext.projectDataLoader.load(projectContext.projectId);
-  }, [projectContext.projectDataLoader, projectContext.projectId]);
+    projectLoadRef.current(projectContext.projectId);
+  }, [projectContext.projectId]);
   const projectData = projectContext.projectDataLoader.data?.projectData;
 
   const formikRef = useRef<FormikProps<IEditSurveyRequest>>(null);

--- a/app/src/features/surveys/animals/profile/mortality/components/mortality-card-details/MortalityDetails.tsx
+++ b/app/src/features/surveys/animals/profile/mortality/components/mortality-card-details/MortalityDetails.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import { IMortalityWithSupplementaryData } from 'features/surveys/animals/profile/mortality/AnimalMortalityContainer';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { hasRealTime } from 'utils/datetime';
 
 interface IMortalityDetailsProps {
@@ -26,9 +26,11 @@ export const MortalityDetails = (props: IMortalityDetailsProps) => {
 
   const mortalityCodesDataLoader = useDataLoader(() => critterbaseApi.mortality.getCauseOfDeathOptions());
 
+  const loadRef = useRef(mortalityCodesDataLoader.load);
+  loadRef.current = mortalityCodesDataLoader.load;
   useEffect(() => {
-    mortalityCodesDataLoader.load();
-  }, [mortalityCodesDataLoader]);
+    loadRef.current();
+  }, []);
 
   const mortalityTimestamp = mortality.mortality_timestamp;
   const mortalityComment = mortality.mortality_comment;

--- a/app/src/features/surveys/components/funding/SurveyFundingSourceForm.tsx
+++ b/app/src/features/surveys/components/funding/SurveyFundingSourceForm.tsx
@@ -11,7 +11,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { IEditSurveyRequest } from 'interfaces/useSurveyApi.interface';
 import get from 'lodash-es/get';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import yup from 'utils/YupSchema';
 
@@ -84,9 +84,11 @@ const SurveyFundingSourceForm = () => {
 
   const fundingSourcesDataLoader = useDataLoader(() => biohubApi.funding.getAllFundingSources());
 
+  const loadRef = useRef(fundingSourcesDataLoader.load);
+  loadRef.current = fundingSourcesDataLoader.load;
   useEffect(() => {
-    fundingSourcesDataLoader.load();
-  }, [fundingSourcesDataLoader]);
+    loadRef.current();
+  }, []);
 
   const fundingSourceOptions = useMemo(
     () =>

--- a/app/src/features/surveys/sampling-information/sites/components/map/SamplingSiteMapControl.tsx
+++ b/app/src/features/surveys/sampling-information/sites/components/map/SamplingSiteMapControl.tsx
@@ -81,9 +81,11 @@ const SamplingSiteMapControl = (props: ISamplingSiteMapControlProps) => {
     biohubApi.samplingSite.getSampleSitesGeometry(surveyContext.projectId, surveyContext.surveyId)
   );
 
+  const loadRef = useRef(samplingSiteDataLoader.load);
+  loadRef.current = samplingSiteDataLoader.load;
   useEffect(() => {
-    samplingSiteDataLoader.load();
-  }, [samplingSiteDataLoader]);
+    loadRef.current();
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   let numSites = samplingSiteDataLoader.data?.sampleSites.length ?? 0;
 

--- a/app/src/features/surveys/telemetry/manage/deployments/table/DeploymentsTable.tsx
+++ b/app/src/features/surveys/telemetry/manage/deployments/table/DeploymentsTable.tsx
@@ -20,7 +20,7 @@ import isBetween from 'dayjs/plugin/isBetween';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext, useSurveyContext } from 'hooks/useContext';
 import { TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { combineDateTime, formatDateTime } from 'utils/datetime';
 
@@ -71,9 +71,11 @@ export const DeploymentsTable = (props: IDeploymentsTableProps) => {
   const [actionMenuDeploymentId, setActionMenuDeploymentId] = useState<number | undefined>();
   const [actionMenuAnchorEl, setActionMenuAnchorEl] = useState<MenuProps['anchorEl']>(null);
 
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
 
   const handleCloseActionMenu = () => {
     setActionMenuAnchorEl(null);

--- a/app/src/features/surveys/telemetry/manage/devices/table/DevicesContainer.tsx
+++ b/app/src/features/surveys/telemetry/manage/devices/table/DevicesContainer.tsx
@@ -22,7 +22,7 @@ import { DevicesTable } from 'features/surveys/telemetry/manage/devices/table/De
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useDialogContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { getDeviceCSVTemplate } from 'utils/csv-templates';
 import { downloadFile } from 'utils/file-utils';
@@ -43,9 +43,11 @@ export const DevicesContainer = () => {
     biohubApi.telemetryDevice.getDevicesInSurvey(projectId, surveyId)
   );
 
+  const devicesLoadRef = useRef(devicesDataLoader.load);
+  devicesLoadRef.current = devicesDataLoader.load;
   useEffect(() => {
-    devicesDataLoader.load(surveyContext.projectId, surveyContext.surveyId);
-  }, [devicesDataLoader, surveyContext.projectId, surveyContext.surveyId]);
+    devicesLoadRef.current(surveyContext.projectId, surveyContext.surveyId);
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   const devices = devicesDataLoader.data?.devices ?? [];
   const devicesCount = devicesDataLoader.data?.count ?? 0;
@@ -55,9 +57,11 @@ export const DevicesContainer = () => {
     biohubApi.telemetryDeployment.getDeploymentsInSurvey(projectId, surveyId)
   );
 
+  const deploymentsLoadRef = useRef(deploymentsDataLoader.load);
+  deploymentsLoadRef.current = deploymentsDataLoader.load;
   useEffect(() => {
-    deploymentsDataLoader.load(surveyContext.projectId, surveyContext.surveyId);
-  }, [deploymentsDataLoader, surveyContext.projectId, surveyContext.surveyId]);
+    deploymentsLoadRef.current(surveyContext.projectId, surveyContext.surveyId);
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   const deployments = deploymentsDataLoader.data?.deployments ?? [];
 

--- a/app/src/features/surveys/telemetry/manage/devices/table/DevicesTable.tsx
+++ b/app/src/features/surveys/telemetry/manage/devices/table/DevicesTable.tsx
@@ -20,7 +20,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useDialogContext, useSurveyContext } from 'hooks/useContext';
 import { TelemetryDeployment } from 'interfaces/useTelemetryDeploymentApi.interface';
 import { TelemetryDevice } from 'interfaces/useTelemetryDeviceApi.interface';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { combineDateTime } from 'utils/datetime';
 
@@ -57,9 +57,11 @@ export const DevicesTable = (props: IDevicesTableProps) => {
   const [actionMenuDeviceId, setActionMenuDeviceId] = useState<number>();
   const [actionMenuAnchorEl, setActionMenuAnchorEl] = useState<MenuProps['anchorEl']>(null);
 
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
 
   const handleDeleteDevice = async () => {
     if (!actionMenuDeviceId) {

--- a/app/src/features/surveys/view/survey-sampling/components/period/SurveyPeriodsTable.tsx
+++ b/app/src/features/surveys/view/survey-sampling/components/period/SurveyPeriodsTable.tsx
@@ -4,7 +4,7 @@ import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { useCodesContext } from 'hooks/useContext';
 import { GetSamplingPeriod } from 'interfaces/useSamplingPeriodApi.interface';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { formatTimeDifference } from 'utils/datetime';
 import { getCodesName, getFormattedDate } from 'utils/Utils';
 
@@ -28,9 +28,11 @@ export const SurveyPeriodsTable = (props: ISamplingPeriodTableProps) => {
 
   const codesContext = useCodesContext();
 
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
 
   const columns: GridColDef<GetSamplingPeriod>[] = [
     {

--- a/app/src/features/surveys/view/survey-sampling/components/technique/SurveyTechniqueCardContainer.tsx
+++ b/app/src/features/surveys/view/survey-sampling/components/technique/SurveyTechniqueCardContainer.tsx
@@ -6,7 +6,7 @@ import { GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { IGetTechniqueResponse } from 'interfaces/useTechniqueApi.interface';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { SurveyTechniqueCard } from './components/SurveyTechniqueCard';
 
 const pageSizeOptions = [10, 25, 50];
@@ -29,9 +29,11 @@ export const SurveyTechniquesCardContainer = (props: ISurveyTechniquesCardContai
     biohubApi.reference.getTechniqueAttributes(techniques.map((technique) => technique.method_lookup_id))
   );
 
+  const loadRef = useRef(methodAttributeDataLoader.load);
+  loadRef.current = methodAttributeDataLoader.load;
   useEffect(() => {
-    methodAttributeDataLoader.load();
-  }, [methodAttributeDataLoader]);
+    loadRef.current();
+  }, [techniques]);
 
   const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     // reset the page to 0 when changing the page size

--- a/app/src/features/surveys/view/survey-spatial/SurveySpatialContainer.tsx
+++ b/app/src/features/surveys/view/survey-spatial/SurveySpatialContainer.tsx
@@ -10,7 +10,7 @@ import { SurveySpatialTelemetry } from 'features/surveys/view/survey-spatial/com
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext, useTaxonomyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ApiPaginationRequestOptions } from 'types/misc';
 import { SurveySpatialHabitatFeature } from './components/habitat-feature/SurveySpatialHabitatFeature';
 import { useSamplingSiteStaticLayer } from './components/map/useSamplingSiteStaticLayer';
@@ -43,10 +43,11 @@ export const SurveySpatialContainer = (): JSX.Element => {
     [samplingSiteStaticLayer, studyAreaStaticLayer]
   );
 
+  const loadRef = useRef(observationsDataLoader.load);
+  loadRef.current = observationsDataLoader.load;
   useEffect(() => {
-    // Load the observations data
-    observationsDataLoader.load();
-  }, [observationsDataLoader]);
+    loadRef.current();
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   // Fetch and cache all taxonomic data required for the observations.
   useEffect(() => {

--- a/app/src/features/surveys/view/survey-spatial/components/animal/SurveySpatialAnimal.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/animal/SurveySpatialAnimal.tsx
@@ -8,7 +8,7 @@ import SurveyMapTooltip from 'features/surveys/view/SurveyMapTooltip';
 import { useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { coloredCustomMortalityMarker } from 'utils/mapUtils';
 import { SurveySpatialAnimalTable } from './SurveySpatialAnimalTable';
 
@@ -38,13 +38,15 @@ export const SurveySpatialAnimal = (props: ISurveySpatialAnimalProps) => {
     crittersApi.critters.getMultipleCrittersGeometryByIds(critter_ids)
   );
 
+  const loadRef = useRef(geometryDataLoader.load);
+  loadRef.current = geometryDataLoader.load;
   useEffect(() => {
     if (!critterIds.length) {
       return;
     }
 
-    geometryDataLoader.load(critterIds);
-  }, [critterIds, geometryDataLoader]);
+    loadRef.current(critterIds);
+  }, [critterIds]);
 
   const captureLayer: IStaticLayer = {
     layerName: 'Animal Captures',

--- a/app/src/features/surveys/view/survey-spatial/components/animal/SurveySpatialAnimalTable.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/animal/SurveySpatialAnimalTable.tsx
@@ -12,7 +12,7 @@ import { ScientificNameTypography } from 'features/surveys/animals/components/Sc
 import { useSurveyContext } from 'hooks/useContext';
 import { useCritterbaseApi } from 'hooks/useCritterbaseApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 const rowHeight = 52;
 
@@ -46,11 +46,13 @@ export const SurveySpatialAnimalTable = (props: ISurveyDataAnimalTableProps) => 
     critterbaseApi.critters.getMultipleCrittersByIds(animals.map((animal) => animal.critterbase_critter_id))
   );
 
+  const loadRef = useRef(animalsDataLoader.load);
+  loadRef.current = animalsDataLoader.load;
   useEffect(() => {
     if (animals.length) {
-      animalsDataLoader.load();
+      loadRef.current();
     }
-  }, [animals, animalsDataLoader]);
+  }, [animals]);
 
   const rows: IAnimalRow[] =
     animalsDataLoader.data?.map((animal) => ({

--- a/app/src/features/surveys/view/survey-spatial/components/habitat-feature/SurveySpatialHabitatFeature.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/habitat-feature/SurveySpatialHabitatFeature.tsx
@@ -9,7 +9,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { SurveyHabitatFeaturesGeometry } from 'interfaces/useSurveyHabitatFeatureApi.interface';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { coloredCustomHabitatFeatureMarker } from 'utils/mapUtils';
 import { SurveySpatialHabitatFeatureTableContainer } from './SurveySpatialHabitatFeatureTableContainer';
 
@@ -35,9 +35,11 @@ export const SurveySpatialHabitatFeature = (props: ISurveySpatialHabitatFeatureP
     biohubApi.habitatFeature.getSurveyHabitatFeaturesGeometry(surveyContext.projectId, surveyContext.surveyId)
   );
 
+  const loadRef = useRef(habitatFeaturesGeometryDataLoader.load);
+  loadRef.current = habitatFeaturesGeometryDataLoader.load;
   useEffect(() => {
-    habitatFeaturesGeometryDataLoader.load();
-  }, [habitatFeaturesGeometryDataLoader]);
+    loadRef.current();
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   const habitatFeatures: SurveyHabitatFeaturesGeometry | undefined = habitatFeaturesGeometryDataLoader.data;
 

--- a/app/src/features/surveys/view/survey-spatial/components/habitat-feature/SurveySpatialHabitatFeaturePointPopup.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/habitat-feature/SurveySpatialHabitatFeaturePointPopup.tsx
@@ -6,7 +6,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { SurveyHabitatFeature } from 'interfaces/useSurveyHabitatFeatureApi.interface';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Popup } from 'react-leaflet';
 import { getCodesName } from 'utils/Utils';
 
@@ -27,9 +27,11 @@ export const SurveySpatialHabitatFeaturePointPopup = (props: ISurveySpatialHabit
   const surveyContext = useSurveyContext();
   const biohubApi = useBiohubApi();
 
+  const codesLoadRef = useRef(codesContext.codesDataLoader.load);
+  codesLoadRef.current = codesContext.codesDataLoader.load;
   useEffect(() => {
-    codesContext.codesDataLoader.load();
-  }, [codesContext.codesDataLoader]);
+    codesLoadRef.current();
+  }, []);
 
   const habitatFeatureDataLoader = useDataLoader((surveyHabitatFeatureId: number) =>
     biohubApi.habitatFeature.getSurveyHabitatFeatureWithSupplementaryData(

--- a/app/src/features/surveys/view/survey-spatial/components/map/useSamplingSiteStaticLayer.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/map/useSamplingSiteStaticLayer.tsx
@@ -5,7 +5,7 @@ import { SurveySampleSiteMapPopup } from 'features/surveys/view/SurveySampleSite
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Popup } from 'react-leaflet';
 
 /**
@@ -21,9 +21,11 @@ export const useSamplingSiteStaticLayer = (): IStaticLayer => {
     biohubApi.samplingSite.getSampleSitesGeometry(surveyContext.projectId, surveyContext.surveyId)
   );
 
+  const loadRef = useRef(geometryDataLoader.load);
+  loadRef.current = geometryDataLoader.load;
   useEffect(() => {
-    geometryDataLoader.load();
-  }, [geometryDataLoader]);
+    loadRef.current();
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   const samplingSites = geometryDataLoader.data?.sampleSites ?? [];
 

--- a/app/src/features/surveys/view/survey-spatial/components/observation/SurveySpatialObservation.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/observation/SurveySpatialObservation.tsx
@@ -9,7 +9,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { IGetSurveyObservationsGeometryResponse } from 'interfaces/useObservationApi.interface';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { coloredCustomObservationMarker } from 'utils/mapUtils';
 
 interface ISurveySpatialObservationProps {
@@ -31,9 +31,11 @@ export const SurveySpatialObservation = (props: ISurveySpatialObservationProps) 
     biohubApi.observation.getObservationsGeometry(projectId, surveyId)
   );
 
+  const loadRef = useRef(observationsGeometryDataLoader.load);
+  loadRef.current = observationsGeometryDataLoader.load;
   useEffect(() => {
-    observationsGeometryDataLoader.load();
-  }, [observationsGeometryDataLoader]);
+    loadRef.current();
+  }, [projectId, surveyId]);
 
   const observations: IGetSurveyObservationsGeometryResponse | undefined = observationsGeometryDataLoader.data;
 

--- a/app/src/features/surveys/view/survey-spatial/components/observation/analytics/SurveyObservationAnalytics.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/observation/analytics/SurveyObservationAnalytics.tsx
@@ -14,7 +14,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import startCase from 'lodash-es/startCase';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type GroupByColumnType = 'column' | 'quantitative_measurement' | 'qualitative_measurement';
 
@@ -49,9 +49,11 @@ export const SurveyObservationAnalytics = () => {
     biohubApi.observation.getObservationMeasurementDefinitions(projectId, surveyId)
   );
 
+  const loadRef = useRef(measurementDefinitionsDataLoader.load);
+  loadRef.current = measurementDefinitionsDataLoader.load;
   useEffect(() => {
-    measurementDefinitionsDataLoader.load();
-  }, [measurementDefinitionsDataLoader]);
+    loadRef.current();
+  }, [projectId, surveyId]);
 
   const groupByOptions: IGroupByOption[] = [
     ...allGroupByColumnOptions,

--- a/app/src/features/surveys/view/survey-spatial/components/observation/analytics/components/ObservationAnalyticsDataTableContainer.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/observation/analytics/components/ObservationAnalyticsDataTableContainer.tsx
@@ -10,7 +10,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext, useTaxonomyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { IObservationCountByGroup } from 'interfaces/useAnalyticsApi.interface';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
   getBasicGroupByColDefs,
   getDateColDef,
@@ -68,20 +68,17 @@ export const ObservationAnalyticsDataTableContainer = (props: IObservationAnalyt
       )
   );
 
+  const refreshRef = useRef(analyticsDataLoader.refresh);
+  refreshRef.current = analyticsDataLoader.refresh;
+
   useEffect(() => {
-    analyticsDataLoader.refresh(
+    refreshRef.current(
       surveyContext.surveyId,
       groupByColumns,
       groupByQuantitativeMeasurements,
       groupByQualitativeMeasurements
     );
-  }, [
-    analyticsDataLoader,
-    groupByColumns,
-    groupByQualitativeMeasurements,
-    groupByQuantitativeMeasurements,
-    surveyContext.surveyId
-  ]);
+  }, [groupByColumns, groupByQualitativeMeasurements, groupByQuantitativeMeasurements, surveyContext.surveyId]);
 
   const rows = useMemo(
     () =>

--- a/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialDeploymentTable.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialDeploymentTable.tsx
@@ -12,7 +12,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useCodesContext, useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { IAnimalDeploymentWithCritter } from 'interfaces/useSurveyApi.interface';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 // Set height so the skeleton loader will match table rows
 const rowHeight = 52;
@@ -67,9 +67,11 @@ export const SurveySpatialDeploymentTable = () => {
 
   const critterDataLoader = useDataLoader(biohubApi.survey.getSurveyCritters);
 
+  const critterLoadRef = useRef(critterDataLoader.load);
+  critterLoadRef.current = critterDataLoader.load;
   useEffect(() => {
-    critterDataLoader.load(surveyContext.projectId, surveyContext.surveyId);
-  }, [deploymentsDataLoader, critterDataLoader, surveyContext.projectId, surveyContext.surveyId]);
+    critterLoadRef.current(surveyContext.projectId, surveyContext.surveyId);
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   /**
    * Merges critters with associated deployments

--- a/app/src/hooks/useFocalOrObservedTsns.tsx
+++ b/app/src/hooks/useFocalOrObservedTsns.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useBiohubApi } from './useBioHubApi';
 import { useSurveyContext } from './useContext';
 import useDataLoader from './useDataLoader';
@@ -21,10 +21,11 @@ export const useFocalOrObservedSpeciesTsns = () => {
 
   const hierarchyDataLoader = useDataLoader((tsns: number[]) => biohubApi.taxonomy.getTaxonHierarchyByTSNs(tsns));
 
-  // Load observed species when component mounts
+  const observedLoadRef = useRef(observedSpeciesDataLoader.load);
+  observedLoadRef.current = observedSpeciesDataLoader.load;
   useEffect(() => {
-    observedSpeciesDataLoader.load();
-  }, [observedSpeciesDataLoader]);
+    observedLoadRef.current();
+  }, [surveyContext.projectId, surveyContext.surveyId]);
 
   // Combine focal species and observed species TSNs into a single array
   const focalSpeciesTsns = useMemo(
@@ -42,12 +43,13 @@ export const useFocalOrObservedSpeciesTsns = () => {
     [focalSpeciesTsns, observedSpeciesTsns]
   );
 
-  // Fetch parent taxa hierarchy for combined species TSNs
+  const hierarchyLoadRef = useRef(hierarchyDataLoader.load);
+  hierarchyLoadRef.current = hierarchyDataLoader.load;
   useEffect(() => {
     if (observedAndFocalSpeciesTsns.length && observedSpeciesDataLoader.data) {
-      hierarchyDataLoader.load(observedAndFocalSpeciesTsns);
+      hierarchyLoadRef.current(observedAndFocalSpeciesTsns);
     }
-  }, [observedAndFocalSpeciesTsns, hierarchyDataLoader, observedSpeciesDataLoader]);
+  }, [observedAndFocalSpeciesTsns, observedSpeciesDataLoader.data]);
 
   // Combine TSNs of focal/observed species with their parent taxa
   const allSpeciesWithParentsTsns = [


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-867 – BugFix: Analytics Tab Infinite Load Error](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-867)

## Description of Changes

- **Analytics tab:** On the survey details Analytics tab, the observations analytics API was being called many times per second and only stopped when switching back to the Counts tab. The effect that triggers the fetch had `analyticsDataLoader` in its dependency array. The loader object from `useDataLoader` gets a new reference whenever its state updates (e.g. after each request), so the effect kept re-running and calling `refresh()` in a loop. The fix is to hold the loader’s `refresh` in a ref and have the effect depend only on the real inputs (`surveyId` and the group-by options).
- **Same pattern elsewhere:** The same “loader in effect deps” pattern existed in a bunch of other places (codes context, survey spatial components, devices/deployments containers, create survey page, etc.). Those are updated to use the same ref approach so we don’t get similar request loops or unnecessary refetches.

## Testing Notes

- **Analytics tab (primary):** Go to survey details (e.g. `/admin/projects/1/surveys/1/details`), open the **Analytics** tab and leave it open. In the Network tab you should see a single request to `/api/analytics/observations` (or one per change to group-by options), not a continuous stream of requests.
- **Other areas to spot-check** (same ref-based fix applied; confirm data still loads and no request storms):
  - **Survey spatial:** Observations, Animals, Telemetry, and Habitat Features map/table views under survey details.
  - **Survey sampling:** Techniques list/cards, Sampling Sites map, Sampling Periods table.
  - **Telemetry:** Devices and Deployments tables under a survey (manage devices/deployments).
  - **Survey create/edit:** Create Survey page (codes + project data), Funding section, and any forms that use codes (e.g. habitat feature type dropdowns).
  - **Summary / list filters:** Habitat Features list filter form (codes for habitat feature types).
  - **Animals:** Mortality details (cause-of-death codes), ecological units card (species standards).
  - **Standards:** Species standards ecological unit card.