### PR TITLE
SIMSBIOHUB-870: Align payload property names with BioHub

### DIFF
--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -127,7 +127,7 @@ describe('PostSurveyObservationToBiohubObject', () => {
       expect(quantitativeEnvFeature.type).to.equal('observation_environmental_condition');
       expect(quantitativeEnvFeature.properties).to.eql({
         environmental_condition: 'code::environment_quantitative::env-quant-uuid-1',
-        environmental_quantitative_value: '25.5'
+        environmental_condition_value: '25.5'
       });
     });
   });
@@ -216,7 +216,7 @@ describe('PostSurveyObservationToBiohubObject', () => {
       expect(quantitativeEnvFeature.type).to.equal('observation_environmental_condition');
       expect(quantitativeEnvFeature.properties).to.eql({
         environmental_condition: 'code::environment_quantitative::wind-speed-uuid',
-        environmental_quantitative_value: '15.2 meter'
+        environmental_condition_value: '15.2 meter'
       });
     });
   });
@@ -571,7 +571,7 @@ describe('PostSurveyEnvironmentalConditionToBiohubObject', () => {
     it('sets properties for quantitative data', () => {
       expect(data.properties).to.eql({
         environmental_condition: 'code::environment_quantitative::temperature-uuid',
-        environmental_quantitative_value: '23.5 °C'
+        environmental_condition_value: '23.5 °C'
       });
     });
 
@@ -608,7 +608,7 @@ describe('PostSurveyEnvironmentalConditionToBiohubObject', () => {
     it('uses ID and no unit when missing for quantitative', () => {
       expect(quantData.properties).to.eql({
         environmental_condition: 'code::environment_quantitative::env-quant-uuid',
-        environmental_quantitative_value: '42'
+        environmental_condition_value: '42'
       });
     });
   });

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -366,7 +366,7 @@ export class PostSurveyEnvironmentalConditionToBiohubObject implements BioHubSub
     } else {
       this.properties = {
         environmental_condition: `code::environment_quantitative::${environmentData.environment_quantitative_id}`,
-        environmental_quantitative_value: `${environmentData.value}${environmentData.unit ? ' ' + environmentData.unit : ''}`
+        environmental_condition_value: `${environmentData.value}${environmentData.unit ? ' ' + environmentData.unit : ''}`
       };
     }
 
@@ -719,13 +719,13 @@ export class PostSurveyReportAttachmentsToBiohubObject implements BioHubSubmissi
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.REPORT;
     this.properties = {
-      artifact_id: reportAttachmentRecord.survey_report_attachment_id,
+      artifact_key: reportAttachmentRecord.key,
       filename: reportAttachmentRecord.file_name,
       file_type: ATTACHMENT_TYPE.REPORT,
       file_size: reportAttachmentRecord.file_size,
-      title: reportAttachmentRecord.title,
+      name: reportAttachmentRecord.title,
       description: reportAttachmentRecord.description,
-      year_published: reportAttachmentRecord.year_published
+      year: reportAttachmentRecord.year_published
     };
     this.child_features = [];
   }
@@ -1017,7 +1017,7 @@ export class PostTelemetryDeviceToBiohubObject implements BioHubSubmissionFeatur
     this.type = BiohubFeatureType.TELEMETRY_DEVICE;
     this.properties = {
       device_manufacturer: `code::device_make::${deviceRecord.device_make_id}`,
-      model: deviceRecord.model || null,
+      device_model: deviceRecord.model || null,
       description: deviceRecord.comment || null,
       serial_number: deviceRecord.serial
     };

--- a/api/src/models/complete-biohub-integration.test.ts
+++ b/api/src/models/complete-biohub-integration.test.ts
@@ -125,7 +125,7 @@ describe('Complete BioHub Integration', () => {
       expect(deviceFeature).to.exist;
       expect(deviceFeature?.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
       expect(deviceFeature?.properties.device_manufacturer).to.equal('code::device_make::1');
-      expect(deviceFeature?.properties.model).to.equal('GPS-Tracker-Pro');
+      expect(deviceFeature?.properties.device_model).to.equal('GPS-Tracker-Pro');
       expect(deviceFeature?.properties.serial_number).to.equal('GPS-DEV-001');
       expect(deviceFeature?.properties.description).to.equal('High-accuracy GPS collar');
 

--- a/api/src/models/telemetry-features.test.ts
+++ b/api/src/models/telemetry-features.test.ts
@@ -90,7 +90,7 @@ describe('Telemetry Features BioHub Integration', () => {
       expect(deviceObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(deviceObj.type).to.equal('telemetry_device');
       expect(deviceObj.properties.device_manufacturer).to.equal('code::device_make::1');
-      expect(deviceObj.properties.model).to.equal('GPS-4400M');
+      expect(deviceObj.properties.device_model).to.equal('GPS-4400M');
       expect(deviceObj.properties.description).to.equal('Wildlife tracking device');
       expect(deviceObj.properties.serial_number).to.equal('ABC123456');
       expect(deviceObj.child_features).to.be.an('array').with.length(0);
@@ -110,7 +110,7 @@ describe('Telemetry Features BioHub Integration', () => {
       const deviceObj = new PostTelemetryDeviceToBiohubObject(deviceRecord);
 
       expect(deviceObj.properties.device_manufacturer).to.equal('code::device_make::99');
-      expect(deviceObj.properties.model).to.equal(null);
+      expect(deviceObj.properties.device_model).to.equal(null);
       expect(deviceObj.properties.description).to.equal(null);
     });
   });
@@ -392,7 +392,7 @@ describe('Telemetry Features BioHub Integration', () => {
 
       const deviceFeature = submissionObj.content.child_features.find((f) => f.type === 'telemetry_device');
       expect(deviceFeature?.properties.device_manufacturer).to.equal('code::device_make::2');
-      expect(deviceFeature?.properties.model).to.equal('Advanced-GPS-Pro');
+      expect(deviceFeature?.properties.device_model).to.equal('Advanced-GPS-Pro');
       expect(deviceFeature?.properties.serial_number).to.equal('TRACK500');
 
       const deploymentFeature = submissionObj.content.child_features.find((f) => f.type === 'telemetry_deployment');


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-870

## Description of Changes

- **observation_environmental_condition (quantitative):** Use `environmental_condition_value` for quantitative conditions instead of `environmental_quantitative_value`, so both qualitative and quantitative use the same property name and match what the companion system expects.
- **telemetry_device:** Renamed payload property from `model` to `device_model` to match the companion audit.
- **report (report attachments):** Send `artifact_key` (from report attachment key), `name` (from title), and `year` (from year_published) instead of `artifact_id`, `title`, and `year_published` so the payload matches the companion audit.
- Updated the tests that were asserting on the old property names so the suite passes.

## Testing Notes

- `npm test` in the api package — all tests pass. The only changes in this PR are the payload property names above and the corresponding test expectations; no behaviour change beyond what we send to the API.