### PR TITLE
SIMSBIOHUB-850: Implement Crunchy DB

### DIFF
--- a/.github/workflows/deployStatic.yml
+++ b/.github/workflows/deployStatic.yml
@@ -120,62 +120,6 @@ jobs:
           docker build -t ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }} .
           docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
 
-  # Build the Database image
-  buildAndPushDatabase:
-    name: Build Database Image
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
-    env:
-      IMAGE_TAG: build-1.0.0-${{ needs.checkoutRepo.outputs.timestamp }}-${{ github.base_ref || github.ref_name }}
-      BRANCH: ${{ github.base_ref || github.ref_name }}
-      APP_NAME: "biohubbc-db"
-    needs:
-      - checkoutRepo
-    steps:
-      # Load repo from cache
-      - name: Cache repo
-        uses: actions/cache@v4
-        id: cache-repo
-        env:
-          cache-name: cache-repo
-        with:
-          path: ${{ github.workspace }}/*
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
-
-      # Checkout the branch if not restored via cache
-      - name: Checkout Target Branch
-        if: steps.cache-repo.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
-
-      # Authenticate Docker with OpenShift registry
-      - name: Authenticate Docker with OpenShift registry
-        run: |
-          echo ${{ secrets.TOOLS_SA_TOKEN }} | docker login -u unused --password-stdin ${{ vars.OPENSHIFT_REGISTRY }}
-
-      # Build and push the database image using Docker
-      - name: Build and Push Database Image
-        working-directory: database
-        run: |
-          docker build -t ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }} .
-          docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
-
   # Build the Database Setup image
   buildAndPushDatabaseSetup:
     name: Build Database Setup Image
@@ -300,7 +244,6 @@ jobs:
     needs:
       - checkoutRepo
       - buildAndPushApp
-      - buildAndPushDatabase
       - buildAndPushDatabaseSetup
       - buildAndPushAPI
     steps:
@@ -358,15 +301,6 @@ jobs:
             -f ./infrastructure/biohubbc/values-$BRANCH.yaml \
             --set-string biohubbc-app.environment.ts=$TS \
             --set-string biohubbc-app.environment.changeId=$BUILD_TAG \
-            --set-string biohubbc-db.environment.ts=$TS \
-            --set-string biohubbc-db.environment.changeId=$BUILD_TAG \
-            --set-string biohubbc-db.app.postgresAdmin=${{ secrets.DATABASE_ADMIN }} \
-            --set-string biohubbc-db.app.postgresAdminPassword=${{ secrets.DATABASE_ADMIN_PASSWORD }} \
-            --set-string biohubbc-db.app.postgresUser=${{ secrets.DATABASE_USER }} \
-            --set-string biohubbc-db.app.postgresUserPassword=${{ secrets.DATABASE_USER_PASSWORD }} \
-            --set-string biohubbc-db.app.postgresUserApi=${{ secrets.DATABASE_USER_API }} \
-            --set-string biohubbc-db.app.postgresUserApiPassword=${{ secrets.DATABASE_USER_API_PASSWORD }} \
-            --set-string biohubbc-db.app.postgresDb=${{ secrets.DATABASE_NAME }} \
             --set-string biohubbc-db-setup.environment.ts=$TS \
             --set-string biohubbc-db-setup.environment.changeId=$BUILD_TAG \
             --set-string biohubbc-api.environment.ts=$TS \
@@ -403,7 +337,7 @@ jobs:
           set -e
           KEEP=3
           SUFFIX="-$BRANCH"
-          IMAGES="biohubbc-app biohubbc-api biohubbc-db biohubbc-db-setup"
+          IMAGES="biohubbc-app biohubbc-api biohubbc-db-setup"
           echo "Pruning image tags for environment $BRANCH in $TOOLS_NAMESPACE (keeping $KEEP most recent by date)"
           for IMAGE in $IMAGES; do
             echo "Checking image stream $IMAGE..."

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,7 +4,7 @@ import multer from 'multer';
 import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 import swaggerUIExperss from 'swagger-ui-express';
-import { defaultPoolConfig, initDBPool } from './database/db';
+import { getDefaultPoolConfig, initDBPool } from './database/db';
 import { ensureHTTPError, HTTP400, HTTP500 } from './errors/http-error';
 import {
   authorizeAndAuthenticateMiddleware,
@@ -172,7 +172,7 @@ app.use('/api-docs', swaggerUIExperss.serve, swaggerUIExperss.setup(openAPIFrame
 
 // Start api
 try {
-  initDBPool(defaultPoolConfig);
+  initDBPool(getDefaultPoolConfig());
 
   app.listen(PORT, () => {
     defaultLog.info({ label: 'start api', message: `started api on ${HOST}:${PORT}/api` });

--- a/api/src/cronjobs/telemetry/cronjob.ts
+++ b/api/src/cronjobs/telemetry/cronjob.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'util';
 import { z } from 'zod';
-import { defaultPoolConfig, getAPIUserDBConnection, initDBPool } from '../../database/db';
+import { getAPIUserDBConnection, getDefaultPoolConfig, initDBPool } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';
 import { TelemetryLotekService } from '../../services/telemetry-services/telemetry-lotek-service';
 import { TelemetryVectronicService } from '../../services/telemetry-services/telemetry-vectronic-service';
@@ -47,7 +47,7 @@ export async function telemetryCronjob() {
   const args = parseArguments();
   defaultLog.info({ message: 'Cronjob starting.', args });
 
-  initDBPool(defaultPoolConfig);
+  initDBPool(getDefaultPoolConfig());
 
   const connection = getAPIUserDBConnection();
 

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
 import knex, { Knex } from 'knex';
+import * as fs from 'node:fs';
 import * as pg from 'pg';
 import SQL, { SQLStatement } from 'sql-template-strings';
 import { z } from 'zod';

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import knex, { Knex } from 'knex';
 import * as pg from 'pg';
 import SQL, { SQLStatement } from 'sql-template-strings';
@@ -39,6 +40,12 @@ export const defaultPoolConfig: pg.PoolConfig = {
   connectionTimeoutMillis: DB_CONNECTION_TIMEOUT,
   idleTimeoutMillis: DB_IDLE_TIMEOUT
 };
+
+/** Default pool config with SSL (CA verification) when PG_SSL_CA_PATH is set. */
+export const getDefaultPoolConfig = (): pg.PoolConfig => ({
+  ...defaultPoolConfig,
+  ...(process.env.PG_SSL_CA_PATH && { ssl: { ca: fs.readFileSync(process.env.PG_SSL_CA_PATH) } })
+});
 
 // Custom type handler for psq `DATE` type to prevent local time/zone information from being added.
 // Why? By default, node-postgres assumes local time/zone for any psql `DATE` or `TIME` types that don't have timezone information.

--- a/database/src/knexfile.ts
+++ b/database/src/knexfile.ts
@@ -1,9 +1,7 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 // Use SSL with CA verification when PG_SSL_CA_PATH is set (Crunchy); otherwise no SSL (legacy/PR).
-const sslConfig = process.env.PG_SSL_CA_PATH
-  ? { ca: fs.readFileSync(process.env.PG_SSL_CA_PATH) }
-  : false;
+const sslConfig = process.env.PG_SSL_CA_PATH ? { ca: fs.readFileSync(process.env.PG_SSL_CA_PATH) } : false;
 
 export default {
   development: {

--- a/database/src/knexfile.ts
+++ b/database/src/knexfile.ts
@@ -1,3 +1,6 @@
+// When PGSSLMODE=require (e.g. Crunchy Postgres with self-signed cert), use SSL and accept self-signed for this connection only.
+const sslConfig = process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : false;
+
 export default {
   development: {
     client: 'pg',
@@ -6,7 +9,8 @@ export default {
       port: process.env.DB_PORT,
       database: process.env.DB_DATABASE,
       user: process.env.DB_ADMIN,
-      password: process.env.DB_ADMIN_PASS
+      password: process.env.DB_ADMIN_PASS,
+      ...(sslConfig && { ssl: sslConfig })
     },
     pool: {
       min: 2,
@@ -28,7 +32,8 @@ export default {
       port: process.env.DB_PORT,
       database: process.env.DB_DATABASE,
       user: process.env.DB_ADMIN,
-      password: process.env.DB_ADMIN_PASS
+      password: process.env.DB_ADMIN_PASS,
+      ...(sslConfig && { ssl: sslConfig })
     },
     pool: {
       min: 2,

--- a/database/src/knexfile.ts
+++ b/database/src/knexfile.ts
@@ -1,5 +1,9 @@
-// When PGSSLMODE=require (e.g. Crunchy Postgres with self-signed cert), use SSL and accept self-signed for this connection only.
-const sslConfig = process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : false;
+import * as fs from 'fs';
+
+// Use SSL with CA verification when PG_SSL_CA_PATH is set (Crunchy); otherwise no SSL (legacy/PR).
+const sslConfig = process.env.PG_SSL_CA_PATH
+  ? { ca: fs.readFileSync(process.env.PG_SSL_CA_PATH) }
+  : false;
 
 export default {
   development: {

--- a/infrastructure/api/templates/cronjob-telemetry.yaml
+++ b/infrastructure/api/templates/cronjob-telemetry.yaml
@@ -33,22 +33,22 @@ spec:
                 - name: TZ
                   value: {{ .Values.app.timezone }}
                 - name: DB_HOST
-                  value: {{ include "dbHost" . }}
+                  value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
                 - name: DB_USER_API
                   valueFrom:
                     secretKeyRef:
-                      key: database-user-api
-                      name: {{ include "dbHost" . }}
+                      name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                      key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-user-api{{ end }}
                 - name: DB_USER_API_PASS
                   valueFrom:
                     secretKeyRef:
-                      key: database-user-api-password
-                      name: {{ include "dbHost" . }}
+                      name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                      key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-user-api-password{{ end }}
                 - name: DB_DATABASE
                   valueFrom:
                     secretKeyRef:
-                      key: database-name
-                      name: {{ include "dbHost" . }}
+                      name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                      key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
                 - name: DB_PORT
                   value: {{ .Values.app.database.port | quote }}
                 # Telemetry

--- a/infrastructure/api/templates/cronjob-telemetry.yaml
+++ b/infrastructure/api/templates/cronjob-telemetry.yaml
@@ -51,6 +51,10 @@ spec:
                       key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
                 - name: DB_PORT
                   value: {{ .Values.app.database.port | quote }}
+                {{- if .Values.app.database.useCrunchy }}
+                - name: PG_SSL_CA_PATH
+                  value: "/etc/pg-ssl/{{ .Values.app.database.caSecretKey }}"
+                {{- end }}
                 # Telemetry
                 - name: LOTEK_API_HOST
                   value: {{ .Values.app.lotekApiHost }}
@@ -96,8 +100,21 @@ spec:
               volumeMounts:
                 - name: {{ include "app.fullname" . }}
                   mountPath: /opt/app-root/src/data
+                {{- if .Values.app.database.useCrunchy }}
+                - name: pg-root-ca
+                  mountPath: /etc/pg-ssl
+                  readOnly: true
+                {{- end }}
           restartPolicy: Never
           volumes:
             - name: {{ include "app.fullname" . }}
               persistentVolumeClaim:
                 claimName: {{ default (include "app.fullname" .) .Values.persistence.existingClaim }}
+            {{- if .Values.app.database.useCrunchy }}
+            - name: pg-root-ca
+              secret:
+                secretName: {{ .Values.app.database.caSecretName }}
+                items:
+                  - key: {{ .Values.app.database.caSecretKey }}
+                    path: {{ .Values.app.database.caSecretKey }}
+            {{- end }}

--- a/infrastructure/api/templates/deployment.yaml
+++ b/infrastructure/api/templates/deployment.yaml
@@ -148,6 +148,10 @@ spec:
                   key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
             - name: DB_PORT
               value: {{ .Values.app.database.port | quote }}
+            {{- if .Values.app.database.useCrunchy }}
+            - name: PG_SSL_CA_PATH
+              value: "/etc/pg-ssl/{{ .Values.app.database.caSecretKey }}"
+            {{- end }}
             # Telemetry
             - name: LOTEK_API_HOST
               value: {{ .Values.app.lotekApiHost }}
@@ -311,6 +315,11 @@ spec:
           volumeMounts:
             - name: {{ include "app.fullname" . }}
               mountPath: /opt/app-root/src/data
+            {{- if .Values.app.database.useCrunchy }}
+            - name: pg-root-ca
+              mountPath: /etc/pg-ssl
+              readOnly: true
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -320,3 +329,11 @@ spec:
         - name: {{ include "app.fullname" . }}
           persistentVolumeClaim:
             claimName: {{ default (include "app.fullname" .) .Values.persistence.existingClaim }}
+        {{- if .Values.app.database.useCrunchy }}
+        - name: pg-root-ca
+          secret:
+            secretName: {{ .Values.app.database.caSecretName }}
+            items:
+              - key: {{ .Values.app.database.caSecretKey }}
+                path: {{ .Values.app.database.caSecretKey }}
+        {{- end }}

--- a/infrastructure/api/templates/deployment.yaml
+++ b/infrastructure/api/templates/deployment.yaml
@@ -31,63 +31,63 @@ spec:
           command: ['sh', '-c']
           args:
             - |
-              until pg_isready -h {{ include "dbHost" . }} -p {{ .Values.app.database.port }} -U $DB_USER_API; do
+              until pg_isready -h $DB_HOST -p {{ .Values.app.database.port }} -U $DB_USER_API; do
                 echo "Waiting for database to be ready..."
                 sleep 5
               done
               echo "Database is ready!"
           env:
             - name: DB_HOST
-              value: {{ include "dbHost" . }}
+              value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
             - name: DB_USER_API
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-user-api{{ end }}
             - name: DB_USER_API_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-user-api-password{{ end }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-user-api-password{{ end }}
         - name: wait-for-database-setup
           image: postgres:15-alpine
           command: ['sh', '-c']
           args:
             - |
               echo "Waiting for database-setup job to complete..."
-              until PGPASSWORD=$DB_ADMIN_PASS psql -h {{ include "dbHost" . }} -U $DB_ADMIN -d $DB_DATABASE -c "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER_API';" | grep -q "1"; do
+              until PGPASSWORD=$DB_CHECK_PASS psql -h $DB_HOST -U $DB_CHECK_USER -d $DB_DATABASE -c "SELECT 1;" | grep -q "1"; do
                 echo "Database-setup not complete, waiting..."
                 sleep 5
               done
               echo "Database-setup completed successfully!"
           env:
             - name: DB_HOST
-              value: {{ include "dbHost" . }}
-            - name: DB_ADMIN
+              value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
+            - name: DB_CHECK_USER
               valueFrom:
                 secretKeyRef:
-                  key: database-admin
-                  name: {{ include "dbHost" . }}
-            - name: DB_ADMIN_PASS
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-admin{{ end }}
+            - name: DB_CHECK_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-admin-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-admin-password{{ end }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:
-                  key: database-name
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
             - name: DB_USER_API
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-user-api{{ end }}
       containers:
         - name: api
           env:
@@ -130,22 +130,22 @@ spec:
             - name: TZ
               value: {{ .Values.app.timezone }}
             - name: DB_HOST
-              value: {{ include "dbHost" . }}
+              value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
             - name: DB_USER_API
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-user-api{{ end }}
             - name: DB_USER_API_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-user-api-password{{ end }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:
-                  key: database-name
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
             - name: DB_PORT
               value: {{ .Values.app.database.port | quote }}
             # Telemetry

--- a/infrastructure/api/values.yaml
+++ b/infrastructure/api/values.yaml
@@ -37,9 +37,16 @@ app:
 
   # Database
   database:
-    secretName: biohubbc-db
-    serviceName: "" # Database service name associated with deployment
-    port: 5432 # Database port'
+    secretName: biohubbc-db # Unused: legacy path uses hardcoded dbHost helper (biohubbc-db + app.suffix) for secret name
+    serviceName: "" # Unused: reserved for future use
+    port: 5432 # Database port
+    # useCrunchy: true = Crunchy Postgres (DEV/TEST/PROD). Set to false for PR environments (legacy dbHost secret).
+    useCrunchy: true
+    host: "" # e.g. "<release>-primary" (biohubbc-db-dev-primary for DEV); use primary not pgbouncer (biohub_api not in PgBouncer config)
+    appSecretName: "" # e.g. "<release>-pguser-biohub-api" (biohubbc-db-dev-pguser-biohub-api for DEV)
+    dbNameSecretName: "" # e.g. "<release>-pguser-<cluster-name>" (biohubbc-db-dev-pguser-biohubbc-db-dev for DEV)
+    adminSecretName: "" # e.g. "<release>-pguser-postgres" (biohubbc-db-dev-pguser-postgres for DEV)
+    # Secret keys default in templates: user/password/dbname (override in parent values if needed)
 
   # Keycloak
   keycloak:

--- a/infrastructure/api/values.yaml
+++ b/infrastructure/api/values.yaml
@@ -47,6 +47,9 @@ app:
     dbNameSecretName: "" # e.g. "<release>-pguser-<cluster-name>" (biohubbc-db-dev-pguser-biohubbc-db-dev for DEV)
     adminSecretName: "" # e.g. "<release>-pguser-postgres" (biohubbc-db-dev-pguser-postgres for DEV)
     # Secret keys default in templates: user/password/dbname (override in parent values if needed)
+    # PGO root CA for TLS verification (same secret name in all envs)
+    caSecretName: "pgo-root-cacert"
+    caSecretKey: "root.crt"
 
   # Keycloak
   keycloak:

--- a/infrastructure/biohubbc/Chart.yaml
+++ b/infrastructure/biohubbc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: biohubbc
-description: A Helm umbrella chart for SIMS BioHub BC - deploys app, database-setup, api, and queue. For PR previews the database subchart (single-pod Postgres) is enabled; for static envs (dev/test/prod) database is disabled and Crunchy Postgres is deployed separately (see infrastructure/crunchy-db).
+description: A Helm umbrella chart for SIMS BioHub BC - deploys app, database-setup, and api. For PR previews the database subchart (single-pod Postgres) is enabled; for static envs (dev/test/prod) database is disabled and Crunchy Postgres is deployed separately (see infrastructure/crunchy-db).
 type: application
 version: 0.1.0
 appVersion: "1.0.0"

--- a/infrastructure/biohubbc/Chart.yaml
+++ b/infrastructure/biohubbc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: biohubbc
-description: A Helm umbrella chart for SIMS BioHub BC - deploys app, database, database-setup, and api in proper order
+description: A Helm umbrella chart for SIMS BioHub BC - deploys app, database-setup, api, and queue. For PR previews the database subchart (single-pod Postgres) is enabled; for static envs (dev/test/prod) database is disabled and Crunchy Postgres is deployed separately (see infrastructure/crunchy-db).
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
@@ -18,8 +18,6 @@ dependencies:
     repository: file://../database-setup
     version: 0.1.0
     condition: database-setup.enabled
-    dependsOn:
-      - biohubbc-db
   - name: biohubbc-clamav
     repository: file://../clamav
     version: 0.1.0

--- a/infrastructure/biohubbc/values-dev.yaml
+++ b/infrastructure/biohubbc/values-dev.yaml
@@ -73,6 +73,8 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: development
+
+    # Database
     database:
       host: "biohubbc-db-dev-primary"
       adminSecretName: "biohubbc-db-dev-pguser-postgres"

--- a/infrastructure/biohubbc/values-dev.yaml
+++ b/infrastructure/biohubbc/values-dev.yaml
@@ -9,8 +9,9 @@ environment:
 app:
   enabled: true
 
+# Disabled: DEV uses the separate Crunchy Postgres Helm release (infrastructure/crunchy-db).
 database:
-  enabled: true
+  enabled: false
 
 database-setup:
   enabled: true
@@ -60,40 +61,6 @@ biohubbc-app:
   route:
     host: dev-biohubbc.apps.silver.devops.gov.bc.ca
 
-# Values passed to biohubbc-db subchart
-biohubbc-db:
-  environment:
-    licensePlate: "af2668"
-    name: dev
-    id: deploy
-    # changeId will be dynamically set: "1234"
-    ts: ""
-
-  # App configuration
-  app:
-    nodeEnv: development
-    postgresAdmin: ""
-    postgresAdminPassword: ""
-    postgresUser: ""
-    postgresUserPassword: ""
-    postgresUserApi: ""
-    postgresUserApiPassword: ""
-    postgresDb: ""
-
-  # Openshift Resources
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 100Mi
-    limits:
-      cpu: 600m
-      memory: 4Gi
-
-  # Volume for persistent data
-  persistence:
-    existingClaim: "biohubbc-db-postgresql-dev-deploy"
-
 # Values passed to biohubbc-db-setup subchart
 biohubbc-db-setup:
   environment:
@@ -106,6 +73,11 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: development
+    database:
+      host: "biohubbc-db-dev-primary"
+      adminSecretName: "biohubbc-db-dev-pguser-postgres"
+      appSecretName: "biohubbc-db-dev-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-dev-pguser-biohubbc-db-dev"
 
 # Values passed to biohubbc-clamav subchart
 biohubbc-clamav:
@@ -153,6 +125,14 @@ biohubbc-api:
     
     # Critterbase
     critterbaseApiHost: "https://moe-critterbase-api-dev.apps.silver.devops.gov.bc.ca/api"
+
+    # Database
+    database:
+      host: "biohubbc-db-dev-primary"
+      port: 5432
+      appSecretName: "biohubbc-db-dev-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-dev-pguser-biohubbc-db-dev"
+      adminSecretName: "biohubbc-db-dev-pguser-postgres"
 
     # Keycloak
     keycloak:

--- a/infrastructure/biohubbc/values-pr.yaml
+++ b/infrastructure/biohubbc/values-pr.yaml
@@ -105,6 +105,8 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: development
+    database:
+      useCrunchy: false # PRs use legacy dbHost secret
 
 # Values passed to biohubbc-clamav subchart
 # NOTE: ClamAV is DISABLED for PR previews to save resources.
@@ -140,6 +142,10 @@ biohubbc-api:
     
     # Critterbase
     critterbaseApiHost: "https://moe-critterbase-api-dev.apps.silver.devops.gov.bc.ca/api"
+
+    # Database: PRs use legacy dbHost secret (not Crunchy)
+    database:
+      useCrunchy: false
 
     # Keycloak
     keycloak:

--- a/infrastructure/biohubbc/values-prod.yaml
+++ b/infrastructure/biohubbc/values-prod.yaml
@@ -9,8 +9,9 @@ environment:
 app:
   enabled: true
 
+# Disabled: PROD uses the separate Crunchy Postgres Helm release (infrastructure/crunchy-db).
 database:
-  enabled: true
+  enabled: false
 
 database-setup:
   enabled: true
@@ -60,33 +61,6 @@ biohubbc-app:
   route:
     host: biohubbc.apps.silver.devops.gov.bc.ca
 
-# Values passed to biohubbc-db subchart
-biohubbc-db:
-  environment:
-    licensePlate: "af2668"
-    name: prod
-    id: deploy
-    # changeId will be dynamically set: "1234"
-    ts: ""
-
-  # App configuration
-  app:
-    nodeEnv: production
-
-  # Openshift Resources
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 100Mi
-    limits:
-      cpu: 4000m
-      memory: 10Gi
-
-  # Volume for persistent data
-  persistence:
-    existingClaim: "biohubbc-db-postgresql-prod"
-
 # Values passed to biohubbc-db-setup subchart
 biohubbc-db-setup:
   environment:
@@ -99,6 +73,11 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: production
+    database:
+      host: "biohubbc-db-prod-primary"
+      adminSecretName: "biohubbc-db-prod-pguser-postgres"
+      appSecretName: "biohubbc-db-prod-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-prod-pguser-biohubbc-db-prod"
 
 # Values passed to biohubbc-clamav subchart
 biohubbc-clamav:
@@ -146,6 +125,14 @@ biohubbc-api:
     
     # Critterbase
     critterbaseApiHost: "https://moe-critterbase-api-prod.apps.silver.devops.gov.bc.ca/api"
+
+    # Database
+    database:
+      host: "biohubbc-db-prod-primary"
+      port: 5432
+      appSecretName: "biohubbc-db-prod-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-prod-pguser-biohubbc-db-prod"
+      adminSecretName: "biohubbc-db-prod-pguser-postgres"
 
     # Keycloak
     keycloak:

--- a/infrastructure/biohubbc/values-prod.yaml
+++ b/infrastructure/biohubbc/values-prod.yaml
@@ -73,6 +73,8 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: production
+
+    # Database
     database:
       host: "biohubbc-db-prod-primary"
       adminSecretName: "biohubbc-db-prod-pguser-postgres"

--- a/infrastructure/biohubbc/values-test.yaml
+++ b/infrastructure/biohubbc/values-test.yaml
@@ -9,8 +9,9 @@ environment:
 app:
   enabled: true
 
+# Disabled: TEST uses the separate Crunchy Postgres Helm release (infrastructure/crunchy-db).
 database:
-  enabled: true
+  enabled: false
 
 database-setup:
   enabled: true
@@ -60,40 +61,6 @@ biohubbc-app:
   route:
     host: test-biohubbc.apps.silver.devops.gov.bc.ca
 
-# Values passed to biohubbc-db subchart
-biohubbc-db:
-  environment:
-    licensePlate: "af2668"
-    name: test
-    id: deploy
-    # changeId will be dynamically set: "1234"
-    ts: ""
-
-  # App configuration
-  app:
-    nodeEnv: production # This is set to production as test is not a valid name in the Knexfile
-    postgresAdmin: ""
-    postgresAdminPassword: ""
-    postgresUser: ""
-    postgresUserPassword: ""
-    postgresUserApi: ""
-    postgresUserApiPassword: ""
-    postgresDb: ""
-
-  # Openshift Resources
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 100Mi
-    limits:
-      cpu: 2000m
-      memory: 5Gi
-
-  # Volume for persistent data
-  persistence:
-    existingClaim: "biohubbc-db-postgresql-test"
-
 # Values passed to biohubbc-db-setup subchart
 biohubbc-db-setup:
   environment:
@@ -106,6 +73,11 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: production # This is set to production as test is not a valid name in the Knexfile and to only run the procedures and not seed the database
+    database:
+      host: "biohubbc-db-test-primary"
+      adminSecretName: "biohubbc-db-test-pguser-postgres"
+      appSecretName: "biohubbc-db-test-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-test-pguser-biohubbc-db-test"
 
 # Values passed to biohubbc-clamav subchart
 biohubbc-clamav:
@@ -153,6 +125,14 @@ biohubbc-api:
     
     # Critterbase
     critterbaseApiHost: "https://moe-critterbase-api-test.apps.silver.devops.gov.bc.ca/api"
+
+    # Database
+    database:
+      host: "biohubbc-db-test-primary"
+      port: 5432
+      appSecretName: "biohubbc-db-test-pguser-biohub-api"
+      dbNameSecretName: "biohubbc-db-test-pguser-biohubbc-db-test"
+      adminSecretName: "biohubbc-db-test-pguser-postgres"
 
     # Keycloak
     keycloak:

--- a/infrastructure/biohubbc/values-test.yaml
+++ b/infrastructure/biohubbc/values-test.yaml
@@ -73,6 +73,8 @@ biohubbc-db-setup:
   # App configuration
   app:
     nodeEnv: production # This is set to production as test is not a valid name in the Knexfile and to only run the procedures and not seed the database
+    
+    # Database
     database:
       host: "biohubbc-db-test-primary"
       adminSecretName: "biohubbc-db-test-pguser-postgres"

--- a/infrastructure/crunchy-db/Chart.lock
+++ b/infrastructure/crunchy-db/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: crunchy-postgres
+  repository: https://bcgov.github.io/crunchy-postgres/
+  version: 0.6.6
+digest: sha256:e7d340d8b2a1fc12c941a247a075ffb31d3beee821d69a0fb4c283863a1912f1
+generated: "2026-02-24T11:59:44.706537-07:00"

--- a/infrastructure/crunchy-db/Chart.yaml
+++ b/infrastructure/crunchy-db/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: biohubbc-crunchy-db
+description: A Helm chart for SIMS Crunchy Postgres Cluster (DEV/TEST/PROD only)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+dependencies:
+  - name: crunchy-postgres
+    version: 0.6.6
+    repository: https://bcgov.github.io/crunchy-postgres/

--- a/infrastructure/crunchy-db/templates/migration-job.yaml
+++ b/infrastructure/crunchy-db/templates/migration-job.yaml
@@ -1,0 +1,227 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: biohubbc-db-migration
+  labels:
+    app: biohubbc-db-migration
+    role: migration
+  annotations:
+    # Ensures this job is not re-created on subsequent helm upgrades unless explicitly enabled
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  # Allow up to 30 minutes for the migration
+  activeDeadlineSeconds: 1800
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: biohubbc-db-migration
+        role: migration
+    spec:
+      restartPolicy: Never
+      initContainers:
+        # Wait for the old database to be reachable
+        - name: wait-for-old-db
+          image: postgres:17-alpine
+          command: ['sh', '-c']
+          args:
+            - |
+              echo "Waiting for old database to be ready at {{ .Values.migration.oldDb.host }}..."
+              until pg_isready -h {{ .Values.migration.oldDb.host }} -p 5432 -U $OLD_DB_ADMIN; do
+                echo "Old database not ready, waiting..."
+                sleep 5
+              done
+              echo "Old database is ready."
+          env:
+            - name: OLD_DB_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migration.oldDb.secretName }}
+                  key: {{ .Values.migration.oldDb.adminKey }}
+        # Wait for the new Crunchy DB to be ready (host from postgres secret = primary)
+        # Secret name uses cluster name (fullnameOverride), not Helm release name.
+        - name: wait-for-new-db
+          image: postgres:17-alpine
+          command: ['sh', '-c']
+          args:
+            - |
+              echo "Waiting for Crunchy DB at $NEW_DB_HOST:5432..."
+              until pg_isready -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN; do
+                echo "Crunchy DB not ready, waiting..."
+                sleep 5
+              done
+              echo "Crunchy DB is ready."
+          env:
+            - name: NEW_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-postgres
+                  key: host
+            - name: NEW_DB_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-postgres
+                  key: {{ .Values.migration.newDb.adminUserKey }}
+      containers:
+        - name: migrate
+          image: postgres:17-alpine
+          command: ['sh', '-c']
+          args:
+            - |
+              set -e
+
+              echo "=== Starting database migration ==="
+              echo "Source: $OLD_DB_HOST / $OLD_DB_NAME"
+              echo "Target: $NEW_DB_HOST / $NEW_DB_NAME"
+
+              # biohub_api password comes from a secret you create manually (see values migration.newDb.appUserSecretName).
+              # Example: kubectl create secret generic biohubbc-db-dev-pguser-biohub-api --from-literal=user=biohub_api --from-literal=password='YOUR_PASSWORD' -n <namespace>
+              if [ -z "$NEW_DB_APP_PASS" ]; then
+                echo "ERROR: NEW_DB_APP_PASS is not set. Create the app user secret before running migration (e.g. biohubbc-db-dev-pguser-biohub-api with key password)."
+                exit 1
+              fi
+
+              echo "--- Running pg_dump from old database and restoring into Crunchy ---"
+              PGPASSWORD=$OLD_DB_ADMIN_PASS pg_dump \
+                -h $OLD_DB_HOST \
+                -p 5432 \
+                -U $OLD_DB_ADMIN \
+                -d $OLD_DB_NAME \
+                --no-owner \
+                --no-acl \
+                --format=custom \
+                -f /tmp/migration.dump
+
+              echo "--- Dump complete, size: $(du -sh /tmp/migration.dump | cut -f1) ---"
+
+              export PGSSLMODE=require
+              # Strip newlines/carriage returns from secrets (K8s can have trailing newlines)
+              NEW_DB_HOST=$(printf '%s' "$NEW_DB_HOST" | tr -d '\n\r')
+              NEW_DB_NAME=$(printf '%s' "$NEW_DB_NAME" | tr -d '\n\r')
+              NEW_DB_ADMIN=$(printf '%s' "$NEW_DB_ADMIN" | tr -d '\n\r')
+              NEW_PASS_ESC=$(printf '%s' "$NEW_DB_ADMIN_PASS" | tr -d '\n\r' | sed 's/\\/\\\\/g; s/:/\\:/g')
+              printf '%s:5432:%s:%s:%s\n' "$NEW_DB_HOST" "$NEW_DB_NAME" "$NEW_DB_ADMIN" "$NEW_PASS_ESC" > /tmp/.pgpass.new
+              chmod 600 /tmp/.pgpass.new
+              export PGPASSFILE=/tmp/.pgpass.new
+
+              echo "--- Clean new database completely (drop all extensions and non-system schemas) ---"
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=0 -c "
+                SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();
+              "
+              for ext in $(psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -t -A -v ON_ERROR_STOP=0 -c "SELECT extname FROM pg_extension WHERE extname != 'plpgsql'"); do
+                echo "Dropping extension $ext"
+                psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=0 -c "DROP EXTENSION IF EXISTS \"$ext\" CASCADE;"
+              done
+              for schema in $(psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -t -A -v ON_ERROR_STOP=0 -c "SELECT nspname FROM pg_namespace WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast') AND nspname NOT LIKE 'pg_temp%'"); do
+                echo "Dropping schema $schema"
+                psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=0 -c "DROP SCHEMA IF EXISTS \"$schema\" CASCADE;"
+              done
+              echo "--- Recreate public schema (pg_restore expects it for extensions and tables) ---"
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=1 -c "
+                CREATE SCHEMA IF NOT EXISTS public;
+                GRANT ALL ON SCHEMA public TO postgres;
+                GRANT ALL ON SCHEMA public TO public;
+              "
+              echo "--- New database cleaned ---"
+
+              echo "--- Create biohub_api role with new password (must exist before restore so ACLs can be restored) ---"
+              ESCAPED=$(echo "$NEW_DB_APP_PASS" | sed "s/'/''/g")
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=1 -c "
+                DO \$\$
+                BEGIN
+                  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'biohub_api') THEN
+                    EXECUTE format('CREATE USER biohub_api WITH LOGIN PASSWORD %L', '${ESCAPED}');
+                  ELSE
+                    EXECUTE format('ALTER USER biohub_api PASSWORD %L', '${ESCAPED}');
+                  END IF;
+                END \$\$;
+              "
+              echo "biohub_api role ready."
+
+              echo "--- Restoring into Crunchy database (postgres superuser; ACLs restored so biohub_api grants apply) ---"
+              pg_restore \
+                -h "$NEW_DB_HOST" \
+                -p 5432 \
+                -U $NEW_DB_ADMIN \
+                -d $NEW_DB_NAME \
+                --no-owner \
+                --clean \
+                --if-exists \
+                /tmp/migration.dump
+
+              # Ensure password is set after restore (restore may have overwritten role)
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=1 -c "ALTER USER biohub_api PASSWORD '${ESCAPED}';"
+              echo "biohub_api password confirmed."
+
+              echo "--- Set search_path and re-grant ACLs for biohub_api (dump used --no-acl; role defaults not in dump) ---"
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=1 -c "
+                ALTER ROLE biohub_api SET search_path TO biohub, public, biohub_dapi_v1;
+                GRANT USAGE ON SCHEMA biohub TO biohub_api;
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA biohub TO biohub_api;
+                GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA biohub TO biohub_api;
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA biohub TO biohub_api;
+              "
+              psql -h "$NEW_DB_HOST" -p 5432 -U $NEW_DB_ADMIN -d $NEW_DB_NAME -v ON_ERROR_STOP=0 -c "
+                GRANT USAGE ON SCHEMA biohub_dapi_v1 TO biohub_api;
+                GRANT ALL ON ALL TABLES IN SCHEMA biohub_dapi_v1 TO biohub_api;
+                GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA biohub_dapi_v1 TO biohub_api;
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA biohub_dapi_v1 TO biohub_api;
+              " || true
+              echo "biohub_api search_path and ACLs set."
+
+              echo "=== Migration complete ==="
+          env:
+            - name: OLD_DB_HOST
+              value: {{ .Values.migration.oldDb.host }}
+            - name: OLD_DB_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migration.oldDb.secretName }}
+                  key: {{ .Values.migration.oldDb.adminKey }}
+            - name: OLD_DB_ADMIN_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migration.oldDb.secretName }}
+                  key: {{ .Values.migration.oldDb.passwordKey }}
+            - name: OLD_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migration.oldDb.secretName }}
+                  key: {{ .Values.migration.oldDb.dbNameKey }}
+            - name: NEW_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-postgres
+                  key: host
+            - name: NEW_DB_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-postgres
+                  key: {{ .Values.migration.newDb.adminUserKey }}
+            - name: NEW_DB_ADMIN_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-postgres
+                  key: {{ .Values.migration.newDb.adminPasswordKey }}
+            - name: NEW_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "crunchy-postgres").fullnameOverride }}-pguser-{{ (index .Values "crunchy-postgres").fullnameOverride }}
+                  key: dbname
+            # Password for biohub_api role; create this secret manually before running migration (valid name: no underscore, e.g. pguser-biohub-api).
+            - name: NEW_DB_APP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (.Values.migration.newDb.appUserSecretName | default (printf "%s-pguser-biohub-api" (index .Values "crunchy-postgres").fullnameOverride)) }}
+                  key: {{ .Values.migration.newDb.appPasswordKey | default "password" }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+{{- end }}

--- a/infrastructure/crunchy-db/values-dev.yaml
+++ b/infrastructure/crunchy-db/values-dev.yaml
@@ -1,0 +1,38 @@
+# DEV environment overrides for Crunchy Postgres cluster.
+# Single instance (no HA), separate S3 backup path.
+
+crunchy-postgres:
+  fullnameOverride: biohubbc-db-dev
+
+  instances:
+    replicas: 1
+    dataVolumeClaimSpec:
+      storage: 5Gi
+    requests:
+      cpu: 50m
+      memory: 256Mi
+
+  proxy:
+    pgBouncer:
+      replicas: 1
+
+  pgBackRest:
+    retention: "7"
+    s3:
+      s3Path: "/biohubbc/dev"
+
+  patroni:
+    postgresql:
+      parameters:
+        shared_buffers: 16MB
+
+# To perform the one-time data migration from the old database, set:
+#   migration.enabled: true
+#   migration.oldDb.host: "biohubbc-db-dev-deploy"
+#   migration.oldDb.secretName: "biohubbc-db-postgresql-dev-deploy"
+# Then re-deploy with migration.enabled: false once complete.
+migration:
+  enabled: false
+  oldDb:
+    host: "biohubbc-db-dev-deploy"
+    secretName: "biohubbc-db-postgresql-dev-deploy"

--- a/infrastructure/crunchy-db/values-prod.yaml
+++ b/infrastructure/crunchy-db/values-prod.yaml
@@ -28,11 +28,11 @@ crunchy-postgres:
 
 # To perform the one-time data migration from the old database, set:
 #   migration.enabled: true
-#   migration.oldDb.host: "biohubbc-db-postgresql-prod"
+#   migration.oldDb.host: "biohubbc-db-prod"
 #   migration.oldDb.secretName: "biohubbc-db-postgresql-prod"
 # Then re-deploy with migration.enabled: false once complete.
 migration:
   enabled: false
   oldDb:
-    host: "biohubbc-db-postgresql-prod"
+    host: "biohubbc-db-prod"
     secretName: "biohubbc-db-postgresql-prod"

--- a/infrastructure/crunchy-db/values-prod.yaml
+++ b/infrastructure/crunchy-db/values-prod.yaml
@@ -1,0 +1,38 @@
+# PROD environment overrides for Crunchy Postgres cluster.
+# High-availability: 2 instances + 2 pgBouncer replicas, separate S3 backup path, higher retention.
+
+crunchy-postgres:
+  fullnameOverride: biohubbc-db-prod
+
+  instances:
+    replicas: 2
+    dataVolumeClaimSpec:
+      storage: 20Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  proxy:
+    pgBouncer:
+      replicas: 2
+
+  pgBackRest:
+    retention: "30"
+    s3:
+      s3Path: "/biohubbc/prod"
+
+  patroni:
+    postgresql:
+      parameters:
+        shared_buffers: 64MB
+
+# To perform the one-time data migration from the old database, set:
+#   migration.enabled: true
+#   migration.oldDb.host: "biohubbc-db-postgresql-prod"
+#   migration.oldDb.secretName: "biohubbc-db-postgresql-prod"
+# Then re-deploy with migration.enabled: false once complete.
+migration:
+  enabled: false
+  oldDb:
+    host: "biohubbc-db-postgresql-prod"
+    secretName: "biohubbc-db-postgresql-prod"

--- a/infrastructure/crunchy-db/values-test.yaml
+++ b/infrastructure/crunchy-db/values-test.yaml
@@ -28,11 +28,11 @@ crunchy-postgres:
 
 # To perform the one-time data migration from the old database, set:
 #   migration.enabled: true
-#   migration.oldDb.host: "biohubbc-db-postgresql-test"
+#   migration.oldDb.host: "biohubbc-db-test"
 #   migration.oldDb.secretName: "biohubbc-db-postgresql-test"
 # Then re-deploy with migration.enabled: false once complete.
 migration:
   enabled: false
   oldDb:
-    host: "biohubbc-db-postgresql-test"
+    host: "biohubbc-db-test"
     secretName: "biohubbc-db-postgresql-test"

--- a/infrastructure/crunchy-db/values-test.yaml
+++ b/infrastructure/crunchy-db/values-test.yaml
@@ -1,0 +1,38 @@
+# TEST environment overrides for Crunchy Postgres cluster.
+# High-availability: 2 instances + 2 pgBouncer replicas, separate S3 backup path.
+
+crunchy-postgres:
+  fullnameOverride: biohubbc-db-test
+
+  instances:
+    replicas: 2
+    dataVolumeClaimSpec:
+      storage: 10Gi
+    requests:
+      cpu: 50m
+      memory: 256Mi
+
+  proxy:
+    pgBouncer:
+      replicas: 2
+
+  pgBackRest:
+    retention: "14"
+    s3:
+      s3Path: "/biohubbc/test"
+
+  patroni:
+    postgresql:
+      parameters:
+        shared_buffers: 32MB
+
+# To perform the one-time data migration from the old database, set:
+#   migration.enabled: true
+#   migration.oldDb.host: "biohubbc-db-postgresql-test"
+#   migration.oldDb.secretName: "biohubbc-db-postgresql-test"
+# Then re-deploy with migration.enabled: false once complete.
+migration:
+  enabled: false
+  oldDb:
+    host: "biohubbc-db-postgresql-test"
+    secretName: "biohubbc-db-postgresql-test"

--- a/infrastructure/crunchy-db/values.yaml
+++ b/infrastructure/crunchy-db/values.yaml
@@ -1,0 +1,123 @@
+# Base values for biohubbc Crunchy Postgres cluster.
+# Environment-specific overrides are in values-dev.yaml, values-test.yaml, values-prod.yaml.
+# This chart is NOT used for PR preview environments, which use the vanilla database subchart.
+
+crunchy-postgres:
+  # Overridden per environment (e.g. biohubbc-db-dev in values-dev.yaml)
+  fullnameOverride: biohubbc-db
+
+  # PostGIS-enabled image for PostgreSQL 17
+  crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi9-17.7-3.5-2547
+  postgresVersion: 17
+  postGISVersion: '3.5'
+  imagePullPolicy: IfNotPresent
+  openshift: true
+
+  standby:
+    enabled: false
+    repoName: repo2
+
+  instances:
+    name: ha
+    replicas: 1
+    dataVolumeClaimSpec:
+      storage: 5Gi
+      storageClassName: netapp-block-standard
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    replicaCertCopy:
+      requests:
+        cpu: 1m
+        memory: 32Mi
+
+  dataSource:
+    enabled: false
+    secretName: s3-pgbackrest
+    repo:
+      name: repo2
+      path: "/biohubbc/dev"
+      s3:
+        bucket: "vjfnyw"
+        endpoint: "https://nrs.objectstore.gov.bc.ca:443"
+        region: "ca-central-1"
+    stanza: db
+
+  pgBackRest:
+    retention: "7"
+    retentionFullType: count
+    repo1:
+      enabled: true
+    repos:
+      schedules:
+        full: 0 8 * * *
+        incremental: 0 0,4,12,16,20 * * *
+      volume:
+        accessModes: "ReadWriteOnce"
+        storage: 512Mi
+        storageClassName: netapp-file-backup
+    repoHost:
+      requests:
+        cpu: 1m
+        memory: 64Mi
+    sidecars:
+      requests:
+        cpu: 1m
+        memory: 64Mi
+    s3:
+      enabled: true
+      # The s3-pgbackrest secret must be pre-created in the namespace before deploying this chart.
+      createS3Secret: false
+      s3Secret: s3-pgbackrest
+      # s3Path is overridden per environment to keep backups separated.
+      s3Path: "/biohubbc/dev"
+      s3UriStyle: path
+      bucket: "vjfnyw"
+      endpoint: "https://nrs.objectstore.gov.bc.ca:443"
+      region: "ca-central-1"
+      key: ""
+      keySecret: ""
+      fullSchedule: "0 9 * * *"
+      incrementalSchedule: "0 1,5,13,17,21 * * *"
+
+  patroni:
+    postgresql:
+      pg_hba: "host all all 0.0.0.0/0 md5"
+      parameters:
+        shared_buffers: 16MB
+        wal_buffers: "64kB"
+        min_wal_size: 32MB
+        max_wal_size: 64MB
+        max_slot_wal_keep_size: 128MB
+
+  proxy:
+    pgBouncer:
+      replicas: 1
+      requests:
+        cpu: 1m
+        memory: 64Mi
+
+  pgmonitor:
+    enabled: false
+    exporter:
+      requests:
+        cpu: 1m
+        memory: 64Mi
+
+# Migration job values (disabled by default, enabled one-time per environment to copy data).
+migration:
+  enabled: false
+  oldDb:
+    host: ""
+    secretName: ""
+    adminKey: "database-admin"
+    passwordKey: "database-admin-password"
+    dbNameKey: "database-name"
+  # New (Crunchy) DB: admin secret and app user secret (create manually before migration; name must be RFC 1123, e.g. <fullnameOverride>-pguser-biohub-api).
+  newDb:
+    adminUserKey: "user"
+    adminPasswordKey: "password"
+    # App user secret: create manually before migration. Leave empty to use <fullnameOverride>-pguser-biohub-api (hyphen, not underscore).
+    appUserSecretName: ""
+    appUserKey: "user"
+    appPasswordKey: "password"

--- a/infrastructure/database-setup/templates/job.yaml
+++ b/infrastructure/database-setup/templates/job.yaml
@@ -61,8 +61,8 @@ spec:
                   name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
                   key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminPasswordKey | default "password" }}{{ else }}database-admin-password{{ end }}
             {{- if .Values.app.database.useCrunchy }}
-            - name: PGSSLMODE
-              value: "require"
+            - name: PG_SSL_CA_PATH
+              value: "/etc/pg-ssl/{{ .Values.app.database.caSecretKey }}"
             {{- end }}
             - name: DB_USER_API
               valueFrom:
@@ -91,6 +91,12 @@ spec:
               value: {{ .Values.app.dbSchema }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.image }}:{{ include "app.imageTag" . }}"
           imagePullPolicy: Always
+          {{- if .Values.app.database.useCrunchy }}
+          volumeMounts:
+            - name: pg-root-ca
+              mountPath: /etc/pg-ssl
+              readOnly: true
+          {{- end }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
@@ -98,6 +104,15 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+      {{- if .Values.app.database.useCrunchy }}
+      volumes:
+        - name: pg-root-ca
+          secret:
+            secretName: {{ .Values.app.database.caSecretName }}
+            items:
+              - key: {{ .Values.app.database.caSecretKey }}
+                path: {{ .Values.app.database.caSecretKey }}
+      {{- end }}
       restartPolicy: Never
       activeDeadlineSeconds: 900
       dnsPolicy: ClusterFirst

--- a/infrastructure/database-setup/templates/job.yaml
+++ b/infrastructure/database-setup/templates/job.yaml
@@ -22,59 +22,63 @@ spec:
           args:
             - |
               echo "Waiting for database to be ready..."
-              until pg_isready -h {{ include "dbHost" . }} -p 5432 -U $DB_ADMIN; do
+              until pg_isready -h $DB_HOST -p 5432 -U $DB_ADMIN; do
                 echo "Database not ready, waiting..."
                 sleep 5
               done
               echo "Database is ready!"
           env:
             - name: DB_HOST
-              value: {{ include "dbHost" . }}
+              value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.migrationHost | default .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
             - name: DB_ADMIN
               valueFrom:
                 secretKeyRef:
-                  key: database-admin
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminUserKey | default "user" }}{{ else }}database-admin{{ end }}
             - name: DB_ADMIN_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-admin-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminPasswordKey | default "password" }}{{ else }}database-admin-password{{ end }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: database-admin-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminPasswordKey | default "password" }}{{ else }}database-admin-password{{ end }}
       containers:
         - name: postgresql
           env:
             - name: DB_HOST
-              value: {{ include "dbHost" . }}
+              value: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.migrationHost | default .Values.app.database.host }}{{ else }}{{ include "dbHost" . }}{{ end }}
             - name: DB_ADMIN
               valueFrom:
                 secretKeyRef:
-                  key: database-admin
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminUserKey | default "user" }}{{ else }}database-admin{{ end }}
             - name: DB_ADMIN_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-admin-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.adminPasswordKey | default "password" }}{{ else }}database-admin-password{{ end }}
+            {{- if .Values.app.database.useCrunchy }}
+            - name: PGSSLMODE
+              value: "require"
+            {{- end }}
             - name: DB_USER_API
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appUserKey | default "user" }}{{ else }}database-user-api{{ end }}
             - name: DB_USER_API_PASS
               valueFrom:
                 secretKeyRef:
-                  key: database-user-api-password
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.appPasswordKey | default "password" }}{{ else }}database-user-api-password{{ end }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:
-                  key: database-name
-                  name: {{ include "dbHost" . }}
+                  name: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameSecretName }}{{ else }}{{ include "dbHost" . }}{{ end }}
+                  key: {{ if .Values.app.database.useCrunchy }}{{ .Values.app.database.dbNameKey | default "dbname" }}{{ else }}database-name{{ end }}
             - name: DB_PORT
               value: '5432'
             - name: CHANGE_VERSION

--- a/infrastructure/database-setup/values.yaml
+++ b/infrastructure/database-setup/values.yaml
@@ -26,6 +26,9 @@ app:
     appSecretName: "" # e.g. "biohubbc-db-dev-pguser-biohub-api"
     dbNameSecretName: "" # e.g. "biohubbc-db-dev-pguser-biohubbc-db-dev"
     # Secret keys default in templates: user/password/dbname (override in parent values if needed)
+    # PGO root CA for TLS verification (same secret name in all envs)
+    caSecretName: "pgo-root-cacert"
+    caSecretKey: "root.crt"
 
 # Openshift Resources
 resources:

--- a/infrastructure/database-setup/values.yaml
+++ b/infrastructure/database-setup/values.yaml
@@ -17,6 +17,16 @@ app:
 
   dbSchema: biohub # Database schema
 
+  database:
+    # useCrunchy: true = Crunchy Postgres (DEV/TEST/PROD). Set to false for PR environments (legacy dbHost secret).
+    useCrunchy: true
+    host: "" # e.g. "biohubbc-db-dev-primary" (use -primary not pgbouncer; also used for migrations unless migrationHost set)
+    migrationHost: "" # optional; defaults to host when empty (set only if migration target differs from app host)
+    adminSecretName: "" # e.g. "biohubbc-db-dev-pguser-postgres"
+    appSecretName: "" # e.g. "biohubbc-db-dev-pguser-biohub-api"
+    dbNameSecretName: "" # e.g. "biohubbc-db-dev-pguser-biohubbc-db-dev"
+    # Secret keys default in templates: user/password/dbname (override in parent values if needed)
+
 # Openshift Resources
 resources:
   requests:


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-850](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-850)

## Description of Changes

- **Crunchy Postgres for DEV/TEST/PROD**: New Helm chart `infrastructure/crunchy-db` deploys Crunchy Postgres (PGO) as a separate release. Static environments (dev/test/prod) disable the in-repo database subchart and use Crunchy; PR previews keep the legacy single-pod Postgres.
- **One-time migration job**: Optional migration Job (pg_dump from legacy DB → pg_restore into Crunchy) with manual app-user secret (`<release>-pguser-biohub-api`). Post-restore step sets `search_path` and ACLs for `biohub_api` so the API can resolve and run biohub schema functions.
- **API and database-setup**: Default `useCrunchy: true`; connection details (host, secret names) come from values. Secret keys (`user`/`password`/`dbname`) default in templates so env values only set host and secret names. PRs explicitly set `useCrunchy: false` and use the legacy `dbHost` secret.
- **Simplified values**: Removed redundant `migrationHost` when same as `host` (template defaults); removed duplicate `adminUserKey`/`appUserKey`/etc. from dev/test/prod.
- **CI**: Removed `buildAndPushDatabase` job and its dependency from the deploy job for static envs; Chart description and `biohubbc-db-setup` dependency updated.

## Testing Notes

- **PR previews**: Ensure `useCrunchy: false` for api and db-setup so PRs still use the legacy database secret and keys.
- **DEV/TEST/PROD (after Crunchy is deployed)**: Create the app user secret before running migration (see `docs/LOCAL-DEV-TEST.md`). Run migration once with `migration.enabled=true`, then set it false. Verify API and db-setup use Crunchy primary and `pguser-biohub-api` secret.