### PR TITLE
SIMSBIOHUB-911: Modify SIMS Codesets in Tarball

### DIFF
--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -5,6 +5,9 @@ import { describe } from 'mocha';
 import { SurveyObservationRecord } from '../database-models/survey_observation';
 import { ICritterDetailed } from '../services/critterbase-service';
 import {
+  buildCodesetExportContext,
+  CodesetCategory,
+  minimalCodesetExportContext,
   PostCodesetToBiohubObject,
   PostSurveyAnimalToBiohubObject,
   PostSurveyMarkingToBiohubObject,
@@ -36,7 +39,9 @@ describe('PostSurveyObservationToBiohubObject', () => {
     };
 
     before(() => {
-      data = new PostSurveyObservationToBiohubObject(obj);
+      data = new PostSurveyObservationToBiohubObject(obj, {
+        codesetExportContext: minimalCodesetExportContext
+      });
     });
 
     it('sets id', () => {
@@ -115,7 +120,9 @@ describe('PostSurveyObservationToBiohubObject', () => {
     };
 
     before(() => {
-      data = new PostSurveyObservationToBiohubObject(objWithEnvironments);
+      data = new PostSurveyObservationToBiohubObject(objWithEnvironments, {
+        codesetExportContext: minimalCodesetExportContext
+      });
     });
 
     it('creates environmental_condition and environmental_condition_value on properties (first only)', () => {
@@ -194,7 +201,10 @@ describe('PostSurveyObservationToBiohubObject', () => {
     };
 
     before(() => {
-      data = new PostSurveyObservationToBiohubObject(objWithEnvironments, environmentDefinitions);
+      data = new PostSurveyObservationToBiohubObject(objWithEnvironments, {
+        environmentDefinitions,
+        codesetExportContext: minimalCodesetExportContext
+      });
     });
 
     it('creates environmental_condition with unit from definitions (first only)', () => {
@@ -278,7 +288,10 @@ describe('PostSurveyObservationToBiohubObject', () => {
     };
 
     before(() => {
-      data = new PostSurveyObservationToBiohubObject(objWithSubcounts, undefined, measurementDefinitions);
+      data = new PostSurveyObservationToBiohubObject(objWithSubcounts, {
+        measurementDefinitions,
+        codesetExportContext: minimalCodesetExportContext
+      });
     });
 
     it('creates subcount and measurement single-value properties (first only)', () => {
@@ -1016,7 +1029,9 @@ describe('PostSurveyToBiohubObject', () => {
       expect(childFeature).to.be.instanceOf(PostSurveyObservationToBiohubObject);
 
       // Create a comparison object to check all properties except the id
-      const expectedChild = new PostSurveyObservationToBiohubObject(observation_obj);
+      const expectedChild = new PostSurveyObservationToBiohubObject(observation_obj, {
+        codesetExportContext: minimalCodesetExportContext
+      });
       expect(childFeature.type).to.equal(expectedChild.type);
       expect(childFeature.properties).to.deep.equal(expectedChild.properties);
       expect(childFeature.child_features).to.deep.equal(expectedChild.child_features);
@@ -1415,54 +1430,57 @@ describe('PostSurveySubmissionToBioHubObject', () => {
 
 describe('PostCodesetToBiohubObject and alias mapping', () => {
   it('creates alias-keyed categories and codes', () => {
-    const codesetCategories = [
+    const codesetCategories: CodesetCategory[] = [
       {
-        name: 'life_stage',
+        key: 'life_stage',
+        label: 'Life Stage',
         description: 'Life stage of the organism',
         codes: [
-          { id: 'juvenile', name: 'Juvenile', description: null },
-          { id: 'adult', name: 'Adult', description: 'Mature life stage' }
+          { key: 'juvenile', label: 'Juvenile', description: null, external_id: '1' },
+          { key: 'adult', label: 'Adult', description: 'Mature life stage', external_id: '2' }
         ]
       },
       {
-        name: 'sex',
+        key: 'sex',
+        label: 'Sex',
         description: null,
         codes: [
-          { id: 'male', name: 'Male', description: null },
-          { id: 'female', name: 'Female', description: null }
+          { key: 'male', label: 'Male', description: null, external_id: '1' },
+          { key: 'female', label: 'Female', description: null, external_id: '2' }
         ]
       }
     ];
 
-    const codeset = new PostCodesetToBiohubObject(codesetCategories as any);
+    const context = buildCodesetExportContext(codesetCategories);
+    const codeset = new PostCodesetToBiohubObject(codesetCategories, context);
 
     const categories = codeset.properties as any;
-    expect(categories).to.have.property('life_stage_v1');
-    expect(categories).to.have.property('sex_v1');
+    expect(categories).to.have.property('life_stage');
+    expect(categories).to.have.property('sex');
 
-    const lifeStageCategory = categories['life_stage_v1'];
+    const lifeStageCategory = categories['life_stage'];
     expect(lifeStageCategory).to.include({
-      id: 'life_stage',
+      key: 'life_stage',
       label: 'Life Stage',
       description: 'Life stage of the organism',
-      version: 'v1'
+      external_id: null
     });
 
-    expect(lifeStageCategory.codes).to.have.property('juvenile_v1');
-    expect(lifeStageCategory.codes).to.have.property('adult_v1');
+    expect(lifeStageCategory.codes).to.have.property('juvenile');
+    expect(lifeStageCategory.codes).to.have.property('adult');
 
-    expect(lifeStageCategory.codes['juvenile_v1']).to.eql({
-      id: 'juvenile',
+    expect(lifeStageCategory.codes['juvenile']).to.eql({
+      key: 'juvenile',
       label: 'Juvenile',
       description: null,
-      version: 'v1'
+      external_id: '1'
     });
 
-    expect(lifeStageCategory.codes['adult_v1']).to.eql({
-      id: 'adult',
+    expect(lifeStageCategory.codes['adult']).to.eql({
+      key: 'adult',
       label: 'Adult',
       description: 'Mature life stage',
-      version: 'v1'
+      external_id: '2'
     });
   });
 
@@ -1485,11 +1503,12 @@ describe('PostCodesetToBiohubObject and alias mapping', () => {
       revision_count: 0
     };
 
-    const codesetCategories = [
+    const codesetCategories: CodesetCategory[] = [
       {
-        name: 'site_strategy',
+        key: 'site_strategy',
+        label: 'Site Strategy',
         description: 'Site selection strategies',
-        codes: [{ id: '5', name: 'Random', description: null }]
+        codes: [{ key: '5', label: 'Random', description: null, external_id: '5' }]
       }
     ];
 
@@ -1502,17 +1521,17 @@ describe('PostCodesetToBiohubObject and alias mapping', () => {
       [],
       {
         siteSelectionStrategies: [5],
-        codesetCategories: codesetCategories as any
+        codesetCategories
       }
     );
 
     const categories = (data.child_features.find((f) => f.type === 'codeset') as any).properties;
-    expect(categories).to.have.property('site_strategy_v1');
-    const siteStrategyCategory = categories['site_strategy_v1'];
-    expect(siteStrategyCategory.id).to.equal('site_strategy');
+    expect(categories).to.have.property('site_strategy');
+    const siteStrategyCategory = categories['site_strategy'];
+    expect(siteStrategyCategory.key).to.equal('site_strategy');
 
     const siteSelectionStrategies = (data.properties as any).site_select_strategy;
-    expect(siteSelectionStrategies).to.eql([{ strategy: 'code::site_strategy_v1::5_v1' }]);
+    expect(siteSelectionStrategies).to.eql([{ strategy: 'code::site_strategy::5' }]);
   });
 
   it('returns canonical code reference when context has no matching category', () => {

--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -5,6 +5,7 @@ import { describe } from 'mocha';
 import { SurveyObservationRecord } from '../database-models/survey_observation';
 import { ICritterDetailed } from '../services/critterbase-service';
 import {
+  PostCodesetToBiohubObject,
   PostSurveyAnimalToBiohubObject,
   PostSurveyMarkingToBiohubObject,
   PostSurveyMeasurementToBiohubObject,
@@ -1409,5 +1410,196 @@ describe('PostSurveySubmissionToBioHubObject', () => {
       expect(data.content.properties).to.eql(expectedContent.properties);
       expect(data.content.child_features).to.have.length(expectedContent.child_features.length);
     });
+  });
+});
+
+describe('PostCodesetToBiohubObject and alias mapping', () => {
+  it('creates alias-keyed categories and codes', () => {
+    const codesetCategories = [
+      {
+        name: 'life_stage',
+        description: 'Life stage of the organism',
+        codes: [
+          { id: 'juvenile', name: 'Juvenile', description: null },
+          { id: 'adult', name: 'Adult', description: 'Mature life stage' }
+        ]
+      },
+      {
+        name: 'sex',
+        description: null,
+        codes: [
+          { id: 'male', name: 'Male', description: null },
+          { id: 'female', name: 'Female', description: null }
+        ]
+      }
+    ];
+
+    const codeset = new PostCodesetToBiohubObject(codesetCategories as any);
+
+    const categories = codeset.properties as any;
+    expect(categories).to.have.property('life_stage_v1');
+    expect(categories).to.have.property('sex_v1');
+
+    const lifeStageCategory = categories['life_stage_v1'];
+    expect(lifeStageCategory).to.include({
+      id: 'life_stage',
+      label: 'Life Stage',
+      description: 'Life stage of the organism',
+      version: 'v1'
+    });
+
+    expect(lifeStageCategory.codes).to.have.property('juvenile_v1');
+    expect(lifeStageCategory.codes).to.have.property('adult_v1');
+
+    expect(lifeStageCategory.codes['juvenile_v1']).to.eql({
+      id: 'juvenile',
+      label: 'Juvenile',
+      description: null,
+      version: 'v1'
+    });
+
+    expect(lifeStageCategory.codes['adult_v1']).to.eql({
+      id: 'adult',
+      label: 'Adult',
+      description: 'Mature life stage',
+      version: 'v1'
+    });
+  });
+
+  it('uses alias-based code references when codeset categories are provided', () => {
+    const survey_obj: GetSurveyData = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    };
+
+    const survey_purpose_obj: GetSurveyPurposeAndMethodologyData = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    };
+
+    const codesetCategories = [
+      {
+        name: 'site_strategy',
+        description: 'Site selection strategies',
+        codes: [{ id: '5', name: 'Random', description: null }]
+      }
+    ];
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [],
+      { type: 'FeatureCollection', features: [] },
+      [],
+      [],
+      {
+        siteSelectionStrategies: [5],
+        codesetCategories: codesetCategories as any
+      }
+    );
+
+    const categories = (data.child_features.find((f) => f.type === 'codeset') as any).properties;
+    expect(categories).to.have.property('site_strategy_v1');
+    const siteStrategyCategory = categories['site_strategy_v1'];
+    expect(siteStrategyCategory.id).to.equal('site_strategy');
+
+    const siteSelectionStrategies = (data.properties as any).site_select_strategy;
+    expect(siteSelectionStrategies).to.eql([{ strategy: 'code::site_strategy_v1::5_v1' }]);
+  });
+
+  it('returns canonical code reference when context has no matching category', () => {
+    const survey_obj: GetSurveyData = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    };
+
+    const survey_purpose_obj: GetSurveyPurposeAndMethodologyData = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    };
+
+    const observation_obj: SurveyObservationRecord = {
+      survey_observation_id: 1,
+      survey_id: 1,
+      survey_sample_period_id: 1,
+      latitude: 1,
+      longitude: 1,
+      count: 1,
+      itis_tsn: 1,
+      itis_scientific_name: 'test',
+      observation_time: '12:00',
+      observation_date: '2023-01-01',
+      observation_sign_id: 1
+    };
+
+    const codesetCategories = [
+      { name: 'site_strategy', description: null, codes: [{ id: '5', name: 'Random', description: null }] }
+    ];
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [observation_obj],
+      { type: 'FeatureCollection', features: [] },
+      [],
+      [],
+      { codesetCategories: codesetCategories as any }
+    );
+
+    const observation = data.child_features.find((f) => f.type === 'species_observation');
+    expect(observation?.properties).to.have.property('sign', 'code::observation_sign::1');
+  });
+
+  it('returns canonical code reference when context has category but no matching code', () => {
+    const survey_obj: GetSurveyData = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    };
+
+    const survey_purpose_obj: GetSurveyPurposeAndMethodologyData = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    };
+
+    const codesetCategories = [
+      { name: 'site_strategy', description: null, codes: [{ id: '5', name: 'Random', description: null }] }
+    ];
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [],
+      { type: 'FeatureCollection', features: [] },
+      [],
+      [],
+      { siteSelectionStrategies: [999], codesetCategories: codesetCategories as any }
+    );
+
+    const siteSelectionStrategies = (data.properties as any).site_select_strategy;
+    expect(siteSelectionStrategies).to.eql([{ strategy: 'code::site_strategy::999' }]);
   });
 });

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -69,6 +69,15 @@ export interface CodesetCategory {
   codes: CodesetCode[];
 }
 
+interface CodesetExportContext {
+  version: string;
+  versionSuffix: string;
+  categoryAliasByName: Record<string, string>;
+  categoryNameByAlias: Record<string, string>;
+  codeAliasByCategoryAndId: Record<string, Record<string, string>>;
+  codeIdByCategoryAndAlias: Record<string, Record<string, string>>;
+}
+
 const defaultLog = getLogger('models/biohub-create');
 
 interface BioHubSubmission {
@@ -141,7 +150,8 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
     measurementDefinitions?: {
       qualitative_measurements: CBQualitativeMeasurementTypeDefinition[];
       quantitative_measurements: CBQuantitativeMeasurementTypeDefinition[];
-    }
+    },
+    codesetExportContext?: CodesetExportContext
   ) {
     defaultLog.debug({ label: 'PostSurveyObservationToBiohubObject', message: 'params', observationRecord });
 
@@ -193,7 +203,7 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
       count: observationRecord.count,
       timestamp: timestamp,
       sign: observationRecord.observation_sign_id
-        ? `code::observation_sign::${observationRecord.observation_sign_id}`
+        ? buildCodesetReference('observation_sign', observationRecord.observation_sign_id, codesetExportContext)
         : null,
       geometry:
         observationRecord.longitude && observationRecord.latitude
@@ -676,13 +686,13 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(samplingTechniqueRecord: SampleTechniqueRecord) {
+  constructor(samplingTechniqueRecord: SampleTechniqueRecord, codesetExportContext?: CodesetExportContext) {
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.SAMPLE_TECHNIQUE;
 
     // Use attractant IDs array from the database and convert to code format
     const attractantsArray = (samplingTechniqueRecord.attractant_ids || []).map((attractant) => ({
-      attractant_name: `code::attractant_lookup::${attractant.attractant_lookup_id}`
+      attractant_name: buildCodesetReference('attractant_lookup', attractant.attractant_lookup_id, codesetExportContext)
     }));
 
     let method_attribute: string | null = null;
@@ -719,9 +729,17 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
     this.properties = {
       name: samplingTechniqueRecord.method_name,
       description: samplingTechniqueRecord.description,
-      method_name: `code::method_lookup::${samplingTechniqueRecord.method_lookup_id}`,
+      method_name: buildCodesetReference(
+        'method_lookup',
+        samplingTechniqueRecord.method_lookup_id,
+        codesetExportContext
+      ),
       attractant: attractantsArray,
-      response_metric: `code::method_response_metric::${samplingTechniqueRecord.method_response_metric_id}`,
+      response_metric: buildCodesetReference(
+        'method_response_metric',
+        samplingTechniqueRecord.method_response_metric_id,
+        codesetExportContext
+      ),
       ...(samplingTechniqueRecord.distance_threshold
         ? { detect_distance: samplingTechniqueRecord.distance_threshold }
         : {}),
@@ -748,7 +766,10 @@ export class PostSurveyHabitatFeatureToBiohubObject implements BioHubSubmissionF
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(habitatFeatureRecord: SurveyHabitatFeatureWithTaxonsAndSampling) {
+  constructor(
+    habitatFeatureRecord: SurveyHabitatFeatureWithTaxonsAndSampling,
+    codesetExportContext?: CodesetExportContext
+  ) {
     defaultLog.debug({ label: 'PostSurveyHabitatFeatureToBiohubObject', message: 'params', habitatFeatureRecord });
 
     // Combine date and time into a single timestamp
@@ -766,7 +787,11 @@ export class PostSurveyHabitatFeatureToBiohubObject implements BioHubSubmissionF
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.HABITAT_FEATURE;
     this.properties = {
-      name: `code::habitat_feature_type::${habitatFeatureRecord.habitat_feature_type_id}`,
+      name: buildCodesetReference(
+        'habitat_feature_type',
+        habitatFeatureRecord.habitat_feature_type_id,
+        codesetExportContext
+      ),
       count: habitatFeatureRecord.count,
       timestamp: timestamp,
       ...(associatedSpeciesArray.length > 0 ? { associated_species: associatedSpeciesArray } : {}),
@@ -804,13 +829,13 @@ export class PostTelemetryDeviceToBiohubObject implements BioHubSubmissionFeatur
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(deviceRecord: DeviceRecord) {
+  constructor(deviceRecord: DeviceRecord, codesetExportContext?: CodesetExportContext) {
     defaultLog.debug({ label: 'PostTelemetryDeviceToBiohubObject', message: 'params', deviceRecord });
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.TELEMETRY_DEVICE;
     this.properties = {
-      device_manufacturer: `code::device_make::${deviceRecord.device_make_id}`,
+      device_manufacturer: buildCodesetReference('device_make', deviceRecord.device_make_id, codesetExportContext),
       device_model: deviceRecord.model || null,
       description: deviceRecord.comment || null,
       serial_number: deviceRecord.serial
@@ -886,7 +911,7 @@ export class PostTelemetryFrequencyToBiohubObject implements BioHubSubmissionFea
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(frequency: number | null, frequencyUnitId: number | null) {
+  constructor(frequency: number | null, frequencyUnitId: number | null, codesetExportContext?: CodesetExportContext) {
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.TELEMETRY_FREQUENCY;
 
@@ -896,7 +921,7 @@ export class PostTelemetryFrequencyToBiohubObject implements BioHubSubmissionFea
       this.properties.frequency = frequency;
     }
     if (frequencyUnitId != null) {
-      this.properties.frequency_unit = `code::frequency_unit::${frequencyUnitId}`;
+      this.properties.frequency_unit = buildCodesetReference('frequency_unit', frequencyUnitId, codesetExportContext);
     }
 
     this.child_features = [];
@@ -1064,7 +1089,7 @@ export class PostCodesetToBiohubObject implements BioHubSubmissionFeature {
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(codesetCategories: CodesetCategory[]) {
+  constructor(codesetCategories: CodesetCategory[], exportContext?: CodesetExportContext) {
     defaultLog.debug({
       label: 'PostCodesetToBiohubObject',
       message: 'params',
@@ -1074,50 +1099,8 @@ export class PostCodesetToBiohubObject implements BioHubSubmissionFeature {
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.CODESET;
 
-    // Helper function to convert snake_case to Title Case
-    const toTitleCase = (str: string): string => {
-      return str
-        .split('_')
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-        .join(' ');
-    };
-
-    // Convert categories array to object format
-    const categoriesObject: Record<
-      string,
-      {
-        label: string;
-        description: string | null;
-        codes: Record<string, { label: string; description: string | null }>;
-      }
-    > = {};
-
-    for (const category of codesetCategories) {
-      // Create category key: use table name as-is
-      const categoryKey = category.name;
-
-      // Convert snake_case to Title Case for label
-      const categoryLabel = toTitleCase(category.name);
-
-      // Convert codes array to object format
-      const codesObject: Record<string, { label: string; description: string | null }> = {};
-      for (const code of category.codes) {
-        codesObject[code.id] = {
-          label: code.name,
-          description: code.description
-        };
-      }
-
-      categoriesObject[categoryKey] = {
-        label: categoryLabel,
-        description: category.description,
-        codes: codesObject
-      };
-    }
-
-    this.properties = {
-      categories: categoriesObject
-    };
+    const context = exportContext ?? buildCodesetExportContext(codesetCategories);
+    this.properties = buildCodesetProperties(codesetCategories, context);
     this.child_features = [];
   }
 }
@@ -1166,9 +1149,16 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       codesetCategories
     } = options;
 
+    const codesetExportContext = codesetCategories?.length ? buildCodesetExportContext(codesetCategories) : undefined;
+
     const observationFeatures = observationRecords.map(
       (observation) =>
-        new PostSurveyObservationToBiohubObject(observation, environmentDefinitions, measurementDefinitions)
+        new PostSurveyObservationToBiohubObject(
+          observation,
+          environmentDefinitions,
+          measurementDefinitions,
+          codesetExportContext
+        )
     );
 
     const attachmentFeatures = surveyAttachments.map(
@@ -1194,19 +1184,19 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
 
     const samplingTechniqueFeatures = mapOrEmpty(
       samplingTechniques,
-      (samplingTechnique) => new PostSampleTechniqueToBiohubObject(samplingTechnique)
+      (samplingTechnique) => new PostSampleTechniqueToBiohubObject(samplingTechnique, codesetExportContext)
     );
 
     // Create habitat features
     const habitatFeatureFeatures = mapOrEmpty(
       habitatFeatures,
-      (habitatFeature) => new PostSurveyHabitatFeatureToBiohubObject(habitatFeature)
+      (habitatFeature) => new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, codesetExportContext)
     );
 
     // Create telemetry features
     const telemetryDeviceFeatures = mapOrEmpty(
       telemetryDevices,
-      (device) => new PostTelemetryDeviceToBiohubObject(device)
+      (device) => new PostTelemetryDeviceToBiohubObject(device, codesetExportContext)
     );
 
     const telemetryDeploymentFeatures = mapOrEmpty(
@@ -1217,7 +1207,7 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     // Create study area feature if survey location data is available
     const studyAreaFeature = createStudyAreaFeature(surveyLocation, surveyData.survey_name);
 
-    const partnershipsValue = buildPartnershipsValue(partnerships, firstNations);
+    const partnershipsValue = buildPartnershipsValue(partnerships, firstNations, codesetExportContext);
 
     // Create focal species array from focal species
     const focalSpeciesArray = buildFocalSpeciesArray(focalSpecies);
@@ -1230,10 +1220,15 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     const stratumFeatures = mapOrEmpty(strata, (stratum) => new PostStratumToBiohubObject(stratum));
 
     // Create site selection strategies array
-    const siteSelectionStrategiesArray = buildSiteSelectionStrategiesArray(siteSelectionStrategies);
+    const siteSelectionStrategiesArray = buildSiteSelectionStrategiesArray(
+      siteSelectionStrategies,
+      codesetExportContext
+    );
 
     // Create codeset feature if codeset categories are available
-    const codesetFeature = codesetCategories ? [new PostCodesetToBiohubObject(codesetCategories)] : [];
+    const codesetFeature = codesetCategories
+      ? [new PostCodesetToBiohubObject(codesetCategories, codesetExportContext)]
+      : [];
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.DATASET;
@@ -1370,7 +1365,8 @@ function createStudyAreaFeature(
 
 function buildPartnershipsValue(
   partnerships: { indigenous_partnerships: number[]; stakeholder_partnerships: string[] } | undefined,
-  _firstNations: { id: number; name: string }[] | undefined
+  _firstNations: { id: number; name: string }[] | undefined,
+  codesetExportContext?: CodesetExportContext
 ): {
   indigenous_partnerships: { name: string }[];
   stakeholder_partnerships: { name: string }[];
@@ -1380,7 +1376,7 @@ function buildPartnershipsValue(
   }
 
   const indigenousPartnerships = (partnerships.indigenous_partnerships || []).map((id) => ({
-    name: `code::first_nations::${id}`
+    name: buildCodesetReference('first_nations', id, codesetExportContext)
   }));
   const stakeholderPartnerships = (partnerships.stakeholder_partnerships || []).map((name) => ({
     name: name
@@ -1402,9 +1398,12 @@ function buildFocalSpeciesArray(focalSpecies?: { focal_species: ITaxonomyWithEco
   return focalSpecies?.focal_species?.map((species) => ({ taxon_id: species.tsn })) ?? [];
 }
 
-function buildSiteSelectionStrategiesArray(siteSelectionStrategies?: number[]): { strategy: string }[] {
+function buildSiteSelectionStrategiesArray(
+  siteSelectionStrategies?: number[],
+  codesetExportContext?: CodesetExportContext
+): { strategy: string }[] {
   return (siteSelectionStrategies ?? []).map((site_strategy_id) => ({
-    strategy: `code::site_strategy::${site_strategy_id}`
+    strategy: buildCodesetReference('site_strategy', site_strategy_id, codesetExportContext)
   }));
 }
 
@@ -1424,6 +1423,125 @@ function buildSurveyDateProperties(surveyData: GetSurveyData): Record<string, st
   }
 
   return props;
+}
+
+function buildCodesetExportContext(codesetCategories: CodesetCategory[]): CodesetExportContext {
+  const version = 'v1';
+  const versionSuffix = `_${version}`;
+
+  const context: CodesetExportContext = {
+    version,
+    versionSuffix,
+    categoryAliasByName: {},
+    categoryNameByAlias: {},
+    codeAliasByCategoryAndId: {},
+    codeIdByCategoryAndAlias: {}
+  };
+
+  codesetCategories.forEach((category) => {
+    const categoryKey = category.name + versionSuffix;
+    context.categoryAliasByName[category.name] = categoryKey;
+    context.categoryNameByAlias[categoryKey] = category.name;
+
+    const codeAliasById: Record<string, string> = {};
+    const codeIdByAlias: Record<string, string> = {};
+
+    category.codes.forEach((code) => {
+      const codeId = String(code.id);
+      const codeKey = codeId + versionSuffix;
+      codeAliasById[codeId] = codeKey;
+      codeIdByAlias[codeKey] = codeId;
+    });
+
+    context.codeAliasByCategoryAndId[category.name] = codeAliasById;
+    context.codeIdByCategoryAndAlias[category.name] = codeIdByAlias;
+  });
+
+  return context;
+}
+
+function buildCodesetProperties(
+  codesetCategories: CodesetCategory[],
+  context: CodesetExportContext
+): Record<string, unknown> {
+  const categories: Record<
+    string,
+    {
+      id: string;
+      label: string;
+      description: string | null;
+      version: string;
+      codes: Record<
+        string,
+        {
+          id: string;
+          label: string;
+          description: string | null;
+          version: string;
+        }
+      >;
+    }
+  > = {};
+
+  for (const category of codesetCategories) {
+    const categoryKey = context.categoryAliasByName[category.name];
+
+    const codes: Record<
+      string,
+      {
+        id: string;
+        label: string;
+        description: string | null;
+        version: string;
+      }
+    > = {};
+
+    category.codes.forEach((code) => {
+      const codeKey = context.codeAliasByCategoryAndId[category.name]?.[String(code.id)];
+      if (!codeKey) {
+        return;
+      }
+      codes[codeKey] = {
+        id: String(code.id),
+        label: code.name,
+        description: code.description,
+        version: context.version
+      };
+    });
+
+    categories[categoryKey] = {
+      id: category.name,
+      label: category.name
+        .split('_')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' '),
+      description: category.description,
+      version: context.version,
+      codes
+    };
+  }
+
+  return categories;
+}
+
+function buildCodesetReference(categoryName: string, codeId: string | number, context?: CodesetExportContext): string {
+  const canonical = `code::${categoryName}::${codeId}`;
+
+  if (!context) {
+    return canonical;
+  }
+
+  const categoryAlias = context.categoryAliasByName[categoryName];
+  if (!categoryAlias) {
+    return canonical;
+  }
+
+  const codeAlias = context.codeAliasByCategoryAndId[categoryName]?.[String(codeId)];
+  if (!codeAlias) {
+    return canonical;
+  }
+
+  return `code::${categoryAlias}::${codeAlias}`;
 }
 
 enum BiohubFeatureType {

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -58,25 +58,33 @@ interface MortalityRecord {
 
 // Codeset types for exporting codetables
 export interface CodesetCode {
-  id: string;
-  name: string;
+  key: string;
+  label: string;
   description: string | null;
+  external_id: string | null;
 }
 
 export interface CodesetCategory {
-  name: string;
+  key: string;
+  label: string;
   description: string | null;
   codes: CodesetCode[];
 }
 
-interface CodesetExportContext {
-  version: string;
-  versionSuffix: string;
+export interface CodesetExportContext {
   categoryAliasByName: Record<string, string>;
   categoryNameByAlias: Record<string, string>;
   codeAliasByCategoryAndId: Record<string, Record<string, string>>;
   codeIdByCategoryAndAlias: Record<string, Record<string, string>>;
 }
+
+/** Empty codeset export context for tests or when no category/code alias mapping is needed. */
+export const minimalCodesetExportContext: CodesetExportContext = {
+  categoryAliasByName: {},
+  categoryNameByAlias: {},
+  codeAliasByCategoryAndId: {},
+  codeIdByCategoryAndAlias: {}
+};
 
 const defaultLog = getLogger('models/biohub-create');
 
@@ -128,6 +136,18 @@ export interface BioHubSubmissionFeature {
   child_features: BioHubSubmissionFeature[];
 }
 
+export interface PostSurveyObservationToBiohubOptions {
+  environmentDefinitions?: {
+    qualitative_environments: QualitativeEnvironmentTypeDefinition[];
+    quantitative_environments: QuantitativeEnvironmentTypeDefinition[];
+  };
+  measurementDefinitions?: {
+    qualitative_measurements: CBQualitativeMeasurementTypeDefinition[];
+    quantitative_measurements: CBQuantitativeMeasurementTypeDefinition[];
+  };
+  codesetExportContext: CodesetExportContext;
+}
+
 /**
  * Object to be sent to Biohub API for creating an observation.
  *
@@ -143,17 +163,11 @@ export class PostSurveyObservationToBiohubObject implements BioHubSubmissionFeat
 
   constructor(
     observationRecord: SurveyObservationRecord | ObservationRecordWithSamplingAndSubcountData,
-    environmentDefinitions?: {
-      qualitative_environments: QualitativeEnvironmentTypeDefinition[];
-      quantitative_environments: QuantitativeEnvironmentTypeDefinition[];
-    },
-    measurementDefinitions?: {
-      qualitative_measurements: CBQualitativeMeasurementTypeDefinition[];
-      quantitative_measurements: CBQuantitativeMeasurementTypeDefinition[];
-    },
-    codesetExportContext?: CodesetExportContext
+    options: PostSurveyObservationToBiohubOptions
   ) {
     defaultLog.debug({ label: 'PostSurveyObservationToBiohubObject', message: 'params', observationRecord });
+
+    const { environmentDefinitions, measurementDefinitions, codesetExportContext } = options;
 
     // Combine date and time into a single timestamp
     const timestamp = observationRecord.observation_time
@@ -686,7 +700,8 @@ export class PostSampleTechniqueToBiohubObject implements BioHubSubmissionFeatur
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(samplingTechniqueRecord: SampleTechniqueRecord, codesetExportContext?: CodesetExportContext) {
+  constructor(samplingTechniqueRecord: SampleTechniqueRecord, options: { codesetExportContext: CodesetExportContext }) {
+    const { codesetExportContext } = options;
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.SAMPLE_TECHNIQUE;
 
@@ -768,9 +783,10 @@ export class PostSurveyHabitatFeatureToBiohubObject implements BioHubSubmissionF
 
   constructor(
     habitatFeatureRecord: SurveyHabitatFeatureWithTaxonsAndSampling,
-    codesetExportContext?: CodesetExportContext
+    options: { codesetExportContext: CodesetExportContext }
   ) {
     defaultLog.debug({ label: 'PostSurveyHabitatFeatureToBiohubObject', message: 'params', habitatFeatureRecord });
+    const { codesetExportContext } = options;
 
     // Combine date and time into a single timestamp
     let timestamp: string | null = null;
@@ -829,8 +845,9 @@ export class PostTelemetryDeviceToBiohubObject implements BioHubSubmissionFeatur
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(deviceRecord: DeviceRecord, codesetExportContext?: CodesetExportContext) {
+  constructor(deviceRecord: DeviceRecord, options: { codesetExportContext: CodesetExportContext }) {
     defaultLog.debug({ label: 'PostTelemetryDeviceToBiohubObject', message: 'params', deviceRecord });
+    const { codesetExportContext } = options;
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.TELEMETRY_DEVICE;
@@ -851,14 +868,22 @@ export class PostTelemetryDeviceToBiohubObject implements BioHubSubmissionFeatur
  * @class PostTelemetryDeploymentToBiohubObject
  * @implements {BioHubSubmissionFeature}
  */
+export interface PostTelemetryDeploymentToBiohubOptions {
+  telemetry?: Telemetry[];
+  animalRecords?: ICritterDetailed[];
+  codesetExportContext: CodesetExportContext;
+}
+
 export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFeature {
   id: string;
   type: string;
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(deploymentRecord: ExtendedDeploymentRecord, telemetry?: Telemetry[], animalRecords?: ICritterDetailed[]) {
+  constructor(deploymentRecord: ExtendedDeploymentRecord, options: PostTelemetryDeploymentToBiohubOptions) {
     defaultLog.debug({ label: 'PostTelemetryDeploymentToBiohubObject', message: 'params', deploymentRecord });
+
+    const { telemetry, animalRecords, codesetExportContext } = options;
 
     // Find the matching animal record to get the animal_id
     const matchingAnimal = animalRecords?.find(
@@ -892,7 +917,9 @@ export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFe
     // Add frequency child feature if frequency data exists
     if (deploymentRecord.frequency != null || deploymentRecord.frequency_unit_id != null) {
       this.child_features.push(
-        new PostTelemetryFrequencyToBiohubObject(deploymentRecord.frequency, deploymentRecord.frequency_unit_id)
+        new PostTelemetryFrequencyToBiohubObject(deploymentRecord.frequency, deploymentRecord.frequency_unit_id, {
+          codesetExportContext
+        })
       );
     }
   }
@@ -911,7 +938,12 @@ export class PostTelemetryFrequencyToBiohubObject implements BioHubSubmissionFea
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(frequency: number | null, frequencyUnitId: number | null, codesetExportContext?: CodesetExportContext) {
+  constructor(
+    frequency: number | null,
+    frequencyUnitId: number | null,
+    options: { codesetExportContext: CodesetExportContext }
+  ) {
+    const { codesetExportContext } = options;
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.TELEMETRY_FREQUENCY;
 
@@ -1089,7 +1121,7 @@ export class PostCodesetToBiohubObject implements BioHubSubmissionFeature {
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(codesetCategories: CodesetCategory[], exportContext?: CodesetExportContext) {
+  constructor(codesetCategories: CodesetCategory[], exportContext: CodesetExportContext) {
     defaultLog.debug({
       label: 'PostCodesetToBiohubObject',
       message: 'params',
@@ -1099,8 +1131,7 @@ export class PostCodesetToBiohubObject implements BioHubSubmissionFeature {
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.CODESET;
 
-    const context = exportContext ?? buildCodesetExportContext(codesetCategories);
-    this.properties = buildCodesetProperties(codesetCategories, context);
+    this.properties = buildCodesetProperties(codesetCategories, exportContext);
     this.child_features = [];
   }
 }
@@ -1149,16 +1180,15 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       codesetCategories
     } = options;
 
-    const codesetExportContext = codesetCategories?.length ? buildCodesetExportContext(codesetCategories) : undefined;
+    const codesetExportContext = buildCodesetExportContext(codesetCategories ?? []);
 
     const observationFeatures = observationRecords.map(
       (observation) =>
-        new PostSurveyObservationToBiohubObject(
-          observation,
+        new PostSurveyObservationToBiohubObject(observation, {
           environmentDefinitions,
           measurementDefinitions,
           codesetExportContext
-        )
+        })
     );
 
     const attachmentFeatures = surveyAttachments.map(
@@ -1184,30 +1214,35 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
 
     const samplingTechniqueFeatures = mapOrEmpty(
       samplingTechniques,
-      (samplingTechnique) => new PostSampleTechniqueToBiohubObject(samplingTechnique, codesetExportContext)
+      (samplingTechnique) => new PostSampleTechniqueToBiohubObject(samplingTechnique, { codesetExportContext })
     );
 
     // Create habitat features
     const habitatFeatureFeatures = mapOrEmpty(
       habitatFeatures,
-      (habitatFeature) => new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, codesetExportContext)
+      (habitatFeature) => new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, { codesetExportContext })
     );
 
     // Create telemetry features
     const telemetryDeviceFeatures = mapOrEmpty(
       telemetryDevices,
-      (device) => new PostTelemetryDeviceToBiohubObject(device, codesetExportContext)
+      (device) => new PostTelemetryDeviceToBiohubObject(device, { codesetExportContext })
     );
 
     const telemetryDeploymentFeatures = mapOrEmpty(
       telemetryDeployments,
-      (deployment) => new PostTelemetryDeploymentToBiohubObject(deployment, telemetry, animalRecords)
+      (deployment) =>
+        new PostTelemetryDeploymentToBiohubObject(deployment, {
+          telemetry,
+          animalRecords,
+          codesetExportContext
+        })
     );
 
     // Create study area feature if survey location data is available
     const studyAreaFeature = createStudyAreaFeature(surveyLocation, surveyData.survey_name);
 
-    const partnershipsValue = buildPartnershipsValue(partnerships, firstNations, codesetExportContext);
+    const partnershipsValue = buildPartnershipsValue(partnerships, firstNations, { codesetExportContext });
 
     // Create focal species array from focal species
     const focalSpeciesArray = buildFocalSpeciesArray(focalSpecies);
@@ -1220,13 +1255,12 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     const stratumFeatures = mapOrEmpty(strata, (stratum) => new PostStratumToBiohubObject(stratum));
 
     // Create site selection strategies array
-    const siteSelectionStrategiesArray = buildSiteSelectionStrategiesArray(
-      siteSelectionStrategies,
+    const siteSelectionStrategiesArray = buildSiteSelectionStrategiesArray(siteSelectionStrategies, {
       codesetExportContext
-    );
+    });
 
     // Create codeset feature if codeset categories are available
-    const codesetFeature = codesetCategories
+    const codesetFeature = codesetCategories?.length
       ? [new PostCodesetToBiohubObject(codesetCategories, codesetExportContext)]
       : [];
 
@@ -1366,7 +1400,7 @@ function createStudyAreaFeature(
 function buildPartnershipsValue(
   partnerships: { indigenous_partnerships: number[]; stakeholder_partnerships: string[] } | undefined,
   _firstNations: { id: number; name: string }[] | undefined,
-  codesetExportContext?: CodesetExportContext
+  options: { codesetExportContext: CodesetExportContext }
 ): {
   indigenous_partnerships: { name: string }[];
   stakeholder_partnerships: { name: string }[];
@@ -1375,6 +1409,7 @@ function buildPartnershipsValue(
     return null;
   }
 
+  const { codesetExportContext } = options;
   const indigenousPartnerships = (partnerships.indigenous_partnerships || []).map((id) => ({
     name: buildCodesetReference('first_nations', id, codesetExportContext)
   }));
@@ -1399,9 +1434,10 @@ function buildFocalSpeciesArray(focalSpecies?: { focal_species: ITaxonomyWithEco
 }
 
 function buildSiteSelectionStrategiesArray(
-  siteSelectionStrategies?: number[],
-  codesetExportContext?: CodesetExportContext
+  siteSelectionStrategies: number[] | undefined,
+  options: { codesetExportContext: CodesetExportContext }
 ): { strategy: string }[] {
+  const { codesetExportContext } = options;
   return (siteSelectionStrategies ?? []).map((site_strategy_id) => ({
     strategy: buildCodesetReference('site_strategy', site_strategy_id, codesetExportContext)
   }));
@@ -1425,13 +1461,16 @@ function buildSurveyDateProperties(surveyData: GetSurveyData): Record<string, st
   return props;
 }
 
-function buildCodesetExportContext(codesetCategories: CodesetCategory[]): CodesetExportContext {
-  const version = 'v1';
-  const versionSuffix = `_${version}`;
-
+/**
+ * Builds a shared export context for codeset categories, including alias mappings for category and
+ * code keys used in BioHub code references and codeset JSON. The context should be built once per
+ * export and passed to all helpers that emit code references or codeset JSON.
+ *
+ * @param {CodesetCategory[]} codesetCategories - SIMS codeset categories (name, description, codes)
+ * @return {*}  {CodesetExportContext} Context with category/code alias maps
+ */
+export function buildCodesetExportContext(codesetCategories: CodesetCategory[]): CodesetExportContext {
   const context: CodesetExportContext = {
-    version,
-    versionSuffix,
     categoryAliasByName: {},
     categoryNameByAlias: {},
     codeAliasByCategoryAndId: {},
@@ -1439,27 +1478,35 @@ function buildCodesetExportContext(codesetCategories: CodesetCategory[]): Codese
   };
 
   codesetCategories.forEach((category) => {
-    const categoryKey = category.name + versionSuffix;
-    context.categoryAliasByName[category.name] = categoryKey;
-    context.categoryNameByAlias[categoryKey] = category.name;
+    const categoryKey = category.key;
+    context.categoryAliasByName[category.key] = categoryKey;
+    context.categoryNameByAlias[categoryKey] = category.key;
 
     const codeAliasById: Record<string, string> = {};
     const codeIdByAlias: Record<string, string> = {};
 
     category.codes.forEach((code) => {
-      const codeId = String(code.id);
-      const codeKey = codeId + versionSuffix;
-      codeAliasById[codeId] = codeKey;
-      codeIdByAlias[codeKey] = codeId;
+      const codeKey = String(code.key);
+      codeAliasById[codeKey] = codeKey;
+      codeIdByAlias[codeKey] = codeKey;
     });
 
-    context.codeAliasByCategoryAndId[category.name] = codeAliasById;
-    context.codeIdByCategoryAndAlias[category.name] = codeIdByAlias;
+    context.codeAliasByCategoryAndId[category.key] = codeAliasById;
+    context.codeIdByCategoryAndAlias[category.key] = codeIdByAlias;
   });
 
   return context;
 }
 
+/**
+ * Builds the `codes/codeset.json` payload from SIMS codeset categories using the provided export context.
+ * The result is a single object keyed by category keys (e.g. `life_stage`), with each category and code
+ * object containing key, label, description, and external_id per the BioHub spec.
+ *
+ * @param {CodesetCategory[]} codesetCategories - SIMS codeset categories to serialize
+ * @param {CodesetExportContext} context - Shared export context from buildCodesetExportContext
+ * @return {*}  {Record<string, unknown>} Object suitable for codes/codeset.json in the tarball
+ */
 function buildCodesetProperties(
   codesetCategories: CodesetCategory[],
   context: CodesetExportContext
@@ -1467,56 +1514,53 @@ function buildCodesetProperties(
   const categories: Record<
     string,
     {
-      id: string;
+      key: string;
       label: string;
       description: string | null;
-      version: string;
+      external_id: string | null;
       codes: Record<
         string,
         {
-          id: string;
+          key: string;
           label: string;
           description: string | null;
-          version: string;
+          external_id: string | null;
         }
       >;
     }
   > = {};
 
   for (const category of codesetCategories) {
-    const categoryKey = context.categoryAliasByName[category.name];
+    const categoryKey = context.categoryAliasByName[category.key];
 
     const codes: Record<
       string,
       {
-        id: string;
+        key: string;
         label: string;
         description: string | null;
-        version: string;
+        external_id: string | null;
       }
     > = {};
 
     category.codes.forEach((code) => {
-      const codeKey = context.codeAliasByCategoryAndId[category.name]?.[String(code.id)];
+      const codeKey = context.codeAliasByCategoryAndId[category.key]?.[String(code.key)];
       if (!codeKey) {
         return;
       }
       codes[codeKey] = {
-        id: String(code.id),
-        label: code.name,
+        key: codeKey,
+        label: code.label,
         description: code.description,
-        version: context.version
+        external_id: code.external_id
       };
     });
 
     categories[categoryKey] = {
-      id: category.name,
-      label: category.name
-        .split('_')
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-        .join(' '),
+      key: categoryKey,
+      label: category.label,
       description: category.description,
-      version: context.version,
+      external_id: null,
       codes
     };
   }
@@ -1524,7 +1568,21 @@ function buildCodesetProperties(
   return categories;
 }
 
-function buildCodesetReference(categoryName: string, codeId: string | number, context?: CodesetExportContext): string {
+/**
+ * Builds a code reference string (e.g. `code::life_stage::juvenile`) using the alias mappings in the
+ * export context. Returns the canonical form `code::<category>::<id>` when the category or code is
+ * not present in the context.
+ *
+ * @param {string} categoryName - Codeset category name (e.g. 'observation_sign', 'site_strategy')
+ * @param {string | number} codeId - Code identifier from SIMS
+ * @param {CodesetExportContext} context - Shared export context from buildCodesetExportContext
+ * @return {*}  {string} Code reference or canonical code reference string
+ */
+function buildCodesetReference(
+  categoryName: string,
+  codeId: string | number,
+  context: CodesetExportContext | undefined
+): string {
   const canonical = `code::${categoryName}::${codeId}`;
 
   if (!context) {

--- a/api/src/models/habitat-features.test.ts
+++ b/api/src/models/habitat-features.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import {
+  minimalCodesetExportContext,
   PostSurveyHabitatFeatureToBiohubObject,
   PostSurveySubmissionToBioHubObject,
   PostSurveyToBiohubObject
@@ -36,7 +37,9 @@ describe('Habitat Features BioHub Integration', () => {
         survey_sample_period_start_datetime: '2024-01-15T10:00:00'
       };
 
-      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature);
+      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(habitatFeatureObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(habitatFeatureObj.type).to.equal('habitat_feature');
@@ -71,7 +74,9 @@ describe('Habitat Features BioHub Integration', () => {
         survey_sample_period_start_datetime: null
       };
 
-      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature);
+      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(habitatFeatureObj.properties.timestamp).to.equal('2024-01-16T00:00:00.000Z');
       expect(habitatFeatureObj.properties).to.not.have.property('taxon_id');
@@ -96,7 +101,9 @@ describe('Habitat Features BioHub Integration', () => {
         survey_sample_period_start_datetime: null
       };
 
-      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature);
+      const habitatFeatureObj = new PostSurveyHabitatFeatureToBiohubObject(habitatFeature, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(habitatFeatureObj.properties.geometry).to.be.null;
       expect(habitatFeatureObj.properties.timestamp).to.be.null;

--- a/api/src/models/sampling-technique-features.test.ts
+++ b/api/src/models/sampling-technique-features.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { PostSampleTechniqueToBiohubObject } from '../models/biohub-create';
+import { minimalCodesetExportContext, PostSampleTechniqueToBiohubObject } from '../models/biohub-create';
 
 describe('Sampling Technique Features BioHub Integration', () => {
   describe('PostSampleTechniqueToBiohubObject', () => {
@@ -37,7 +37,9 @@ describe('Sampling Technique Features BioHub Integration', () => {
         ]
       };
 
-      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord);
+      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(techniqueObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(techniqueObj.type).to.equal('sample_technique');
@@ -73,7 +75,9 @@ describe('Sampling Technique Features BioHub Integration', () => {
         vantage_data: []
       };
 
-      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord);
+      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(techniqueObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(techniqueObj.type).to.equal('sample_technique');
@@ -114,7 +118,9 @@ describe('Sampling Technique Features BioHub Integration', () => {
         ]
       };
 
-      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord);
+      const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(techniqueObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(techniqueObj.type).to.equal('sample_technique');

--- a/api/src/models/sampling-technique-unit.test.ts
+++ b/api/src/models/sampling-technique-unit.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { PostSampleTechniqueToBiohubObject } from '../models/biohub-create';
+import { minimalCodesetExportContext, PostSampleTechniqueToBiohubObject } from '../models/biohub-create';
 
 describe('PostSampleTechniqueToBiohubObject Unit Test', () => {
   it('should create sampling technique object with correct properties', () => {
@@ -36,7 +36,9 @@ describe('PostSampleTechniqueToBiohubObject Unit Test', () => {
       ]
     };
 
-    const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord);
+    const techniqueObj = new PostSampleTechniqueToBiohubObject(samplingTechniqueRecord, {
+      codesetExportContext: minimalCodesetExportContext
+    });
 
     expect(techniqueObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(techniqueObj.type).to.equal('sample_technique');

--- a/api/src/models/telemetry-features.test.ts
+++ b/api/src/models/telemetry-features.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import {
+  minimalCodesetExportContext,
   PostSurveySubmissionToBioHubObject,
   PostSurveyToBiohubObject,
   PostTelemetryDeploymentToBiohubObject,
@@ -85,7 +86,9 @@ describe('Telemetry Features BioHub Integration', () => {
         comment: 'Wildlife tracking device'
       };
 
-      const deviceObj = new PostTelemetryDeviceToBiohubObject(deviceRecord);
+      const deviceObj = new PostTelemetryDeviceToBiohubObject(deviceRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(deviceObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(deviceObj.type).to.equal('telemetry_device');
@@ -107,7 +110,9 @@ describe('Telemetry Features BioHub Integration', () => {
         comment: null
       };
 
-      const deviceObj = new PostTelemetryDeviceToBiohubObject(deviceRecord);
+      const deviceObj = new PostTelemetryDeviceToBiohubObject(deviceRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(deviceObj.properties.device_manufacturer).to.equal('code::device_make::99');
       expect(deviceObj.properties.device_model).to.equal(null);
@@ -141,7 +146,9 @@ describe('Telemetry Features BioHub Integration', () => {
         critterbase_critter_id: 'cb-critter-uuid-123'
       };
 
-      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord);
+      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(deploymentObj.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(deploymentObj.type).to.equal('telemetry_deployment');
@@ -183,7 +190,10 @@ describe('Telemetry Features BioHub Integration', () => {
         critterbase_critter_id: 'critter-uuid-empty'
       };
 
-      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, []);
+      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, {
+        telemetry: [],
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(deploymentObj.properties.animal_identifier).to.equal(null);
       expect(deploymentObj.properties.device_key).to.equal('device-key-124');
@@ -218,7 +228,10 @@ describe('Telemetry Features BioHub Integration', () => {
         critterbase_critter_id: 'test-critter-uuid'
       };
 
-      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, []);
+      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, {
+        telemetry: [],
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(deploymentObj.child_features).to.be.an('array').with.length(1);
 

--- a/api/src/services/code-service.test.ts
+++ b/api/src/services/code-service.test.ts
@@ -61,7 +61,7 @@ describe('CodeService', () => {
       sinon.restore();
     });
 
-    it('returns transformed codeset categories with numeric IDs converted to strings', async function () {
+    it('returns transformed codeset categories', async function () {
       const mockRawCategories = [
         {
           name: 'observation_sign',
@@ -88,21 +88,26 @@ describe('CodeService', () => {
 
       expect(response).to.have.length(2);
 
-      // Verify first category
-      expect(response[0].name).to.equal('observation_sign');
+      // Verify first category (key, label, description; codes with key, label, external_id)
+      expect(response[0].key).to.equal('observation_sign');
+      expect(response[0].label).to.equal('Observation Sign');
       expect(response[0].description).to.equal('Signs of species observation');
       expect(response[0].codes).to.have.length(2);
-      expect(response[0].codes[0].id).to.equal('1'); // Converted to string
-      expect(response[0].codes[0].name).to.equal('Tracks');
-      expect(response[0].codes[1].id).to.equal('2'); // Converted to string
+      expect(response[0].codes[0].key).to.equal('1');
+      expect(response[0].codes[0].label).to.equal('Tracks');
+      expect(response[0].codes[0].external_id).to.equal('1');
+      expect(response[0].codes[1].key).to.equal('2');
+      expect(response[0].codes[1].external_id).to.equal('2');
 
       // Verify second category
-      expect(response[1].name).to.equal('device_make');
-      expect(response[1].codes[0].id).to.equal('5'); // Converted to string
+      expect(response[1].key).to.equal('device_make');
+      expect(response[1].codes[0].key).to.equal('5');
+      expect(response[1].codes[0].label).to.equal('Lotek');
+      expect(response[1].codes[0].external_id).to.equal('5');
       expect(response[1].codes[0].description).to.be.null;
     });
 
-    it('handles UUID string IDs correctly (they remain as strings)', async function () {
+    it('sets external_id to string when code id is string (e.g. UUID)', async function () {
       const mockRawCategories = [
         {
           name: 'environment_qualitative',
@@ -126,9 +131,9 @@ describe('CodeService', () => {
       const response = await codeService.getAllCodesetCategories();
 
       expect(response).to.have.length(1);
-      expect(response[0].name).to.equal('environment_qualitative');
-      // UUID should remain as string
-      expect(response[0].codes[0].id).to.equal('323e4567-e89b-12d3-a456-426614174001');
+      expect(response[0].key).to.equal('environment_qualitative');
+      expect(response[0].codes[0].key).to.equal('323e4567-e89b-12d3-a456-426614174001');
+      expect(response[0].codes[0].external_id).to.equal('323e4567-e89b-12d3-a456-426614174001');
     });
 
     it('returns empty array when no categories are found', async function () {
@@ -161,7 +166,7 @@ describe('CodeService', () => {
       const response = await codeService.getAllCodesetCategories();
 
       expect(response).to.have.length(1);
-      expect(response[0].name).to.equal('empty_category');
+      expect(response[0].key).to.equal('empty_category');
       expect(response[0].codes).to.be.an('array').that.is.empty;
     });
   });

--- a/api/src/services/code-service.ts
+++ b/api/src/services/code-service.ts
@@ -106,14 +106,19 @@ export class CodeService extends DBService {
 
     const rawCategories = await this.codeRepository.getAllCodesetCategories();
 
-    // Transform to CodesetCategory format, converting all IDs to strings
+    // Transform to CodesetCategory format (key, label, description, external_id per BioHub spec)
     return rawCategories.map((category) => ({
-      name: category.name,
+      key: category.name,
+      label: category.name
+        .split('_')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' '),
       description: category.description,
       codes: category.codes.map((code) => ({
-        id: String(code.id),
-        name: code.name,
-        description: code.description
+        key: String(code.id),
+        label: code.name,
+        description: code.description,
+        external_id: code.id == null ? null : String(code.id)
       }))
     }));
   }

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -638,7 +638,7 @@ describe('PlatformService', () => {
       expect(platformService._addFileToArchive).to.be.a('function');
     });
 
-    it('should write JSON files to expected archive paths', () => {
+    it('should write JSON files to expected archive paths', async () => {
       const mockDBConnection = getMockDBConnection();
       const platformService = new PlatformService(mockDBConnection);
 
@@ -652,11 +652,9 @@ describe('PlatformService', () => {
 
       const addFileToArchiveStub = sinon
         .stub(platformService as any, '_addFileToArchive')
-        .callsFake((_pack: any, _dataset: string, _fileName: string, _content: Buffer, onComplete: () => void) => {
-          onComplete();
-        });
+        .callsFake(() => Promise.resolve());
 
-      platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any, () => undefined);
+      await platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any);
 
       const writtenPaths = addFileToArchiveStub.getCalls().map((call) => call.args[2]);
       expect(writtenPaths).to.include('features/dataset.json');
@@ -664,24 +662,22 @@ describe('PlatformService', () => {
       expect(writtenPaths).to.include('features/habitat_feature.json');
     });
 
-    it('should write codeset block properties as codes/codeset.json content when first block has properties', () => {
+    it('should write codeset block properties as codes/codeset.json content when first block has properties', async () => {
       const mockDBConnection = getMockDBConnection();
       const platformService = new PlatformService(mockDBConnection);
 
       const pack: any = {};
       const datasetId = 'test-dataset-id';
-      const codesetProperties = { life_stage_v1: { id: 'life_stage', label: 'Life Stage', codes: {} } };
+      const codesetProperties = { life_stage: { id: 'life_stage', label: 'Life Stage', codes: {} } };
       const blocksByType = new Map<string, any[]>([
         ['codeset', [{ id: 'c1', type: 'codeset', properties: codesetProperties, content: [], parent: null }]]
       ]);
 
       const addFileToArchiveStub = sinon
         .stub(platformService as any, '_addFileToArchive')
-        .callsFake((_pack: any, _dataset: string, _fileName: string, _fileContent: Buffer, onComplete: () => void) => {
-          onComplete();
-        });
+        .callsFake(() => Promise.resolve());
 
-      platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any, () => undefined);
+      await platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any);
 
       const codesetCall = addFileToArchiveStub.getCalls().find((call) => call.args[2] === 'codes/codeset.json');
       expect(codesetCall).to.exist;

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -637,6 +637,56 @@ describe('PlatformService', () => {
       expect(platformService._addJsonFiles).to.be.a('function');
       expect(platformService._addFileToArchive).to.be.a('function');
     });
+
+    it('should write JSON files to expected archive paths', () => {
+      const mockDBConnection = getMockDBConnection();
+      const platformService = new PlatformService(mockDBConnection);
+
+      const pack: any = {};
+      const datasetId = 'test-dataset-id';
+      const blocksByType = new Map<string, any[]>([
+        ['dataset', [{ id: 'd1' }]],
+        ['codeset', [{ id: 'c1' }]],
+        ['habitat_feature', [{ id: 'h1' }]]
+      ]);
+
+      const addFileToArchiveStub = sinon
+        .stub(platformService as any, '_addFileToArchive')
+        .callsFake((_pack: any, _dataset: string, _fileName: string, _content: Buffer, onComplete: () => void) => {
+          onComplete();
+        });
+
+      platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any, () => undefined);
+
+      const writtenPaths = addFileToArchiveStub.getCalls().map((call) => call.args[2]);
+      expect(writtenPaths).to.include('features/dataset.json');
+      expect(writtenPaths).to.include('codes/codeset.json');
+      expect(writtenPaths).to.include('features/habitat_feature.json');
+    });
+
+    it('should write codeset block properties as codes/codeset.json content when first block has properties', () => {
+      const mockDBConnection = getMockDBConnection();
+      const platformService = new PlatformService(mockDBConnection);
+
+      const pack: any = {};
+      const datasetId = 'test-dataset-id';
+      const codesetProperties = { life_stage_v1: { id: 'life_stage', label: 'Life Stage', codes: {} } };
+      const blocksByType = new Map<string, any[]>([
+        ['codeset', [{ id: 'c1', type: 'codeset', properties: codesetProperties, content: [], parent: null }]]
+      ]);
+
+      const addFileToArchiveStub = sinon
+        .stub(platformService as any, '_addFileToArchive')
+        .callsFake((_pack: any, _dataset: string, _fileName: string, _fileContent: Buffer, onComplete: () => void) => {
+          onComplete();
+        });
+
+      platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any, () => undefined);
+
+      const codesetCall = addFileToArchiveStub.getCalls().find((call) => call.args[2] === 'codes/codeset.json');
+      expect(codesetCall).to.exist;
+      expect(JSON.parse(codesetCall!.args[3].toString())).to.deep.equal(codesetProperties);
+    });
   });
 
   describe('_splitFileIntoChunks', () => {

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -664,8 +664,10 @@ export class PlatformService extends DBService {
     onComplete: () => void
   ): void {
     blocksByType.forEach((blocks, type) => {
-      const fileName = `${type}.json`;
-      const fileContent = Buffer.from(JSON.stringify(blocks, null, 2));
+      const fileName = type === 'codeset' ? 'codes/codeset.json' : `features/${type}.json`;
+      const payload =
+        type === 'codeset' && blocks.length > 0 && blocks[0].properties !== undefined ? blocks[0].properties : blocks;
+      const fileContent = Buffer.from(JSON.stringify(payload, null, 2));
       this._addFileToArchive(pack, datasetId, fileName, fileContent, onComplete);
     });
   }

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -66,6 +66,11 @@ interface INestedBlock {
   child_features?: INestedBlock[];
 }
 
+export enum TARBALL_FILE_ROLE {
+  CODESET = 'codeset',
+  FEATURE = 'feature'
+}
+
 const getBackboneInternalApiHost = () => getEnvironmentVariable('BACKBONE_INTERNAL_API_HOST');
 const getBackboneTaxonTsnPath = () => getEnvironmentVariable('BIOHUB_TAXON_TSN_PATH');
 const getBackboneTaxonPath = () => getEnvironmentVariable('BIOHUB_TAXON_PATH');
@@ -607,12 +612,14 @@ export class PlatformService extends DBService {
   }
 
   /**
-   * Adds all JSON files from the blocksByType Map to the TAR archive.
-   * Also includes actual file content for blocks with type 'file'.
+   * Adds all JSON files from the blocksByType Map to the TAR archive and then triggers the addition
+   * of binary file content. Codeset content is written to `codes/codeset.json`; all other feature
+   * blocks are written under `features/`.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
    * @param {string} datasetId - The dataset ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
+   * @return {*}  {Promise<void>}
    * @memberof PlatformService
    */
   async _addJsonFiles(
@@ -626,50 +633,75 @@ export class PlatformService extends DBService {
     }
 
     const fileBlocks = blocksByType.get('file') || [];
-    let jsonFilesProcessed = 0;
-    const totalJsonFiles = blocksByType.size;
-    let fileBlocksProcessed = 0;
-    const totalFileBlocks = fileBlocks.length;
 
-    const checkAndFinalize = () => {
-      if (jsonFilesProcessed === totalJsonFiles && fileBlocksProcessed === totalFileBlocks) {
-        pack.finalize();
-      }
-    };
-
-    this._addJsonFilesToArchive(pack, datasetId, blocksByType, () => {
-      jsonFilesProcessed++;
-      checkAndFinalize();
-    });
-
-    await this._addFileBlocksToArchive(pack, datasetId, fileBlocks, () => {
-      fileBlocksProcessed++;
-      checkAndFinalize();
-    });
+    await Promise.all([
+      this._addJsonFilesToArchive(pack, datasetId, blocksByType),
+      this._addFileBlocksToArchive(pack, datasetId, fileBlocks)
+    ]);
+    pack.finalize();
   }
 
   /**
-   * Adds JSON files for all block types to the TAR archive.
+   * Adds JSON files for all block types to the TAR archive by delegating to _addFeatureToArchive
+   * or _addCodesetToArchive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
    * @param {string} datasetId - The dataset ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
-   * @param {() => void} onComplete - Callback when JSON file is added
+   * @return {Promise<void>} Resolves when all JSON files have been added to the archive
    * @memberof PlatformService
    */
   _addJsonFilesToArchive(
     pack: tarStream.Pack,
     datasetId: string,
-    blocksByType: Map<string, IFlattenedBlock[]>,
-    onComplete: () => void
-  ): void {
-    blocksByType.forEach((blocks, type) => {
-      const fileName = type === 'codeset' ? 'codes/codeset.json' : `features/${type}.json`;
-      const payload =
-        type === 'codeset' && blocks.length > 0 && blocks[0].properties !== undefined ? blocks[0].properties : blocks;
-      const fileContent = Buffer.from(JSON.stringify(payload, null, 2));
-      this._addFileToArchive(pack, datasetId, fileName, fileContent, onComplete);
-    });
+    blocksByType: Map<string, IFlattenedBlock[]>
+  ): Promise<void> {
+    const promises = Array.from(blocksByType.entries()).map(([type, blocks]) =>
+      type === TARBALL_FILE_ROLE.CODESET
+        ? this._addCodesetToArchive(pack, datasetId, blocks)
+        : this._addFeatureToArchive(pack, datasetId, type, blocks)
+    );
+    return Promise.all(promises).then(() => undefined);
+  }
+
+  /**
+   * Adds a feature JSON file for a specific block type to the TAR archive.
+   *
+   * @param {tarStream.Pack} pack - The TAR pack stream
+   * @param {string} datasetId - The dataset ID
+   * @param {string} type - The block type (feature name)
+   * @param {IFlattenedBlock[]} blocks - Flattened blocks of this type
+   * @return {Promise<void>} Resolves when the file has been added to the archive
+   * @memberof PlatformService
+   */
+  _addFeatureToArchive(
+    pack: tarStream.Pack,
+    datasetId: string,
+    type: string,
+    blocks: IFlattenedBlock[]
+  ): Promise<void> {
+    const fileName = `features/${type}.json`;
+    const fileContent = Buffer.from(JSON.stringify(blocks, null, 2));
+    return this._addFileToArchive(pack, datasetId, fileName, fileContent);
+  }
+
+  /**
+   * Adds the consolidated codeset JSON file to the TAR archive.
+   *
+   * @param {tarStream.Pack} pack - The TAR pack stream
+   * @param {string} datasetId - The dataset ID
+   * @param {IFlattenedBlock[]} codesetBlocks - Flattened codeset blocks (expected to contain a single codeset feature)
+   * @return {Promise<void>} Resolves when the file has been added to the archive
+   * @memberof PlatformService
+   */
+  _addCodesetToArchive(pack: tarStream.Pack, datasetId: string, codesetBlocks: IFlattenedBlock[]): Promise<void> {
+    const fileName = 'codes/codeset.json';
+    const payload =
+      codesetBlocks.length > 0 && codesetBlocks[0].properties !== undefined
+        ? codesetBlocks[0].properties
+        : codesetBlocks;
+    const fileContent = Buffer.from(JSON.stringify(payload, null, 2));
+    return this._addFileToArchive(pack, datasetId, fileName, fileContent);
   }
 
   /**
@@ -678,21 +710,16 @@ export class PlatformService extends DBService {
    * @param {tarStream.Pack} pack - The TAR pack stream
    * @param {string} datasetId - The dataset ID
    * @param {IFlattenedBlock[]} fileBlocks - Array of file blocks to process
-   * @param {() => void} onComplete - Callback when file block is processed
+   * @return {Promise<void>} Resolves when all file blocks have been added to the archive
    * @memberof PlatformService
    */
-  async _addFileBlocksToArchive(
-    pack: tarStream.Pack,
-    datasetId: string,
-    fileBlocks: IFlattenedBlock[],
-    onComplete: () => void
-  ): Promise<void> {
+  async _addFileBlocksToArchive(pack: tarStream.Pack, datasetId: string, fileBlocks: IFlattenedBlock[]): Promise<void> {
     if (fileBlocks.length === 0) {
       return;
     }
 
     for (const fileBlock of fileBlocks) {
-      await this._processFileBlock(pack, datasetId, fileBlock, onComplete);
+      await this._processFileBlock(pack, datasetId, fileBlock);
     }
   }
 
@@ -702,36 +729,28 @@ export class PlatformService extends DBService {
    * @param {tarStream.Pack} pack - The TAR pack stream
    * @param {string} datasetId - The dataset ID
    * @param {IFlattenedBlock} fileBlock - The file block to process
-   * @param {() => void} onComplete - Callback when file is processed
+   * @return {Promise<void>} Resolves when the file block has been processed (added or skipped)
    * @memberof PlatformService
    */
-  async _processFileBlock(
-    pack: tarStream.Pack,
-    datasetId: string,
-    fileBlock: IFlattenedBlock,
-    onComplete: () => void
-  ): Promise<void> {
+  async _processFileBlock(pack: tarStream.Pack, datasetId: string, fileBlock: IFlattenedBlock): Promise<void> {
     try {
       const artifactKey = fileBlock.properties?.artifact_key as string | undefined;
       const filename = (fileBlock.properties?.filename as string | undefined) || fileBlock.id;
 
       if (!artifactKey) {
         this._logFileBlockWarning('File block missing artifact_key, skipping', fileBlock.id);
-        onComplete();
         return;
       }
 
       const fileContent = await this._downloadFileFromS3(artifactKey, fileBlock.id);
       if (!fileContent) {
-        onComplete();
         return;
       }
 
       const archivePath = `files/${filename}`;
-      this._addFileToArchive(pack, datasetId, archivePath, fileContent, onComplete);
+      await this._addFileToArchive(pack, datasetId, archivePath, fileContent);
     } catch (error) {
       this._logFileBlockError('Failed to add file block to archive', fileBlock.id, error);
-      onComplete();
     }
   }
 
@@ -802,30 +821,27 @@ export class PlatformService extends DBService {
    * @param {string} datasetId - The dataset ID
    * @param {string} fileName - Filename to add
    * @param {Buffer} fileContent - File content as a Buffer
-   * @param {() => void} onComplete - Callback when file is added
+   * @return {Promise<void>} Resolves when the file entry has been written to the pack
    * @memberof PlatformService
    */
-  _addFileToArchive(
-    pack: tarStream.Pack,
-    datasetId: string,
-    fileName: string,
-    fileContent: Buffer,
-    onComplete: () => void
-  ): void {
-    pack.entry(
-      {
-        name: `${datasetId}/${fileName}`,
-        size: fileContent.length
-      },
-      fileContent,
-      (entryErr?: Error | null) => {
-        if (entryErr) {
-          pack.destroy();
-          throw entryErr;
+  _addFileToArchive(pack: tarStream.Pack, datasetId: string, fileName: string, fileContent: Buffer): Promise<void> {
+    return new Promise((resolve, reject) => {
+      pack.entry(
+        {
+          name: `${datasetId}/${fileName}`,
+          size: fileContent.length
+        },
+        fileContent,
+        (entryErr?: Error | null) => {
+          if (entryErr) {
+            pack.destroy();
+            reject(entryErr);
+            return;
+          }
+          resolve();
         }
-        onComplete();
-      }
-    );
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-911](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-911)

## Description of Changes

- **Tar layout:** Codeset JSON is written to `codes/codeset.json`; all other feature JSON (dataset, habitat_feature, etc.) to `features/<type>.json`. Binary attachments stay under `files/`.
- **codeset.json content:** File is the categories object only (no blocks array). Top-level keys are category name + version suffix (e.g. `life_stage_v1`). Each category has `id`, `label`, `description`, `version`, and a `codes` object keyed by code id + suffix (e.g. `juvenile_v1`) with canonical code metadata.
- **Feature code references:** Properties that reference codes (e.g. habitat feature type, observation sign, site strategy) now use the versioned form `code::<categoryKey>::<codeKey>` (e.g. `code::habitat_feature_type_v1::5_v1`).
- **Export context:** `CodesetExportContext` holds version, versionSuffix, and the lookup maps used to build codeset JSON and code references. Renamed from CodesetAliasContext; `buildCodeReference` renamed to `buildCodesetReference`. Version/suffix moved off module constants into the context.

## Testing Notes

- Publish a survey to BioHub and inspect the generated tarball: confirm `codes/`, `features/`, and `files/` layout and that `codes/codeset.json` is a single object keyed by e.g. `life_stage_v1`, `sex_v1`, with versioned code keys inside.
- Spot-check a feature file (e.g. `features/habitat_feature.json`) and confirm code fields use the `code::..._v1::..._v1` format.
- Run `api` tests (e.g. platform-service and biohub-create) to confirm no regressions.
