### PR TITLE
SIMSBIOHUB-887: Collapse child features into parent

### DIFF
--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -6,13 +6,11 @@ import { SurveyObservationRecord } from '../database-models/survey_observation';
 import { ICritterDetailed } from '../services/critterbase-service';
 import {
   PostSurveyAnimalToBiohubObject,
-  PostSurveyEnvironmentalConditionToBiohubObject,
   PostSurveyMarkingToBiohubObject,
   PostSurveyMeasurementToBiohubObject,
   PostSurveyMortalityToBiohubObject,
   PostSurveyObservationToBiohubObject,
   PostSurveyReleaseToBiohubObject,
-  PostSurveySubcountToBiohubObject,
   PostSurveySubmissionToBioHubObject,
   PostSurveyToBiohubObject
 } from './biohub-create';
@@ -68,11 +66,17 @@ describe('PostSurveyObservationToBiohubObject', () => {
               properties: {}
             }
           ]
-        }
+        },
+        environmental_condition: null,
+        environmental_condition_value: null,
+        subcount_comment: null,
+        subcount_count: null,
+        subcount_measurement_type: null,
+        subcount_measurement_value: null
       });
     });
 
-    it('sets child_features to empty array when no environmental data', () => {
+    it('sets child_features to empty array', () => {
       expect(data.child_features).to.eql([]);
     });
   });
@@ -113,22 +117,12 @@ describe('PostSurveyObservationToBiohubObject', () => {
       data = new PostSurveyObservationToBiohubObject(objWithEnvironments);
     });
 
-    it('creates environmental condition child features', () => {
-      expect(data.child_features).to.have.length(2);
-
-      const qualitativeEnvFeature = data.child_features[0];
-      expect(qualitativeEnvFeature.type).to.equal('observation_environmental_condition');
-      expect(qualitativeEnvFeature.properties).to.eql({
-        environmental_condition: 'code::environment_qualitative::env-qual-uuid-1',
-        environmental_condition_value: 'code::environment_qualitative_option::env-qual-opt-uuid-1'
-      });
-
-      const quantitativeEnvFeature = data.child_features[1];
-      expect(quantitativeEnvFeature.type).to.equal('observation_environmental_condition');
-      expect(quantitativeEnvFeature.properties).to.eql({
-        environmental_condition: 'code::environment_quantitative::env-quant-uuid-1',
-        environmental_condition_value: '25.5'
-      });
+    it('creates environmental_condition and environmental_condition_value on properties (first only)', () => {
+      expect(data.properties.environmental_condition).to.equal('code::environment_qualitative::env-qual-uuid-1');
+      expect(data.properties.environmental_condition_value).to.equal(
+        'code::environment_qualitative_option::env-qual-opt-uuid-1'
+      );
+      expect(data.child_features).to.eql([]);
     });
   });
 
@@ -202,22 +196,10 @@ describe('PostSurveyObservationToBiohubObject', () => {
       data = new PostSurveyObservationToBiohubObject(objWithEnvironments, environmentDefinitions);
     });
 
-    it('creates environmental condition child features with human-readable names', () => {
-      expect(data.child_features).to.have.length(2);
-
-      const qualitativeEnvFeature = data.child_features[0];
-      expect(qualitativeEnvFeature.type).to.equal('observation_environmental_condition');
-      expect(qualitativeEnvFeature.properties).to.eql({
-        environmental_condition: 'code::environment_qualitative::temp-category-uuid',
-        environmental_condition_value: 'code::environment_qualitative_option::cold-uuid'
-      });
-
-      const quantitativeEnvFeature = data.child_features[1];
-      expect(quantitativeEnvFeature.type).to.equal('observation_environmental_condition');
-      expect(quantitativeEnvFeature.properties).to.eql({
-        environmental_condition: 'code::environment_quantitative::wind-speed-uuid',
-        environmental_condition_value: '15.2 meter'
-      });
+    it('creates environmental_condition with unit from definitions (first only)', () => {
+      expect(data.properties.environmental_condition).to.equal('code::environment_qualitative::temp-category-uuid');
+      expect(data.properties.environmental_condition_value).to.equal('code::environment_qualitative_option::cold-uuid');
+      expect(data.child_features).to.eql([]);
     });
   });
 
@@ -298,318 +280,12 @@ describe('PostSurveyObservationToBiohubObject', () => {
       data = new PostSurveyObservationToBiohubObject(objWithSubcounts, undefined, measurementDefinitions);
     });
 
-    it('creates subcount child features', () => {
-      expect(data.child_features).to.have.length(2);
-
-      const firstSubcountFeature = data.child_features[0];
-      expect(firstSubcountFeature.type).to.equal('observation_subcount');
-      expect(firstSubcountFeature.properties).to.eql({
-        comment: 'Adult males',
-        count: 5
-      });
-
-      const secondSubcountFeature = data.child_features[1];
-      expect(secondSubcountFeature.type).to.equal('observation_subcount');
-      expect(secondSubcountFeature.properties).to.eql({
-        comment: 'Juveniles',
-        count: 10
-      });
-    });
-  });
-});
-
-describe('PostSurveySubcountToBiohubObject', () => {
-  describe('Qualitative measurement subcount', () => {
-    let data: PostSurveySubcountToBiohubObject;
-
-    const qualitativeSubcountData = {
-      observation_subcount_id: 1,
-      comment: 'Adult males with tracking collars',
-      subcount: 8,
-      qualitative_measurements: [
-        {
-          critterbase_taxon_measurement_id: 'age-class-uuid',
-          critterbase_measurement_qualitative_option_id: 'adult-uuid'
-        }
-      ],
-      quantitative_measurements: []
-    };
-
-    const measurementDefinitions = {
-      qualitative_measurements: [
-        {
-          itis_tsn: 180543 as number | null,
-          taxon_measurement_id: 'age-class-uuid',
-          measurement_name: 'Age Class',
-          measurement_desc: 'Age classification',
-          options: [
-            {
-              qualitative_option_id: 'adult-uuid',
-              option_label: 'Adult',
-              option_value: 1,
-              option_desc: 'Mature individual'
-            }
-          ]
-        }
-      ],
-      quantitative_measurements: []
-    };
-
-    before(() => {
-      data = new PostSurveySubcountToBiohubObject(qualitativeSubcountData, measurementDefinitions);
-    });
-
-    it('sets id', () => {
-      expect(data.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-
-    it('sets type', () => {
-      expect(data.type).to.equal('observation_subcount');
-    });
-
-    it('sets properties for qualitative measurements', () => {
-      expect(data.properties).to.eql({
-        comment: 'Adult males with tracking collars',
-        count: 8
-      });
-    });
-
-    it('sets empty child_features', () => {
+    it('creates subcount and measurement single-value properties (first only)', () => {
+      expect(data.properties.subcount_comment).to.equal('Adult males');
+      expect(data.properties.subcount_count).to.equal(5);
+      expect(data.properties.subcount_measurement_type).to.be.null;
+      expect(data.properties.subcount_measurement_value).to.be.null;
       expect(data.child_features).to.eql([]);
-    });
-  });
-
-  describe('Quantitative measurement subcount', () => {
-    let data: PostSurveySubcountToBiohubObject;
-
-    const quantitativeSubcountData = {
-      observation_subcount_id: 2,
-      comment: 'Weighed individuals',
-      subcount: 3,
-      qualitative_measurements: [],
-      quantitative_measurements: [
-        {
-          critterbase_taxon_measurement_id: 'weight-uuid',
-          value: 45.7
-        }
-      ]
-    };
-
-    const measurementDefinitions = {
-      qualitative_measurements: [],
-      quantitative_measurements: [
-        {
-          itis_tsn: 180701 as number | null,
-          taxon_measurement_id: 'weight-uuid',
-          measurement_name: 'Body Weight',
-          measurement_desc: 'Individual body weight' as string | null,
-          min_value: 0 as number | null,
-          max_value: 200 as number | null,
-          unit: 'kilogram' as 'kilogram' | null
-        }
-      ]
-    };
-
-    before(() => {
-      data = new PostSurveySubcountToBiohubObject(quantitativeSubcountData, measurementDefinitions);
-    });
-
-    it('sets id', () => {
-      expect(data.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-
-    it('sets type', () => {
-      expect(data.type).to.equal('observation_subcount');
-    });
-
-    it('sets properties for quantitative measurements', () => {
-      expect(data.properties).to.eql({
-        comment: 'Weighed individuals',
-        count: 3
-      });
-    });
-
-    it('sets empty child_features', () => {
-      expect(data.child_features).to.have.length(1);
-      const measurementChild = data.child_features[0];
-      expect(measurementChild.type).to.equal('observation_subcount_measurement');
-      expect(measurementChild.properties).to.eql({
-        measurement_type: 'Body Weight',
-        measurement_value: 45.7
-      });
-    });
-  });
-
-  describe('With missing measurement definitions', () => {
-    let qualData: PostSurveySubcountToBiohubObject;
-    let quantData: PostSurveySubcountToBiohubObject;
-
-    before(() => {
-      qualData = new PostSurveySubcountToBiohubObject({
-        observation_subcount_id: 3,
-        comment: 'Unknown measurement type',
-        subcount: 2,
-        qualitative_measurements: [
-          {
-            critterbase_taxon_measurement_id: 'unknown-measurement-uuid',
-            critterbase_measurement_qualitative_option_id: 'unknown-option-uuid'
-          }
-        ],
-        quantitative_measurements: []
-      });
-
-      quantData = new PostSurveySubcountToBiohubObject({
-        observation_subcount_id: 4,
-        comment: 'Unknown quantitative measurement',
-        subcount: 1,
-        qualitative_measurements: [],
-        quantitative_measurements: [
-          {
-            critterbase_taxon_measurement_id: 'unknown-quant-uuid',
-            value: 123.4
-          }
-        ]
-      });
-    });
-
-    it('uses IDs when measurement names are missing for qualitative', () => {
-      expect(qualData.properties).to.eql({
-        comment: 'Unknown measurement type',
-        count: 2
-      });
-    });
-
-    it('uses ID and no unit when missing for quantitative', () => {
-      expect(quantData.properties).to.eql({
-        comment: 'Unknown quantitative measurement',
-        count: 1
-      });
-    });
-  });
-
-  describe('With no measurements', () => {
-    let data: PostSurveySubcountToBiohubObject;
-
-    before(() => {
-      data = new PostSurveySubcountToBiohubObject({
-        observation_subcount_id: 5,
-        comment: 'General count',
-        subcount: 20,
-        qualitative_measurements: [],
-        quantitative_measurements: []
-      });
-    });
-
-    it('uses empty strings when no measurements available', () => {
-      expect(data.properties).to.eql({
-        comment: 'General count',
-        count: 20
-      });
-    });
-  });
-});
-
-describe('PostSurveyEnvironmentalConditionToBiohubObject', () => {
-  describe('Qualitative environmental condition', () => {
-    let data: PostSurveyEnvironmentalConditionToBiohubObject;
-
-    const qualitativeEnvData = {
-      type: 'qualitative' as const,
-      environment_qualitative_id: 'temp-category-uuid',
-      environment_qualitative_option_id: 'warm-uuid',
-      name: 'Temperature Category',
-      option_name: 'Warm'
-    };
-
-    before(() => {
-      data = new PostSurveyEnvironmentalConditionToBiohubObject(qualitativeEnvData);
-    });
-
-    it('sets id', () => {
-      expect(data.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-
-    it('sets type', () => {
-      expect(data.type).to.equal('observation_environmental_condition');
-    });
-
-    it('sets properties for qualitative data', () => {
-      expect(data.properties).to.eql({
-        environmental_condition: 'code::environment_qualitative::temp-category-uuid',
-        environmental_condition_value: 'code::environment_qualitative_option::warm-uuid'
-      });
-    });
-
-    it('sets empty child_features', () => {
-      expect(data.child_features).to.eql([]);
-    });
-  });
-
-  describe('Quantitative environmental condition', () => {
-    let data: PostSurveyEnvironmentalConditionToBiohubObject;
-
-    const quantitativeEnvData = {
-      type: 'quantitative' as const,
-      environment_quantitative_id: 'temperature-uuid',
-      value: 23.5,
-      name: 'Temperature',
-      unit: '°C'
-    };
-
-    before(() => {
-      data = new PostSurveyEnvironmentalConditionToBiohubObject(quantitativeEnvData);
-    });
-
-    it('sets id', () => {
-      expect(data.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-
-    it('sets type', () => {
-      expect(data.type).to.equal('observation_environmental_condition');
-    });
-
-    it('sets properties for quantitative data', () => {
-      expect(data.properties).to.eql({
-        environmental_condition: 'code::environment_quantitative::temperature-uuid',
-        environmental_condition_value: '23.5 °C'
-      });
-    });
-
-    it('sets empty child_features', () => {
-      expect(data.child_features).to.eql([]);
-    });
-  });
-
-  describe('With missing optional fields', () => {
-    let qualData: PostSurveyEnvironmentalConditionToBiohubObject;
-    let quantData: PostSurveyEnvironmentalConditionToBiohubObject;
-
-    before(() => {
-      qualData = new PostSurveyEnvironmentalConditionToBiohubObject({
-        type: 'qualitative',
-        environment_qualitative_id: 'env-qual-uuid',
-        environment_qualitative_option_id: 'env-qual-opt-uuid'
-      });
-
-      quantData = new PostSurveyEnvironmentalConditionToBiohubObject({
-        type: 'quantitative',
-        environment_quantitative_id: 'env-quant-uuid',
-        value: 42
-      });
-    });
-
-    it('uses IDs when names are missing for qualitative', () => {
-      expect(qualData.properties).to.eql({
-        environmental_condition: 'code::environment_qualitative::env-qual-uuid',
-        environmental_condition_value: 'code::environment_qualitative_option::env-qual-opt-uuid'
-      });
-    });
-
-    it('uses ID and no unit when missing for quantitative', () => {
-      expect(quantData.properties).to.eql({
-        environmental_condition: 'code::environment_quantitative::env-quant-uuid',
-        environmental_condition_value: '42'
-      });
     });
   });
 });

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -152,7 +152,6 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.OBSERVATION;
-    // Single-value properties (first item only) collapsed from observation_environmental_condition children
     let environmental_condition: string | null = null;
     let environmental_condition_value: string | null = null;
     if ('qualitative_environments' in observationRecord && observationRecord.qualitative_environments?.[0]) {
@@ -169,7 +168,6 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
       environmental_condition_value = `${env.value}${unitSuffix}`;
     }
 
-    // Single-value properties (first subcount / first measurement only) collapsed from observation_subcount + observation_subcount_measurement
     let subcount_comment: string | null = null;
     let subcount_count: number | null = null;
     let subcount_measurement_type: string | null = null;
@@ -687,7 +685,6 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
       attractant_name: `code::attractant_lookup::${attractant.attractant_lookup_id}`
     }));
 
-    // Single-value properties (first item only) collapsed from sample_technique_detail
     let method_attribute: string | null = null;
     let method_value: string | null = null;
     const firstAttrib = samplingTechniqueRecord.attribute_data?.find(
@@ -705,7 +702,6 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
       }
     }
 
-    // Single-value properties (first item only) collapsed from sample_technique_vantage
     let vantage_method_attribute: string | null = null;
     let vantage_method_value: string | null = null;
     const firstVantage = samplingTechniqueRecord.vantage_data?.find(

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -690,9 +690,9 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
     // Single-value properties (first item only) collapsed from sample_technique_detail
     let method_attribute: string | null = null;
     let method_value: string | null = null;
-    const firstAttrib = samplingTechniqueRecord.attribute_data?.filter(
+    const firstAttrib = samplingTechniqueRecord.attribute_data?.find(
       (a) => a.attribute_header != null || a.attribute_value != null
-    )?.[0];
+    );
     if (firstAttrib) {
       if (firstAttrib.technique_attribute_qualitative_id != null) {
         method_attribute = `code::technique_attribute_qualitative::${firstAttrib.technique_attribute_qualitative_id}`;
@@ -708,9 +708,9 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
     // Single-value properties (first item only) collapsed from sample_technique_vantage
     let vantage_method_attribute: string | null = null;
     let vantage_method_value: string | null = null;
-    const firstVantage = samplingTechniqueRecord.vantage_data?.filter(
+    const firstVantage = samplingTechniqueRecord.vantage_data?.find(
       (v) => v.vantage_header != null || v.vantage_value != null
-    )?.[0];
+    );
     if (firstVantage) {
       if (firstVantage.vantage_category_id != null) {
         vantage_method_attribute = `code::vantage_category::${firstVantage.vantage_category_id}`;

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -152,6 +152,42 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.OBSERVATION;
+    // Single-value properties (first item only) collapsed from observation_environmental_condition children
+    let environmental_condition: string | null = null;
+    let environmental_condition_value: string | null = null;
+    if ('qualitative_environments' in observationRecord && observationRecord.qualitative_environments?.[0]) {
+      const env = observationRecord.qualitative_environments[0];
+      environmental_condition = `code::environment_qualitative::${env.environment_qualitative_id}`;
+      environmental_condition_value = `code::environment_qualitative_option::${env.environment_qualitative_option_id}`;
+    } else if ('quantitative_environments' in observationRecord && observationRecord.quantitative_environments?.[0]) {
+      const env = observationRecord.quantitative_environments[0];
+      const envDef = environmentDefinitions?.quantitative_environments.find(
+        (def) => def.environment_quantitative_id === env.environment_quantitative_id
+      );
+      const unitSuffix = envDef?.unit ? ' ' + envDef.unit : '';
+      environmental_condition = `code::environment_quantitative::${env.environment_quantitative_id}`;
+      environmental_condition_value = `${env.value}${unitSuffix}`;
+    }
+
+    // Single-value properties (first subcount / first measurement only) collapsed from observation_subcount + observation_subcount_measurement
+    let subcount_comment: string | null = null;
+    let subcount_count: number | null = null;
+    let subcount_measurement_type: string | null = null;
+    let subcount_measurement_value: number | null = null;
+    if ('subcounts' in observationRecord && observationRecord.subcounts?.[0]) {
+      const subcount = observationRecord.subcounts[0];
+      subcount_comment = subcount.comment;
+      subcount_count = subcount.subcount;
+      if (subcount.quantitative_measurements?.[0]) {
+        const measurement = subcount.quantitative_measurements[0];
+        const measurementDef = measurementDefinitions?.quantitative_measurements.find(
+          (def) => def.taxon_measurement_id === measurement.critterbase_taxon_measurement_id
+        );
+        subcount_measurement_type = measurementDef?.measurement_name || measurement.critterbase_taxon_measurement_id;
+        subcount_measurement_value = measurement.value;
+      }
+    }
+
     this.properties = {
       survey_id: observationRecord.survey_id,
       taxon_id: observationRecord.itis_tsn,
@@ -176,199 +212,14 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
                 }
               ]
             }
-          : null
+          : null,
+      environmental_condition,
+      environmental_condition_value,
+      subcount_comment,
+      subcount_count,
+      subcount_measurement_type,
+      subcount_measurement_value
     };
-
-    // Create environmental condition child features if available
-    const childFeatures: BioHubSubmissionFeature[] = [];
-
-    if ('qualitative_environments' in observationRecord && observationRecord.qualitative_environments) {
-      for (const env of observationRecord.qualitative_environments) {
-        // Find the environment definition to get the name
-        const envDef = environmentDefinitions?.qualitative_environments.find(
-          (def) => def.environment_qualitative_id === env.environment_qualitative_id
-        );
-        const optionDef = envDef?.options.find(
-          (opt) => opt.environment_qualitative_option_id === env.environment_qualitative_option_id
-        );
-
-        childFeatures.push(
-          new PostSurveyEnvironmentalConditionToBiohubObject({
-            type: 'qualitative',
-            environment_qualitative_id: env.environment_qualitative_id,
-            environment_qualitative_option_id: env.environment_qualitative_option_id,
-            name: envDef?.name,
-            option_name: optionDef?.name
-          })
-        );
-      }
-    }
-
-    if ('quantitative_environments' in observationRecord && observationRecord.quantitative_environments) {
-      for (const env of observationRecord.quantitative_environments) {
-        // Find the environment definition to get the name and unit
-        const envDef = environmentDefinitions?.quantitative_environments.find(
-          (def) => def.environment_quantitative_id === env.environment_quantitative_id
-        );
-
-        childFeatures.push(
-          new PostSurveyEnvironmentalConditionToBiohubObject({
-            type: 'quantitative',
-            environment_quantitative_id: env.environment_quantitative_id,
-            value: env.value,
-            name: envDef?.name,
-            unit: envDef?.unit || undefined
-          })
-        );
-      }
-    }
-
-    // Create subcount child features if available
-    if ('subcounts' in observationRecord && observationRecord.subcounts) {
-      for (const subcount of observationRecord.subcounts) {
-        childFeatures.push(new PostSurveySubcountToBiohubObject(subcount, measurementDefinitions));
-      }
-    }
-
-    this.child_features = childFeatures;
-  }
-}
-
-/**
- * Object to be sent to Biohub API for creating an observation subcount.
- *
- * @export
- * @class PostSurveySubcountToBiohubObject
- * @implements {BioHubSubmissionFeature}
- */
-export class PostSurveySubcountToBiohubObject implements BioHubSubmissionFeature {
-  id: string;
-  type: string;
-  properties: Record<string, unknown>;
-  child_features: BioHubSubmissionFeature[];
-
-  constructor(
-    subcountData: {
-      observation_subcount_id: number | null;
-      comment: string | null;
-      subcount: number | null;
-      qualitative_measurements: {
-        critterbase_taxon_measurement_id: string;
-        critterbase_measurement_qualitative_option_id: string;
-      }[];
-      quantitative_measurements: {
-        critterbase_taxon_measurement_id: string;
-        value: number;
-      }[];
-    },
-    measurementDefinitions?: {
-      qualitative_measurements: CBQualitativeMeasurementTypeDefinition[];
-      quantitative_measurements: CBQuantitativeMeasurementTypeDefinition[];
-    }
-  ) {
-    defaultLog.debug({ label: 'PostSurveySubcountToBiohubObject', message: 'params', subcountData });
-
-    this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.OBSERVATION_SUBCOUNT;
-
-    this.properties = {
-      comment: subcountData.comment,
-      count: subcountData.subcount
-    };
-
-    // Create child features for quantitative measurements
-    this.child_features = [];
-
-    if (subcountData.quantitative_measurements && subcountData.quantitative_measurements.length > 0) {
-      for (const measurement of subcountData.quantitative_measurements) {
-        const measurementDef = measurementDefinitions?.quantitative_measurements.find(
-          (def) => def.taxon_measurement_id === measurement.critterbase_taxon_measurement_id
-        );
-
-        this.child_features.push(new PostObservationSubcountMeasurementToBiohubObject(measurement, measurementDef));
-      }
-    }
-  }
-}
-
-/**
- * Observation Subcount Measurement object to be sent to Biohub API for creating a measurement feature.
- *
- * @export
- * @class PostObservationSubcountMeasurementToBiohubObject
- * @implements {BioHubSubmissionFeature}
- */
-export class PostObservationSubcountMeasurementToBiohubObject implements BioHubSubmissionFeature {
-  id: string;
-  type: string;
-  properties: Record<string, unknown>;
-  child_features: BioHubSubmissionFeature[];
-
-  constructor(
-    measurement: {
-      critterbase_taxon_measurement_id: string;
-      value: number;
-    },
-    measurementDefinition?: CBQuantitativeMeasurementTypeDefinition
-  ) {
-    this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.OBSERVATION_SUBCOUNT_MEASUREMENT;
-
-    this.properties = {
-      measurement_type: measurementDefinition?.measurement_name || measurement.critterbase_taxon_measurement_id,
-      measurement_value: measurement.value
-    };
-
-    this.child_features = [];
-  }
-}
-
-/**
- * Object to be sent to Biohub API for creating an observation environmental condition.
- *
- * @export
- * @class PostSurveyEnvironmentalConditionToBiohubObject
- * @implements {BioHubSubmissionFeature}
- */
-export class PostSurveyEnvironmentalConditionToBiohubObject implements BioHubSubmissionFeature {
-  id: string;
-  type: string;
-  properties: Record<string, unknown>;
-  child_features: BioHubSubmissionFeature[];
-
-  constructor(
-    environmentData:
-      | {
-          type: 'qualitative';
-          environment_qualitative_id: string;
-          environment_qualitative_option_id: string;
-          name?: string;
-          option_name?: string;
-        }
-      | {
-          type: 'quantitative';
-          environment_quantitative_id: string;
-          value: number;
-          name?: string;
-          unit?: string;
-        }
-  ) {
-    defaultLog.debug({ label: 'PostSurveyEnvironmentalConditionToBiohubObject', message: 'params', environmentData });
-
-    this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.OBSERVATION_ENVIRONMENTAL_CONDITION;
-
-    if (environmentData.type === 'qualitative') {
-      this.properties = {
-        environmental_condition: `code::environment_qualitative::${environmentData.environment_qualitative_id}`,
-        environmental_condition_value: `code::environment_qualitative_option::${environmentData.environment_qualitative_option_id}`
-      };
-    } else {
-      this.properties = {
-        environmental_condition: `code::environment_quantitative::${environmentData.environment_quantitative_id}`,
-        environmental_condition_value: `${environmentData.value}${environmentData.unit ? ' ' + environmentData.unit : ''}`
-      };
-    }
 
     this.child_features = [];
   }
@@ -836,6 +687,39 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
       attractant_name: `code::attractant_lookup::${attractant.attractant_lookup_id}`
     }));
 
+    // Single-value properties (first item only) collapsed from sample_technique_detail
+    let method_attribute: string | null = null;
+    let method_value: string | null = null;
+    const firstAttrib = samplingTechniqueRecord.attribute_data?.filter(
+      (a) => a.attribute_header != null || a.attribute_value != null
+    )?.[0];
+    if (firstAttrib) {
+      if (firstAttrib.technique_attribute_qualitative_id != null) {
+        method_attribute = `code::technique_attribute_qualitative::${firstAttrib.technique_attribute_qualitative_id}`;
+      }
+      if (firstAttrib.technique_attribute_qualitative_option_id != null) {
+        method_value = `code::technique_attribute_qualitative_option::${firstAttrib.technique_attribute_qualitative_option_id}`;
+      }
+      if (firstAttrib.technique_attribute_quantitative_id != null) {
+        method_attribute = `code::technique_attribute_quantitative::${firstAttrib.technique_attribute_quantitative_id}`;
+      }
+    }
+
+    // Single-value properties (first item only) collapsed from sample_technique_vantage
+    let vantage_method_attribute: string | null = null;
+    let vantage_method_value: string | null = null;
+    const firstVantage = samplingTechniqueRecord.vantage_data?.filter(
+      (v) => v.vantage_header != null || v.vantage_value != null
+    )?.[0];
+    if (firstVantage) {
+      if (firstVantage.vantage_category_id != null) {
+        vantage_method_attribute = `code::vantage_category::${firstVantage.vantage_category_id}`;
+      }
+      if (firstVantage.vantage_id != null) {
+        vantage_method_value = `code::vantage::${firstVantage.vantage_id}`;
+      }
+    }
+
     this.properties = {
       name: samplingTechniqueRecord.method_name,
       description: samplingTechniqueRecord.description,
@@ -844,98 +728,12 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
       response_metric: `code::method_response_metric::${samplingTechniqueRecord.method_response_metric_id}`,
       ...(samplingTechniqueRecord.distance_threshold
         ? { detect_distance: samplingTechniqueRecord.distance_threshold }
-        : {})
+        : {}),
+      method_attribute,
+      method_value,
+      vantage_method_attribute,
+      vantage_method_value
     };
-
-    // Create sample technique detail child features from attribute_data, filtering out entries where both values are null
-    const techniqueDetailFeatures = samplingTechniqueRecord.attribute_data
-      ? samplingTechniqueRecord.attribute_data
-          .filter((attrib) => attrib.attribute_header != null || attrib.attribute_value != null)
-          .map(
-            (attrib) =>
-              new PostSampleTechniqueDetailToBiohubObject(
-                attrib.technique_attribute_qualitative_id,
-                attrib.technique_attribute_qualitative_option_id,
-                attrib.technique_attribute_quantitative_id
-              )
-          )
-      : [];
-
-    // Create sample technique vantage child features from vantage_data, filtering out entries where both values are null
-    const techniqueVantageFeatures = samplingTechniqueRecord.vantage_data
-      ? samplingTechniqueRecord.vantage_data
-          .filter((vantage) => vantage.vantage_header != null || vantage.vantage_value != null)
-          .map(
-            (vantage) => new PostSampleTechniqueVantageToBiohubObject(vantage.vantage_category_id, vantage.vantage_id)
-          )
-      : [];
-
-    this.child_features = [...techniqueDetailFeatures, ...techniqueVantageFeatures];
-  }
-}
-
-/**
- * Sample Technique Detail object to be sent to Biohub API for creating a survey sampling technique detail feature.
- *
- * @export
- * @class PostSampleTechniqueDetailToBiohubObject
- * @implements {BioHubSubmissionFeature}
- */
-export class PostSampleTechniqueDetailToBiohubObject implements BioHubSubmissionFeature {
-  id: string;
-  type: string;
-  properties: Record<string, unknown>;
-  child_features: BioHubSubmissionFeature[];
-
-  constructor(
-    techniqueAttributeQualitativeId: string | null,
-    techniqueAttributeQualitativeOptionId: number | null,
-    techniqueAttributeQuantitativeId: string | null
-  ) {
-    this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.SAMPLE_TECHNIQUE_DETAIL;
-
-    // Only include properties if they are not null, using code format
-    this.properties = {};
-    if (techniqueAttributeQualitativeId != null) {
-      this.properties.method_attribute = `code::technique_attribute_qualitative::${techniqueAttributeQualitativeId}`;
-    }
-    if (techniqueAttributeQualitativeOptionId != null) {
-      this.properties.method_value = `code::technique_attribute_qualitative_option::${techniqueAttributeQualitativeOptionId}`;
-    }
-    if (techniqueAttributeQuantitativeId != null) {
-      this.properties.method_attribute = `code::technique_attribute_quantitative::${techniqueAttributeQuantitativeId}`;
-    }
-
-    this.child_features = [];
-  }
-}
-
-/**
- * Sample Technique Vantage object to be sent to Biohub API for creating a survey sampling technique vantage feature.
- *
- * @export
- * @class PostSampleTechniqueVantageToBiohubObject
- * @implements {BioHubSubmissionFeature}
- */
-export class PostSampleTechniqueVantageToBiohubObject implements BioHubSubmissionFeature {
-  id: string;
-  type: string;
-  properties: Record<string, unknown>;
-  child_features: BioHubSubmissionFeature[];
-
-  constructor(vantageCategoryId: number | null, vantageId: number | null) {
-    this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.SAMPLE_TECHNIQUE_VANTAGE;
-
-    // Only include properties if they are not null, using code format
-    this.properties = {};
-    if (vantageCategoryId != null) {
-      this.properties.method_vantage = `code::vantage_category::${vantageCategoryId}`;
-    }
-    if (vantageId != null) {
-      this.properties.method_value = `code::vantage::${vantageId}`;
-    }
 
     this.child_features = [];
   }
@@ -1645,16 +1443,11 @@ enum BiohubFeatureType {
   MEASUREMENT = 'measurement',
   MORTALITY = 'mortality',
   OBSERVATION = 'species_observation',
-  OBSERVATION_ENVIRONMENTAL_CONDITION = 'observation_environmental_condition',
-  OBSERVATION_SUBCOUNT = 'observation_subcount',
-  OBSERVATION_SUBCOUNT_MEASUREMENT = 'observation_subcount_measurement',
   RELEASE = 'release',
   REPORT = 'report',
   SAMPLE_PERIOD = 'sample_period',
   SAMPLE_SITE = 'sample_site',
   SAMPLE_TECHNIQUE = 'sample_technique',
-  SAMPLE_TECHNIQUE_DETAIL = 'sample_technique_detail',
-  SAMPLE_TECHNIQUE_VANTAGE = 'sample_technique_vantage',
   STRATUM = 'stratum',
   STUDY_AREA = 'study_area',
   TELEMETRY = 'telemetry',

--- a/api/src/models/sampling-technique-features.test.ts
+++ b/api/src/models/sampling-technique-features.test.ts
@@ -48,7 +48,13 @@ describe('Sampling Technique Features BioHub Integration', () => {
         { attractant_name: 'code::attractant_lookup::3' },
         { attractant_name: 'code::attractant_lookup::7' }
       ]);
-      expect(techniqueObj.child_features).to.be.an('array').with.length(3);
+      expect(techniqueObj.properties.method_attribute).to.equal(
+        'code::technique_attribute_qualitative::e0479006-f5ee-40cf-a33b-c1ffce393bf4'
+      );
+      expect(techniqueObj.properties.method_value).to.equal('code::technique_attribute_qualitative_option::20');
+      expect(techniqueObj.properties.vantage_method_attribute).to.equal('code::vantage_category::1');
+      expect(techniqueObj.properties.vantage_method_value).to.equal('code::vantage::5');
+      expect(techniqueObj.child_features).to.be.an('array').with.length(0);
     });
 
     it('should handle sampling technique with null values', () => {
@@ -75,6 +81,10 @@ describe('Sampling Technique Features BioHub Integration', () => {
       expect(techniqueObj.properties.description).to.be.null;
       expect(techniqueObj.properties.method_name).to.equal('code::method_lookup::8');
       expect(techniqueObj.properties.attractant).to.deep.equal([]);
+      expect(techniqueObj.properties.method_attribute).to.be.null;
+      expect(techniqueObj.properties.method_value).to.be.null;
+      expect(techniqueObj.properties.vantage_method_attribute).to.be.null;
+      expect(techniqueObj.properties.vantage_method_value).to.be.null;
       expect(techniqueObj.child_features).to.be.an('array').with.length(0);
     });
 
@@ -112,7 +122,13 @@ describe('Sampling Technique Features BioHub Integration', () => {
       expect(techniqueObj.properties.description).to.equal('Passive acoustic monitoring for species identification');
       expect(techniqueObj.properties.method_name).to.equal('code::method_lookup::12');
       expect(techniqueObj.properties.attractant).to.deep.equal([]);
-      expect(techniqueObj.child_features).to.be.an('array').with.length(2);
+      expect(techniqueObj.properties.method_attribute).to.equal(
+        'code::technique_attribute_quantitative::c3719010-f9ff-44ff-e77f-f5ffff7c7ff8'
+      );
+      expect(techniqueObj.properties.method_value).to.be.null;
+      expect(techniqueObj.properties.vantage_method_attribute).to.equal('code::vantage_category::2');
+      expect(techniqueObj.properties.vantage_method_value).to.equal('code::vantage::8');
+      expect(techniqueObj.child_features).to.be.an('array').with.length(0);
     });
   });
 });

--- a/api/src/models/sampling-technique-unit.test.ts
+++ b/api/src/models/sampling-technique-unit.test.ts
@@ -48,6 +48,12 @@ describe('PostSampleTechniqueToBiohubObject Unit Test', () => {
       { attractant_name: 'code::attractant_lookup::3' },
       { attractant_name: 'code::attractant_lookup::7' }
     ]);
-    expect(techniqueObj.child_features).to.be.an('array').with.length(3);
+    expect(techniqueObj.properties.method_attribute).to.equal(
+      'code::technique_attribute_qualitative::e0479006-f5ee-40cf-a33b-c1ffce393bf4'
+    );
+    expect(techniqueObj.properties.method_value).to.equal('code::technique_attribute_qualitative_option::20');
+    expect(techniqueObj.properties.vantage_method_attribute).to.equal('code::vantage_category::1');
+    expect(techniqueObj.properties.vantage_method_value).to.equal('code::vantage::5');
+    expect(techniqueObj.child_features).to.be.an('array').with.length(0);
   });
 });

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -404,14 +404,16 @@ describe('PlatformService', () => {
             {
               id: 'child-1',
               type: 'species_observation',
-              properties: { count: 5 },
-              child_features: [
-                {
-                  id: 'grandchild-1',
-                  type: 'observation_subcount',
-                  properties: { subcount: 2 }
-                }
-              ]
+              properties: {
+                count: 5,
+                environmental_condition: null,
+                environmental_condition_value: null,
+                subcount_comment: null,
+                subcount_count: null,
+                subcount_measurement_type: null,
+                subcount_measurement_value: null
+              },
+              child_features: []
             }
           ]
         }
@@ -419,7 +421,7 @@ describe('PlatformService', () => {
 
       const result = platformService._flattenToBlockModel(nestedData);
 
-      expect(result).to.have.length(3);
+      expect(result).to.have.length(2);
       expect(result.find((b) => b.id === 'root-id')).to.deep.include({
         id: 'root-id',
         type: 'dataset',
@@ -430,12 +432,6 @@ describe('PlatformService', () => {
         id: 'child-1',
         type: 'species_observation',
         parent: 'root-id',
-        content: ['grandchild-1']
-      });
-      expect(result.find((b) => b.id === 'grandchild-1')).to.deep.include({
-        id: 'grandchild-1',
-        type: 'observation_subcount',
-        parent: 'child-1',
         content: []
       });
     });


### PR DESCRIPTION
## Links to Jira Tickets

- N/A (or add link if applicable)

## Description of Changes

- **Collapsed BioHub submission feature types into parents** (API payload only; no DB changes):
  - **species_observation**: Removed child feature types `observation_environmental_condition`, `observation_subcount`, `observation_subcount_measurement`. Added single-value properties: `environmental_condition`, `environmental_condition_value`, `subcount_comment`, `subcount_count`, `subcount_measurement_type`, `subcount_measurement_value` (first item only when multiple exist).
  - **sample_technique**: Removed child feature types `sample_technique_detail`, `sample_technique_vantage`. Added single-value properties: `method_attribute`, `method_value`, `vantage_method_attribute`, `vantage_method_value` (first item only).
- Removed classes and enum values for the collapsed types in `api/src/models/biohub-create.ts`.
- Updated tests in `biohub-create.test.ts`, `sampling-technique-features.test.ts`, `sampling-technique-unit.test.ts`, and `platform-service.test.ts`.

## Testing Notes

- **Scope**: Only the shape of the payload sent to the BioHub API changes; database schema and observation/subcount data entry are unchanged.
- Run API tests: `npm run test` in `api/` (focus on biohub-create, sampling-technique, platform-service if doing a quick pass).
- **Manual**: If you have a flow that submits surveys to BioHub, confirm submission still succeeds and that observation env/subcount and sampling technique detail/vantage data appear on the parent feature properties (single values) in the payload rather than as separate child features.