### PR TITLE
SIMSBIOHUB-872: Remove API_FF_SUBMIT_BIOHUB feature flag from SIMS

### DIFF
--- a/infrastructure/api/values-prod.yaml
+++ b/infrastructure/api/values-prod.yaml
@@ -8,7 +8,7 @@ app:
   nodeEnv: production
   nodeOptions: --max_old_space_size=6000  # 75% of 8Gi memory limit
   appHost: sims.nrs.gov.bc.ca  # Vanity URL for prod
-  featureFlags: API_FF_SUBMIT_BIOHUB,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK # Feature flags
+  featureFlags: API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK # Feature flags
 
   # BioHub Platform (aka: Backbone)
   backboneInternalApiHost: "https://api-biohub-platform.apps.silver.devops.gov.bc.ca"

--- a/infrastructure/biohubbc/values-prod.yaml
+++ b/infrastructure/biohubbc/values-prod.yaml
@@ -132,7 +132,7 @@ biohubbc-api:
     nodeEnv: production
     nodeOptions: --max_old_space_size=6000  # 75% of 8Gi memory limit
     appHost: sims.nrs.gov.bc.ca  # Vanity URL for prod
-    featureFlags: API_FF_SUBMIT_BIOHUB,API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK # Feature flags
+    featureFlags: API_FF_DISABLE_MULTIPLE_ACTIVE_DEPLOYMENTS_CHECK # Feature flags
 
     # ClamAV
     clamav:


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-872](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-872)

## Description of Changes

- Dropped `API_FF_SUBMIT_BIOHUB` from the prod feature-flag list in both `infrastructure/api/values-prod.yaml` and `infrastructure/biohubbc/values-prod.yaml`.

## Testing Notes

- Confirm prod deploy picks up the new values (no `API_FF_SUBMIT_BIOHUB` in `featureFlags`). After deploy, verify that submitting a survey to BioHub from prod works and no longer returns "Publishing to BioHub is not currently enabled."