### PR TITLE
SIMSBIOHUB-850: Update backup schedules and retention

### DIFF
--- a/infrastructure/crunchy-db/Chart.lock
+++ b/infrastructure/crunchy-db/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: crunchy-postgres
-  repository: https://bcgov.github.io/crunchy-postgres/
-  version: 0.6.6
-digest: sha256:e7d340d8b2a1fc12c941a247a075ffb31d3beee821d69a0fb4c283863a1912f1
-generated: "2026-02-24T11:59:44.706537-07:00"

--- a/infrastructure/crunchy-db/Chart.yaml
+++ b/infrastructure/crunchy-db/Chart.yaml
@@ -1,11 +1,7 @@
 apiVersion: v2
-name: biohubbc-crunchy-db
-description: A Helm chart for SIMS Crunchy Postgres Cluster (DEV/TEST/PROD only)
+appVersion: 5.5.1
+description: A Helm chart for SIMS Crunchy Postgres Cluster (DEV/TEST/PROD only), based on the BCGov Crunchy Postgres Helm chart.
+name: crunchy-postgres
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
-
-dependencies:
-  - name: crunchy-postgres
-    version: 0.6.6
-    repository: https://bcgov.github.io/crunchy-postgres/

--- a/infrastructure/crunchy-db/templates/PostgresCluster.yaml
+++ b/infrastructure/crunchy-db/templates/PostgresCluster.yaml
@@ -1,0 +1,213 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  openshift: {{ .Values.openshift }}
+  metadata:
+    labels: {{ include "crunchy-postgres.labels" . | nindent 6 }}
+  {{ if .Values.crunchyImage }}  
+  image: {{ .Values.crunchyImage }}
+  {{ end }}
+  imagePullPolicy: {{.Values.imagePullPolicy}}
+  postgresVersion: {{ .Values.postgresVersion }}
+  {{ if .Values.postGISVersion }}
+  postGISVersion: {{ .Values.postGISVersion | quote }}
+  {{ end }}
+  postgresVersion: {{ .Values.postgresVersion }}
+
+  {{ if .Values.pgmonitor.enabled }}
+
+  monitoring:
+    pgmonitor:
+      # this stuff is for the "exporter" container in the "postgres-cluster-ha" set of pods
+      exporter:
+        {{ if .Values.pgmonitor.exporter.image}}
+        image: {{ .Values.pgmonitor.exporter.image}}
+        {{ end }}
+        resources:
+          requests:
+            cpu: {{ .Values.pgmonitor.exporter.requests.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.requests.memory }}
+          {{ if .Values.pgmonitor.exporter.limits }}
+          limits:
+            cpu: {{ .Values.pgmonitor.exporter.limits.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.limits.memory }}
+          {{ end }}
+
+  {{ end }}
+
+  instances:
+    - name: {{ .Values.instances.name }}
+      replicas: {{ .Values.instances.replicas }}
+      resources:
+        requests:
+          cpu: {{ .Values.instances.requests.cpu }}
+          memory: {{ .Values.instances.requests.memory }}
+        {{ if .Values.instances.limits }}
+        limits:
+          cpu: {{ .Values.instances.limits.cpu }}
+          memory: {{ .Values.instances.limits.memory }}
+        {{ end }}
+      sidecars:
+        replicaCertCopy:
+          resources:
+            requests:
+              cpu: {{ .Values.instances.replicaCertCopy.requests.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.requests.memory }}
+            {{ if .Values.instances.replicaCertCopy.limits }}
+            limits:
+              cpu: {{ .Values.instances.replicaCertCopy.limits.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.limits.memory }}
+            {{ end }}
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.instances.dataVolumeClaimSpec.storage }}
+        storageClassName: {{ .Values.instances.dataVolumeClaimSpec.storageClassName }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ template "crunchy-postgres.fullname" . }}
+                    postgres-operator.crunchydata.com/instance-set: {{ .Values.instances.name }}-ha
+  
+  users:
+    - name: {{ template "crunchy-postgres.fullname" . }}
+      databases:
+        - {{ template "crunchy-postgres.fullname" . }}
+      options: "CREATEROLE"
+    - name: postgres
+      databases:
+        - {{ template "crunchy-postgres.fullname" . }}
+
+  {{ if .Values.dataSource.enabled }}
+  dataSource:
+    pgbackrest:
+      configuration:
+        - secret:
+            name: {{ .Values.dataSource.secretName }}
+      global:
+        {{ .Values.dataSource.repo.name }}-path: {{ .Values.dataSource.repo.path | quote }}
+      repo:
+        name: {{ .Values.dataSource.repo.name }}
+        s3:
+          bucket: {{ .Values.dataSource.repo.s3.bucket }}
+          endpoint: {{ .Values.dataSource.repo.s3.endpoint }}
+          region: {{ .Values.dataSource.repo.s3.region }}
+      stanza: {{ .Values.dataSource.stanza }}
+  {{ end }}
+  
+  backups:
+    pgbackrest:
+      {{ if .Values.pgBackRest.image }}
+      image: {{ .Values.pgBackRest.image }}
+      {{ end }}
+      configuration:
+        - secret:
+            name: {{ .Values.pgBackRest.s3.s3Secret }}
+      global:
+        {{- range .Values.pgBackRest.repos }}
+        {{ .name }}-path: {{ .path | quote }}
+        {{ .name }}-retention-full: {{ .retention | quote }}
+        {{ .name }}-retention-full-type: {{ .retentionFullType }}
+        {{ .name }}-s3-uri-style: {{ $.Values.pgBackRest.s3.s3UriStyle }}
+        {{- end }}
+      repos:
+        {{- range .Values.pgBackRest.repos }}
+        - name: {{ .name }}
+          schedules:
+            full: {{ .fullSchedule | quote }}
+          s3:
+            bucket: {{ $.Values.pgBackRest.s3.bucket }}
+            endpoint: {{ $.Values.pgBackRest.s3.endpoint }}
+            region: {{ $.Values.pgBackRest.s3.region }}
+        {{- end }}
+      # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
+      repoHost:
+        resources:
+          requests:
+            cpu: {{ .Values.pgBackRest.repoHost.requests.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.requests.memory }}
+          {{- if .Values.pgBackRest.repoHost.limits }}
+          limits:
+            cpu: {{ .Values.pgBackRest.repoHost.limits.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.limits.memory }}
+          {{- end }}
+      sidecars:
+        # this stuff is for the "pgbackrest" container in the "postgres-crunchy-ha" set of pods
+        pgbackrest:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
+        pgbackrestConfig:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
+  standby:
+    enabled: {{ .Values.standby.enabled }}
+    repoName: {{ .Values.standby.repoName }}
+  
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        pg_hba:
+          - {{ .Values.patroni.postgresql.pg_hba}}
+        parameters:
+          shared_buffers: {{ .Values.patroni.postgresql.parameters.shared_buffers }}
+          wal_buffers: {{ .Values.patroni.postgresql.parameters.wal_buffers }}
+          min_wal_size: {{ .Values.patroni.postgresql.parameters.min_wal_size }}
+          max_wal_size: {{ .Values.patroni.postgresql.parameters.max_wal_size }}
+          max_slot_wal_keep_size:  {{ .Values.patroni.postgresql.parameters.max_slot_wal_keep_size }}
+  
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          client_tls_sslmode: disable
+      {{ if .Values.proxy.pgBouncer.image }}
+      image: {{ .Values.proxy.pgBouncer.image }}
+      {{ end }}
+      replicas: {{ .Values.proxy.pgBouncer.replicas }}
+      # these resources are for the "pgbouncer" container in the "postgres-crunchy-ha-pgbouncer" set of pods
+      # there is a sidecar in these pods which are not mentioned here, but the requests/limits are teeny weeny by default so no worries there.
+      resources:
+        requests:
+          cpu: {{ .Values.proxy.pgBouncer.requests.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.requests.memory }}
+        {{ if .Values.proxy.pgBouncer.limits }}
+        limits:
+          cpu: {{ .Values.proxy.pgBouncer.limits.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.limits.memory }}
+        {{ end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ template "crunchy-postgres.fullname" . }}
+                    postgres-operator.crunchydata.com/role: pgbouncer

--- a/infrastructure/crunchy-db/templates/_helpers.tpl
+++ b/infrastructure/crunchy-db/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "crunchy-postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "crunchy-postgres.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "crunchy-postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "crunchy-postgres.labels" -}}
+helm.sh/chart: {{ include "crunchy-postgres.chart" . }}
+{{ include "crunchy-postgres.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "crunchy-postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "crunchy-postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "crunchy-postgres.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "crunchy-postgres.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infrastructure/crunchy-db/templates/_s3.tpl
+++ b/infrastructure/crunchy-db/templates/_s3.tpl
@@ -1,0 +1,26 @@
+{{/* Output S3 credential lines for one repo (index 0 = repo1, 1 = repo2, ...). */}}
+{{- define "postgres.s3" }}
+{{- if .s3 }}
+  {{- if .s3.key }}
+repo{{ add .index 1 }}-s3-key={{ .s3.key }}
+  {{- end }}
+  {{- if .s3.keySecret }}
+repo{{ add .index 1 }}-s3-key-secret={{ .s3.keySecret }}
+  {{- end }}
+  {{- if .s3.keyType }}
+repo{{ add .index 1 }}-s3-key-type={{ .s3.keyType }}
+  {{- end }}
+  {{- if .s3.encryptionPassphrase }}
+repo{{ add .index 1 }}-cipher-pass={{ .s3.encryptionPassphrase }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Full S3 config for all four repos (repo1-repo4). Pass root context (.). */}}
+{{- define "postgres.s3.full" -}}
+[global]
+{{- $root := . }}
+{{- range $i := until 4 }}
+{{ include "postgres.s3" (dict "s3" $root.Values.pgBackRest.s3 "index" $i) }}
+{{- end }}
+{{- end }}

--- a/infrastructure/crunchy-db/templates/s3Secret.yaml
+++ b/infrastructure/crunchy-db/templates/s3Secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.pgBackRest.s3.createS3Secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.pgBackRest.s3.s3Secret }}
+type: Opaque
+data:
+  s3.conf: {{ include "postgres.s3.full" . | b64enc }}
+{{- end }}

--- a/infrastructure/crunchy-db/values-dev.yaml
+++ b/infrastructure/crunchy-db/values-dev.yaml
@@ -1,30 +1,47 @@
 # DEV environment overrides for Crunchy Postgres cluster.
 # Single instance (no HA), separate S3 backup path.
 
-crunchy-postgres:
-  fullnameOverride: biohubbc-db-dev
+fullnameOverride: biohubbc-db-dev
 
-  instances:
+instances:
+  replicas: 1
+  dataVolumeClaimSpec:
+    storage: 5Gi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+proxy:
+  pgBouncer:
     replicas: 1
-    dataVolumeClaimSpec:
-      storage: 5Gi
-    requests:
-      cpu: 50m
-      memory: 256Mi
 
-  proxy:
-    pgBouncer:
-      replicas: 1
+pgBackRest:
+  repos:
+    - name: repo1
+      path: "/biohubbc/dev/hourly"
+      fullSchedule: "0 12 * * *"
+      retention: "1"
+      retentionFullType: count
+    - name: repo2
+      path: "/biohubbc/dev/daily"
+      fullSchedule: "0 0 * * *"
+      retention: "7"
+      retentionFullType: count
+    - name: repo3
+      path: "/biohubbc/dev/weekly"
+      fullSchedule: "0 1 * * 0"
+      retention: "4"
+      retentionFullType: count
+    - name: repo4
+      path: "/biohubbc/dev/monthly"
+      fullSchedule: "0 3 1 * *"
+      retention: "12"
+      retentionFullType: count
 
-  pgBackRest:
-    retention: "7"
-    s3:
-      s3Path: "/biohubbc/dev"
-
-  patroni:
-    postgresql:
-      parameters:
-        shared_buffers: 16MB
+patroni:
+  postgresql:
+    parameters:
+      shared_buffers: 16MB
 
 # To perform the one-time data migration from the old database, set:
 #   migration.enabled: true

--- a/infrastructure/crunchy-db/values-prod.yaml
+++ b/infrastructure/crunchy-db/values-prod.yaml
@@ -1,30 +1,47 @@
 # PROD environment overrides for Crunchy Postgres cluster.
 # High-availability: 2 instances + 2 pgBouncer replicas, separate S3 backup path, higher retention.
 
-crunchy-postgres:
-  fullnameOverride: biohubbc-db-prod
+fullnameOverride: biohubbc-db-prod
 
-  instances:
+instances:
+  replicas: 2
+  dataVolumeClaimSpec:
+    storage: 20Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+proxy:
+  pgBouncer:
     replicas: 2
-    dataVolumeClaimSpec:
-      storage: 20Gi
-    requests:
-      cpu: 100m
-      memory: 512Mi
 
-  proxy:
-    pgBouncer:
-      replicas: 2
+pgBackRest:
+  repos:
+    - name: repo1
+      path: "/biohubbc/prod/hourly"
+      fullSchedule: "0 12 * * *"
+      retention: "1"
+      retentionFullType: count
+    - name: repo2
+      path: "/biohubbc/prod/daily"
+      fullSchedule: "0 0 * * *"
+      retention: "7"
+      retentionFullType: count
+    - name: repo3
+      path: "/biohubbc/prod/weekly"
+      fullSchedule: "0 1 * * 0"
+      retention: "4"
+      retentionFullType: count
+    - name: repo4
+      path: "/biohubbc/prod/monthly"
+      fullSchedule: "0 3 1 * *"
+      retention: "12"
+      retentionFullType: count
 
-  pgBackRest:
-    retention: "30"
-    s3:
-      s3Path: "/biohubbc/prod"
-
-  patroni:
-    postgresql:
-      parameters:
-        shared_buffers: 64MB
+patroni:
+  postgresql:
+    parameters:
+      shared_buffers: 64MB
 
 # To perform the one-time data migration from the old database, set:
 #   migration.enabled: true

--- a/infrastructure/crunchy-db/values-test.yaml
+++ b/infrastructure/crunchy-db/values-test.yaml
@@ -1,30 +1,47 @@
 # TEST environment overrides for Crunchy Postgres cluster.
 # High-availability: 2 instances + 2 pgBouncer replicas, separate S3 backup path.
 
-crunchy-postgres:
-  fullnameOverride: biohubbc-db-test
+fullnameOverride: biohubbc-db-test
 
-  instances:
+instances:
+  replicas: 2
+  dataVolumeClaimSpec:
+    storage: 10Gi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+proxy:
+  pgBouncer:
     replicas: 2
-    dataVolumeClaimSpec:
-      storage: 10Gi
-    requests:
-      cpu: 50m
-      memory: 256Mi
 
-  proxy:
-    pgBouncer:
-      replicas: 2
+pgBackRest:
+  repos:
+    - name: repo1
+      path: "/biohubbc/test/hourly"
+      fullSchedule: "0 12 * * *"
+      retention: "1"
+      retentionFullType: count
+    - name: repo2
+      path: "/biohubbc/test/daily"
+      fullSchedule: "0 0 * * *"
+      retention: "7"
+      retentionFullType: count
+    - name: repo3
+      path: "/biohubbc/test/weekly"
+      fullSchedule: "0 1 * * 0"
+      retention: "4"
+      retentionFullType: count
+    - name: repo4
+      path: "/biohubbc/test/monthly"
+      fullSchedule: "0 3 1 * *"
+      retention: "12"
+      retentionFullType: count
 
-  pgBackRest:
-    retention: "14"
-    s3:
-      s3Path: "/biohubbc/test"
-
-  patroni:
-    postgresql:
-      parameters:
-        shared_buffers: 32MB
+patroni:
+  postgresql:
+    parameters:
+      shared_buffers: 32MB
 
 # To perform the one-time data migration from the old database, set:
 #   migration.enabled: true

--- a/infrastructure/crunchy-db/values.yaml
+++ b/infrastructure/crunchy-db/values.yaml
@@ -2,107 +2,118 @@
 # Environment-specific overrides are in values-dev.yaml, values-test.yaml, values-prod.yaml.
 # This chart is NOT used for PR preview environments, which use the vanilla database subchart.
 
-crunchy-postgres:
-  # Overridden per environment (e.g. biohubbc-db-dev in values-dev.yaml)
-  fullnameOverride: biohubbc-db
+# Overridden per environment (e.g. biohubbc-db-dev in values-dev.yaml)
+fullnameOverride: biohubbc-db
 
-  # PostGIS-enabled image for PostgreSQL 17
-  crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi9-17.7-3.5-2547
-  postgresVersion: 17
-  postGISVersion: '3.5'
-  imagePullPolicy: IfNotPresent
-  openshift: true
+# PostGIS-enabled image for PostgreSQL 17
+crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi9-17.7-3.5-2547
+postgresVersion: 17
+postGISVersion: '3.5'
+imagePullPolicy: IfNotPresent
+openshift: true
 
-  standby:
-    enabled: false
-    repoName: repo2
+# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary.
+standby:
+  enabled: false
+  # repo2 = daily tier; used for restore/standby
+  repoName: repo2
 
-  instances:
-    name: ha
-    replicas: 1
-    dataVolumeClaimSpec:
-      storage: 5Gi
-      storageClassName: netapp-block-standard
+instances:
+  name: ha
+  replicas: 1
+  dataVolumeClaimSpec:
+    storage: 5Gi
+    storageClassName: netapp-block-standard
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  replicaCertCopy:
     requests:
-      cpu: 50m
-      memory: 256Mi
-    replicaCertCopy:
-      requests:
-        cpu: 1m
-        memory: 32Mi
+      cpu: 1m
+      memory: 32Mi
 
-  dataSource:
-    enabled: false
-    secretName: s3-pgbackrest
-    repo:
-      name: repo2
-      path: "/biohubbc/dev"
-      s3:
-        bucket: "vjfnyw"
-        endpoint: "https://nrs.objectstore.gov.bc.ca:443"
-        region: "ca-central-1"
-    stanza: db
-
-  pgBackRest:
-    retention: "7"
-    retentionFullType: count
-    repo1:
-      enabled: true
-    repos:
-      schedules:
-        full: 0 8 * * *
-        incremental: 0 0,4,12,16,20 * * *
-      volume:
-        accessModes: "ReadWriteOnce"
-        storage: 512Mi
-        storageClassName: netapp-file-backup
-    repoHost:
-      requests:
-        cpu: 1m
-        memory: 64Mi
-    sidecars:
-      requests:
-        cpu: 1m
-        memory: 64Mi
+# If we need to restore the cluster from a backup, set dataSource.enabled and point repo to the desired tier (e.g. repo2 = daily).
+dataSource:
+  enabled: false
+  secretName: s3-pgbackrest
+  repo:
+    name: repo2
+    path: "/biohubbc/dev/daily"
     s3:
-      enabled: true
-      # The s3-pgbackrest secret must be pre-created in the namespace before deploying this chart.
-      createS3Secret: false
-      s3Secret: s3-pgbackrest
-      # s3Path is overridden per environment to keep backups separated.
-      s3Path: "/biohubbc/dev"
-      s3UriStyle: path
       bucket: "vjfnyw"
       endpoint: "https://nrs.objectstore.gov.bc.ca:443"
       region: "ca-central-1"
-      key: ""
-      keySecret: ""
-      fullSchedule: "0 9 * * *"
-      incrementalSchedule: "0 1,5,13,17,21 * * *"
+  stanza: db
 
-  patroni:
-    postgresql:
-      pg_hba: "host all all 0.0.0.0/0 md5"
-      parameters:
-        shared_buffers: 16MB
-        wal_buffers: "64kB"
-        min_wal_size: 32MB
-        max_wal_size: 64MB
-        max_slot_wal_keep_size: 128MB
+pgBackRest:
+  retention: "7"
+  retentionFullType: count
+  repoHost:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+  sidecars:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+  s3:
+    enabled: true
+    # The s3-pgbackrest secret must be pre-created in the namespace before deploying this chart.
+    createS3Secret: false
+    s3Secret: s3-pgbackrest
+    s3UriStyle: path
+    bucket: "vjfnyw"
+    endpoint: "https://nrs.objectstore.gov.bc.ca:443"
+    region: "ca-central-1"
+    key: ""
+    keySecret: ""
 
-  proxy:
-    pgBouncer:
-      replicas: 1
-      requests:
-        cpu: 1m
-        memory: 64Mi
+  # Four S3 repos with distinct schedules and time-based retention. Override paths per environment if needed.
+  repos:
+    - name: repo1
+      path: "/biohubbc/dev/hourly"
+      fullSchedule: "0 12 * * *"
+      retention: "1"
+      retentionFullType: count
+    - name: repo2
+      path: "/biohubbc/dev/daily"
+      fullSchedule: "0 0 * * *"
+      retention: "7"
+      retentionFullType: count
+    - name: repo3
+      path: "/biohubbc/dev/weekly"
+      fullSchedule: "0 1 * * 0"
+      retention: "4"
+      retentionFullType: count
+    - name: repo4
+      path: "/biohubbc/dev/monthly"
+      fullSchedule: "0 3 1 * *"
+      retention: "12"
+      retentionFullType: count
 
-  pgmonitor:
-    enabled: false
-    exporter:
-      requests:
-        cpu: 1m
-        memory: 64Mi
+patroni:
+  postgresql:
+    pg_hba: "host all all 0.0.0.0/0 md5"
+    parameters:
+      shared_buffers: 16MB
+      wal_buffers: "64kB"
+      min_wal_size: 32MB
+      max_wal_size: 64MB
+      max_slot_wal_keep_size: 128MB
+
+proxy:
+  pgBouncer:
+    replicas: 1
+    requests:
+      cpu: 1m
+      memory: 64Mi
+
+pgmonitor:
+  enabled: false
+  exporter:
+    requests:
+      cpu: 1m
+      memory: 64Mi
 
 # Migration job values (disabled by default, enabled one-time per environment to copy data).
 migration:


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-850](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-850)

## Description of Changes

- **Crunchy Postgres backup schedules and retention:** Refactored the `infrastructure/crunchy-db` Helm chart to use four pgBackRest repos (hourly, daily, weekly, monthly) with distinct schedules and retention per environment (dev/test/prod).
- **Chart structure:** Inlined the PostgresCluster and related templates (no longer using the crunchy-postgres subchart); updated `Chart.yaml` (removed subchart dependency, added appVersion); removed `Chart.lock`.
- **New/updated templates:** Added `PostgresCluster.yaml`, `_helpers.tpl`, `_s3.tpl`, and `s3Secret.yaml`; backup config now drives schedules and retention from `pgBackRest.repos` in values.
- **Values:** Restructured base `values.yaml` and environment overrides (`values-dev.yaml`, `values-test.yaml`, `values-prod.yaml`) so each environment defines four repos with path, full schedule, retention count, and retention type. Data source path updated to use the daily tier (e.g. `/biohubbc/dev/daily`) for restore/standby.

## Testing Notes

- Deploy the crunchy-db chart in a dev/test namespace and confirm the PostgresCluster and repo-host pods come up; verify pgBackRest cron jobs/schedules for the four repos.
- Optionally run a manual full backup and confirm objects appear under the expected S3 paths (e.g. `/biohubbc/<env>/hourly`, `/biohubbc/<env>/daily`, etc.).
- If testing restore/standby, set `dataSource.enabled: true` and ensure the daily repo path and stanza match the backup location.