### PR TITLE
SIMSBIOHUB-871: always build all 4 images and remove skipDuplicateActions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,71 +35,6 @@ jobs:
           echo Git Branch Ref: ${{ github.head_ref }}
           echo PR in Draft: ${{ github.event.pull_request.draft }}
 
-  # Scans the commit against past commits, and determines if any jobs are skippable (due to no changes in target files).
-  # Note: this does not take into account the current branch and will check past workflows from any branch, so an
-  # additional check against the current branch is added to the `if` in the jobs below. This ensures that we only skip
-  # jobs if there are no changes AND the previous successful job was against the current branch.
-  skipDuplicateActions:
-    name: Check for duplicate actions
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs:
-      - checkEnv
-    outputs:
-      paths_result: ${{ steps.skip_check.outputs.paths_result }}
-      # Set to `true` if the latest commit message contains `ignore-skip` anywhere in the message OR the base branch
-      # is dev, test, or prod.
-      # Used to disable duplicate action skipping, if needed.
-      ignore_skip:
-        ${{ contains(steps.head_commit_message.outputs.commit_message, 'ignore-skip') ||
-        github.head_ref == 'dev' || github.head_ref == 'test' || github.head_ref == 'prod' }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          paths_filter: |
-            app:
-              paths:
-                - 'app/src/**'
-                - 'app/package*.json'
-                - 'app/.pipeline/**'
-                - 'app/Dockerfile'
-                - 'app/server/**'
-                - 'app/public/**'
-              paths_ignore:
-                - 'app/src/**/*.test.ts'
-                - 'app/**.md'
-            api:
-              paths:
-                - 'api/src/**'
-                - 'api/package*.json'
-                - 'api/.pipeline/**'
-                - 'api/Dockerfile'
-              paths_ignore:
-                - 'api/src/**/*.test.ts'
-                - 'api/**.md'
-            database:
-              paths:
-                - 'database/src/**' 
-                - 'database/package*.json'
-                - 'database/.pipeline/**'
-                - 'database/.docker/Dockerfile.setup'
-              paths_ignore:
-                - 'database/src/**/*.test.ts'
-                - 'database/**.md'
-
-      # Get the head commit for this pull request, parse out the commit message, and assign to the `commit_message`
-      # output variable, which is then used to determine if the term `ignore-skip` is found in the commit message.
-      - name: Checkout head commit
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Get head commit message
-        id: head_commit_message
-        run: |
-          echo commit message: $(git show -s --format=%s)
-          echo "commit_message=$(git show -s --format=%s)" >> $GITHUB_OUTPUT
-
   # Checkout the repo once and cache it for use in subsequent jobs
   checkoutRepo:
     name: Checkout and cache target branch
@@ -109,7 +44,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
     needs:
-      - skipDuplicateActions
+      - checkEnv
     steps:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
@@ -139,17 +74,12 @@ jobs:
     name: Build App Image
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.event.pull_request.merged == false &&
-      github.event.pull_request.draft == false &&
-      ( needs.skipDuplicateActions.outputs.ignore_skip == 'true' ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).app.should_skip == false ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).app.skipped_by.branch != github.head_ref ) }}
+    if: ${{ github.event.pull_request.merged == false && github.event.pull_request.draft == false }}
     env:
       PR_NUMBER: ${{ github.event.number }}
       APP_NAME: "biohubbc-app"
     needs:
       - checkoutRepo
-      - skipDuplicateActions
     steps:
       # Load repo from cache
       - name: Cache repo
@@ -222,17 +152,12 @@ jobs:
     name: Build Database Image
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.event.pull_request.merged == false &&
-      github.event.pull_request.draft == false &&
-      ( needs.skipDuplicateActions.outputs.ignore_skip == 'true' ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).database.should_skip == false ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).database.skipped_by.branch != github.head_ref ) }}
+    if: ${{ github.event.pull_request.merged == false && github.event.pull_request.draft == false }}
     env:
       PR_NUMBER: ${{ github.event.number }}
       APP_NAME: "biohubbc-db"
     needs:
       - checkoutRepo
-      - skipDuplicateActions
     steps:
       # Load repo from cache
       - name: Cache repo
@@ -305,17 +230,12 @@ jobs:
     name: Build Database Setup Image
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.event.pull_request.merged == false &&
-      github.event.pull_request.draft == false &&
-      ( needs.skipDuplicateActions.outputs.ignore_skip == 'true' ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).database.should_skip == false ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).database.skipped_by.branch != github.head_ref ) }}
+    if: ${{ github.event.pull_request.merged == false && github.event.pull_request.draft == false }}
     env:
       PR_NUMBER: ${{ github.event.number }}
       APP_NAME: "biohubbc-db-setup"
     needs:
       - checkoutRepo
-      - skipDuplicateActions
     steps:
       # Load repo from cache
       - name: Cache repo
@@ -382,17 +302,12 @@ jobs:
     name: Build API Image
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.event.pull_request.merged == false &&
-      github.event.pull_request.draft == false &&
-      ( needs.skipDuplicateActions.outputs.ignore_skip == 'true' ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).api.should_skip == false ||
-      fromJSON(needs.skipDuplicateActions.outputs.paths_result).api.skipped_by.branch != github.head_ref ) }}
+    if: ${{ github.event.pull_request.merged == false && github.event.pull_request.draft == false }}
     env:
       PR_NUMBER: ${{ github.event.number }}
       APP_NAME: "biohubbc-api"
     needs:
       - checkoutRepo
-      - skipDuplicateActions
     steps:
       # Load repo from cache
       - name: Cache repo
@@ -678,7 +593,6 @@ jobs:
       github.event.pull_request.draft == false }}
     needs:
       - checkEnv
-      - skipDuplicateActions
       - checkoutRepo
       - buildAndPushApp
       - buildAndPushDatabase
@@ -690,7 +604,6 @@ jobs:
       - name: Log result
         run: |
           echo needs.checkEnv.result: ${{ needs.checkEnv.result }}
-          echo needs.skipDuplicateActions.result: ${{ needs.skipDuplicateActions.result }}
           echo needs.checkoutRepo.result: ${{ needs.checkoutRepo.result }}
           echo needs.buildAndPushApp.result: ${{ needs.buildAndPushApp.result }}
           echo needs.buildAndPushDatabase.result: ${{ needs.buildAndPushDatabase.result }}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-871](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-871)

## Description of Changes

- **Always build all four images for PRs** (app, database, database-setup, api). Previously only images whose paths changed were built, so FE-only or API-only PRs could have broken previews (missing DB/DB-setup images). Now every non-draft PR builds the full stack so the preview environment works.
- **Removed the `skipDuplicateActions` job** and all path-based skip logic. It was only used to decide which build jobs to run; since we now always run all four build jobs, the job and its outputs (`paths_result`, `ignore_skip`) were unused. `checkoutRepo` now depends only on `checkEnv`, and all build jobs depend only on `checkoutRepo`.

## Testing Notes

- Open or update a PR (non-draft) and confirm the "PR-Based Deploy on OpenShift" workflow runs all four build jobs (Build App Image, Build Database Image, Build Database Setup Image, Build API Image) and then deploys. Preview URL should work for any PR (e.g. FE-only change) with DB and API available.
- Optionally verify a docs-only or infra-only change still triggers the workflow (all four images will build; no path-based skipping).