### PR TITLE
SIMSBIOHUB-970: Publish Part of a Survey

### DIFF
--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -5,6 +5,7 @@ import { describe } from 'mocha';
 import { SurveyObservationRecord } from '../database-models/survey_observation';
 import { ICritterDetailed } from '../services/critterbase-service';
 import {
+  BiohubFeatureType,
   buildCodesetExportContext,
   CodesetCategory,
   minimalCodesetExportContext,
@@ -1620,5 +1621,71 @@ describe('PostCodesetToBiohubObject and alias mapping', () => {
 
     const siteSelectionStrategies = (data.properties as any).site_select_strategy;
     expect(siteSelectionStrategies).to.eql([{ strategy: 'code::site_strategy::999' }]);
+  });
+});
+
+describe('Selective publish feature filtering', () => {
+  it('filters child features by includeFeatureTypes', () => {
+    const survey_obj: GetSurveyData = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    };
+
+    const survey_purpose_obj: GetSurveyPurposeAndMethodologyData = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    };
+
+    const observation_obj: SurveyObservationRecord = {
+      survey_observation_id: 1,
+      survey_id: 1,
+      survey_sample_period_id: 1,
+      latitude: 1,
+      longitude: 1,
+      count: 1,
+      itis_tsn: 1,
+      itis_scientific_name: 'test',
+      observation_time: '12:00',
+      observation_date: '2023-01-01',
+      observation_sign_id: 1
+    };
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [observation_obj],
+      { type: 'FeatureCollection', features: [] },
+      [
+        {
+          survey_attachment_id: 1,
+          file_name: 'attachment.csv',
+          file_size: '10',
+          file_type: 'text/csv',
+          key: 'a',
+          uuid: '123e4567-e89b-12d3-a456-426614174000',
+          create_date: '2024-01-01',
+          update_date: '2024-01-01',
+          create_user: 1,
+          title: null,
+          description: null,
+          revision_count: 1
+        }
+      ],
+      [],
+      {
+        includeFeatureTypes: new Set([BiohubFeatureType.OBSERVATION])
+      }
+    );
+
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.OBSERVATION)).to.equal(true);
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.FILE)).to.equal(false);
   });
 });

--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -1688,4 +1688,133 @@ describe('Selective publish feature filtering', () => {
     expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.OBSERVATION)).to.equal(true);
     expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.FILE)).to.equal(false);
   });
+
+  it('omits unselected study area, report, animal and stratum features', () => {
+    const survey_obj = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    } as GetSurveyData;
+
+    const survey_purpose_obj = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    } as GetSurveyPurposeAndMethodologyData;
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [],
+      { type: 'FeatureCollection', features: [] },
+      [],
+      [
+        {
+          survey_report_attachment_id: 1,
+          file_name: 'report.pdf',
+          file_size: '10',
+          key: 'report-key',
+          uuid: 'report-uuid',
+          title: 'Report',
+          description: null,
+          year_published: null
+        } as any
+      ],
+      {
+        animalRecords: [
+          {
+            critter_id: 'animal-1',
+            animal_id: 'ANIMAL-001',
+            itis_tsn: 1234,
+            critter_comment: 'Test animal',
+            sex: null,
+            captures: []
+          } as any
+        ],
+        surveyLocation: [{ geojson: [] }] as any,
+        strata: [{ name: 'Stratum A', description: 'Description' }],
+        includeFeatureTypes: new Set([BiohubFeatureType.OBSERVATION])
+      }
+    );
+
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.REPORT)).to.equal(false);
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.STUDY_AREA)).to.equal(false);
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.ANIMAL)).to.equal(false);
+    expect(data.child_features.some((feature) => feature.type === BiohubFeatureType.STRATUM)).to.equal(false);
+  });
+
+  it('filters nested animal children by selected feature types', () => {
+    const survey_obj = {
+      id: 1,
+      uuid: '1',
+      project_id: 1,
+      survey_name: 'survey_name',
+      progress_id: 1,
+      start_date: 'start_date',
+      end_date: 'end_date',
+      survey_types: [9],
+      revision_count: 1
+    } as GetSurveyData;
+
+    const survey_purpose_obj = {
+      intended_outcome_ids: [],
+      additional_details: 'A description of the purpose',
+      revision_count: 0
+    } as GetSurveyPurposeAndMethodologyData;
+
+    const animalRecord = {
+      critter_id: 'animal-1',
+      animal_id: 'ANIMAL-001',
+      itis_tsn: 1234,
+      critter_comment: 'Test animal',
+      sex: null,
+      captures: [
+        {
+          capture_date: '2024-01-01',
+          capture_time: null,
+          capture_location: null,
+          markings: [],
+          quantitative_measurements: [],
+          release_date: null
+        }
+      ],
+      mortality: [
+        {
+          mortality_comment: 'deceased',
+          mortality_timestamp: '2024-01-02',
+          location: null,
+          proximate_cause_of_death: null
+        }
+      ]
+    } as any;
+
+    const data = new PostSurveyToBiohubObject(
+      survey_obj,
+      survey_purpose_obj,
+      [],
+      { type: 'FeatureCollection', features: [] },
+      [],
+      [],
+      {
+        animalRecords: [animalRecord],
+        includeFeatureTypes: new Set([BiohubFeatureType.ANIMAL, BiohubFeatureType.CAPTURE])
+      }
+    );
+
+    const animalFeature = data.child_features.find((feature) => feature.type === BiohubFeatureType.ANIMAL);
+    expect(animalFeature).to.exist;
+    expect(animalFeature!.child_features.some((feature) => feature.type === BiohubFeatureType.CAPTURE)).to.equal(true);
+    expect(animalFeature!.child_features.some((feature) => feature.type === BiohubFeatureType.MORTALITY)).to.equal(
+      false
+    );
+    expect(
+      animalFeature!.child_features.some((feature) => feature.type === BiohubFeatureType.ECOLOGICAL_UNIT)
+    ).to.equal(false);
+  });
 });

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -126,6 +126,7 @@ interface PostSurveyToBiohubOptions {
   strata?: { name: string; description: string }[];
   siteSelectionStrategies?: number[];
   codesetCategories?: CodesetCategory[];
+  includeFeatureTypes?: Set<BiohubFeatureType>;
 }
 
 type PostSurveySubmissionOptions = PostSurveyToBiohubOptions;
@@ -872,6 +873,8 @@ export interface PostTelemetryDeploymentToBiohubOptions {
   telemetry?: Telemetry[];
   animalRecords?: ICritterDetailed[];
   codesetExportContext: CodesetExportContext;
+  includeTelemetry?: boolean;
+  includeTelemetryFrequency?: boolean;
 }
 
 export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFeature {
@@ -883,7 +886,13 @@ export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFe
   constructor(deploymentRecord: ExtendedDeploymentRecord, options: PostTelemetryDeploymentToBiohubOptions) {
     defaultLog.debug({ label: 'PostTelemetryDeploymentToBiohubObject', message: 'params', deploymentRecord });
 
-    const { telemetry, animalRecords, codesetExportContext } = options;
+    const {
+      telemetry,
+      animalRecords,
+      codesetExportContext,
+      includeTelemetry = true,
+      includeTelemetryFrequency = true
+    } = options;
 
     // Find the matching animal record to get the animal_id
     const matchingAnimal = animalRecords?.find(
@@ -903,7 +912,7 @@ export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFe
     this.child_features = [];
 
     // Add telemetry child features
-    if (telemetry) {
+    if (telemetry && includeTelemetry) {
       const telemetryFeatures = telemetry
         .filter((telemetryRecord) => {
           // Filter telemetry records that belong to this deployment
@@ -915,7 +924,10 @@ export class PostTelemetryDeploymentToBiohubObject implements BioHubSubmissionFe
     }
 
     // Add frequency child feature if frequency data exists
-    if (deploymentRecord.frequency != null || deploymentRecord.frequency_unit_id != null) {
+    if (
+      includeTelemetryFrequency &&
+      (deploymentRecord.frequency != null || deploymentRecord.frequency_unit_id != null)
+    ) {
       this.child_features.push(
         new PostTelemetryFrequencyToBiohubObject(deploymentRecord.frequency, deploymentRecord.frequency_unit_id, {
           codesetExportContext
@@ -1177,8 +1189,13 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       firstNations,
       strata,
       siteSelectionStrategies,
-      codesetCategories
+      codesetCategories,
+      includeFeatureTypes
     } = options;
+
+    const isFeatureIncluded = (featureType: BiohubFeatureType) => {
+      return includeFeatureTypes ? includeFeatureTypes.has(featureType) : true;
+    };
 
     const codesetExportContext = buildCodesetExportContext(codesetCategories ?? []);
 
@@ -1235,7 +1252,9 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
         new PostTelemetryDeploymentToBiohubObject(deployment, {
           telemetry,
           animalRecords,
-          codesetExportContext
+          codesetExportContext,
+          includeTelemetry: isFeatureIncluded(BiohubFeatureType.TELEMETRY),
+          includeTelemetryFrequency: isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEPLOYMENT)
         })
     );
 
@@ -1283,16 +1302,16 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       ...buildOptionalArrayProperty(siteSelectionStrategiesArray, 'site_select_strategy')
     };
     this.child_features = [
-      ...observationFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.OBSERVATION) ? observationFeatures : []),
       ...reportAttachmentFeatures,
-      ...attachmentFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.FILE) ? attachmentFeatures : []),
       ...animalFeatures,
-      ...samplingSiteFeatures,
-      ...samplingPeriodFeatures,
-      ...samplingTechniqueFeatures,
-      ...habitatFeatureFeatures,
-      ...telemetryDeviceFeatures,
-      ...telemetryDeploymentFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_SITE) ? samplingSiteFeatures : []),
+      ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_PERIOD) ? samplingPeriodFeatures : []),
+      ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_TECHNIQUE) ? samplingTechniqueFeatures : []),
+      ...(isFeatureIncluded(BiohubFeatureType.HABITAT_FEATURE) ? habitatFeatureFeatures : []),
+      ...(isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEVICE) ? telemetryDeviceFeatures : []),
+      ...(isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEPLOYMENT) ? telemetryDeploymentFeatures : []),
       ...studyAreaFeature,
       ...stratumFeatures,
       ...codesetFeature
@@ -1366,7 +1385,8 @@ export class PostSurveySubmissionToBioHubObject implements BioHubSubmission {
         firstNations,
         strata,
         siteSelectionStrategies,
-        codesetCategories
+        codesetCategories,
+        includeFeatureTypes: options.includeFeatureTypes
       }
     );
 
@@ -1602,7 +1622,7 @@ function buildCodesetReference(
   return `code::${categoryAlias}::${codeAlias}`;
 }
 
-enum BiohubFeatureType {
+export enum BiohubFeatureType {
   ANIMAL = 'animal',
   BLOCK = 'block',
   CAPTURE = 'capture',
@@ -1627,3 +1647,21 @@ enum BiohubFeatureType {
   TELEMETRY_FREQUENCY = 'telemetry_frequency',
   TELEMETRY_DEVICE = 'telemetry_device'
 }
+
+export const PUBLISHABLE_FEATURE_TYPES = [
+  BiohubFeatureType.SAMPLE_SITE,
+  BiohubFeatureType.SAMPLE_PERIOD,
+  BiohubFeatureType.SAMPLE_TECHNIQUE,
+  BiohubFeatureType.OBSERVATION,
+  BiohubFeatureType.TELEMETRY,
+  BiohubFeatureType.TELEMETRY_DEVICE,
+  BiohubFeatureType.TELEMETRY_DEPLOYMENT,
+  BiohubFeatureType.HABITAT_FEATURE,
+  BiohubFeatureType.FILE
+] as const;
+
+export const PUBLISHABLE_FEATURE_TYPE_PARENTS: Partial<Record<BiohubFeatureType, BiohubFeatureType[]>> = {
+  [BiohubFeatureType.SAMPLE_PERIOD]: [BiohubFeatureType.SAMPLE_SITE],
+  [BiohubFeatureType.TELEMETRY_DEPLOYMENT]: [BiohubFeatureType.TELEMETRY_DEVICE],
+  [BiohubFeatureType.TELEMETRY]: [BiohubFeatureType.TELEMETRY_DEPLOYMENT]
+};

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -11,7 +11,6 @@ import {
 } from '../repositories/observation-environment-repository';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
 import { SurveySamplePeriodDetails } from '../repositories/sample-period-repository';
-import { SampleSiteRecordExtendedNonSpatial } from '../repositories/sample-site-repository/sample-site-repository';
 import { SurveyLocationRecord } from '../repositories/survey-location-repository';
 import { ExtendedDeploymentRecord } from '../repositories/telemetry-repositories/telemetry-deployment-repository.interface';
 import { Telemetry } from '../repositories/telemetry-repositories/telemetry-vendor-repository.interface';
@@ -26,8 +25,11 @@ import { getLogger } from '../utils/logger';
 import { GetSurveyData, GetSurveyPurposeAndMethodologyData } from './survey-view';
 
 // Extended interface for sampling sites with geometry data
-interface SampleSiteRecordWithGeojson extends SampleSiteRecordExtendedNonSpatial {
-  geojson: Feature;
+interface SampleSiteRecordWithGeojson {
+  name: string;
+  description: string | null;
+  blocks?: { name: string; description: string }[];
+  geojson: Feature | null;
 }
 
 // Measurement record types
@@ -135,6 +137,26 @@ export interface BioHubSubmissionFeature {
   type: string;
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
+}
+
+interface PostSurveyCaptureToBiohubOptions {
+  includeMarking?: boolean;
+  includeMeasurement?: boolean;
+  includeRelease?: boolean;
+}
+
+interface PostSurveyAnimalToBiohubOptions {
+  includeCapture?: boolean;
+  includeMortality?: boolean;
+  includeEcologicalUnit?: boolean;
+  includeMarking?: boolean;
+  includeMeasurement?: boolean;
+  includeRelease?: boolean;
+}
+
+interface PostSurveySamplingSiteToBiohubOptions {
+  includeBlock?: boolean;
+  includeStratum?: boolean;
 }
 
 export interface PostSurveyObservationToBiohubOptions {
@@ -261,8 +283,9 @@ export class PostSurveyCaptureToBiohubObject implements BioHubSubmissionFeature 
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(captureRecord: ICritterDetailed['captures'][0]) {
+  constructor(captureRecord: ICritterDetailed['captures'][0], options: PostSurveyCaptureToBiohubOptions = {}) {
     defaultLog.debug({ label: 'PostSurveyCaptureToBiohubObject', message: 'params', captureRecord });
+    const { includeMarking = true, includeMeasurement = true, includeRelease = true } = options;
 
     // Combine date and time into a single timestamp
     const timestamp = captureRecord.capture_time
@@ -295,14 +318,14 @@ export class PostSurveyCaptureToBiohubObject implements BioHubSubmissionFeature 
     const childFeatures: BioHubSubmissionFeature[] = [];
 
     // Add marking features
-    if (captureRecord.markings) {
+    if (captureRecord.markings && includeMarking) {
       for (const marking of captureRecord.markings) {
         childFeatures.push(new PostSurveyMarkingToBiohubObject(marking));
       }
     }
 
     // Add quantitative measurement features
-    if (captureRecord.quantitative_measurements) {
+    if (captureRecord.quantitative_measurements && includeMeasurement) {
       for (const measurement of captureRecord.quantitative_measurements) {
         childFeatures.push(new PostSurveyMeasurementToBiohubObject(measurement));
       }
@@ -311,7 +334,7 @@ export class PostSurveyCaptureToBiohubObject implements BioHubSubmissionFeature 
     // Note: qualitative_measurements could also be added here if needed
 
     // Add release feature as child of capture if release data exists
-    if (captureRecord.release_date) {
+    if (captureRecord.release_date && includeRelease) {
       childFeatures.push(new PostSurveyReleaseToBiohubObject(captureRecord));
     }
 
@@ -489,36 +512,52 @@ export class PostSurveyAnimalToBiohubObject implements BioHubSubmissionFeature {
 
   constructor(
     animalRecord: ICritterDetailed & { mortality?: MortalityRecord | MortalityRecord[] },
-    focalSpeciesData?: { focal_species: ITaxonomyWithEcologicalUnits[] }
+    focalSpeciesData?: { focal_species: ITaxonomyWithEcologicalUnits[] },
+    options: PostSurveyAnimalToBiohubOptions = {}
   ) {
     defaultLog.debug({ label: 'PostSurveyAnimalToBiohubObject', message: 'params', animalRecord });
+    const {
+      includeCapture = true,
+      includeMortality = true,
+      includeEcologicalUnit = true,
+      includeMarking = true,
+      includeMeasurement = true,
+      includeRelease = true
+    } = options;
 
     // Create capture features for each capture record
     const childFeatures: BioHubSubmissionFeature[] = [];
 
-    if (animalRecord.captures) {
+    if (animalRecord.captures && includeCapture) {
       for (const capture of animalRecord.captures) {
-        // Always create capture feature (release will be a child of capture)
-        childFeatures.push(new PostSurveyCaptureToBiohubObject(capture));
+        childFeatures.push(
+          new PostSurveyCaptureToBiohubObject(capture, {
+            includeMarking,
+            includeMeasurement,
+            includeRelease
+          })
+        );
       }
     }
 
     // Create mortality features if mortality data exists
     // Note: The actual JSON data shows mortality as an array, but the interface shows it as a single object
     const mortalityArray = animalRecord.mortality || [];
-    if (Array.isArray(mortalityArray)) {
+    if (includeMortality && Array.isArray(mortalityArray)) {
       for (const mortality of mortalityArray) {
         childFeatures.push(new PostSurveyMortalityToBiohubObject(mortality));
       }
-    } else if (animalRecord.mortality) {
+    } else if (includeMortality && animalRecord.mortality) {
       // Handle case where mortality is a single object (according to interface)
       childFeatures.push(new PostSurveyMortalityToBiohubObject(animalRecord.mortality));
     }
 
     // Create ecological unit features for this animal if focal species data exists
-    if (focalSpeciesData?.focal_species) {
+    if (includeEcologicalUnit && focalSpeciesData?.focal_species) {
       // Find the species that matches this animal's taxon
-      const matchingSpecies = focalSpeciesData.focal_species.find((species) => species.tsn === animalRecord.itis_tsn);
+      const matchingSpecies = focalSpeciesData.focal_species.find(
+        (species: ITaxonomyWithEcologicalUnits) => species.tsn === animalRecord.itis_tsn
+      );
 
       if (matchingSpecies?.ecological_units && matchingSpecies.ecological_units.length > 0) {
         const ecologicalUnitFeatures = matchingSpecies.ecological_units.map(
@@ -618,8 +657,13 @@ export class PostSurveySamplingSiteToBiohubObject implements BioHubSubmissionFea
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(sampleSiteRecord: SampleSiteRecordWithGeojson, strata?: { name: string; description: string }[]) {
+  constructor(
+    sampleSiteRecord: SampleSiteRecordWithGeojson,
+    strata?: { name: string; description: string }[],
+    options: PostSurveySamplingSiteToBiohubOptions = {}
+  ) {
     defaultLog.debug({ label: 'PostSurveySamplingSiteToBiohubObject', message: 'params', sampleSiteRecord });
+    const { includeBlock = true, includeStratum = true } = options;
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.SAMPLE_SITE;
@@ -635,12 +679,16 @@ export class PostSurveySamplingSiteToBiohubObject implements BioHubSubmissionFea
     };
 
     // Create stratum child features if strata data is available
-    const stratumChildFeatures = strata ? strata.map((stratum) => new PostStratumToBiohubObject(stratum)) : [];
+    const stratumChildFeatures =
+      strata && includeStratum ? strata.map((stratum) => new PostStratumToBiohubObject(stratum)) : [];
 
     // Create block child features if blocks data is available in the sample site record
-    const blockChildFeatures = sampleSiteRecord.blocks
-      ? sampleSiteRecord.blocks.map((block) => new PostBlockToBiohubObject(block))
-      : [];
+    const blockChildFeatures =
+      includeBlock && sampleSiteRecord.blocks
+        ? sampleSiteRecord.blocks.map(
+            (block: { name: string; description: string }) => new PostBlockToBiohubObject(block)
+          )
+        : [];
 
     this.child_features = [...stratumChildFeatures, ...blockChildFeatures];
   }
@@ -799,7 +847,9 @@ export class PostSurveyHabitatFeatureToBiohubObject implements BioHubSubmissionF
 
     // Create associated species array from focal species
     const associatedSpeciesArray =
-      habitatFeatureRecord.survey_habitat_feature_taxons?.map((species) => ({ taxon_id: species.itis_tsn })) || [];
+      habitatFeatureRecord.survey_habitat_feature_taxons?.map((species: { itis_tsn: number }) => ({
+        taxon_id: species.itis_tsn
+      })) || [];
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.HABITAT_FEATURE;
@@ -1216,12 +1266,26 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       (attachment) => new PostSurveyReportAttachmentsToBiohubObject(attachment)
     );
 
-    const animalFeatures = animalRecords.map((animal) => new PostSurveyAnimalToBiohubObject(animal, focalSpecies));
+    const animalFeatures = animalRecords.map(
+      (animal) =>
+        new PostSurveyAnimalToBiohubObject(animal, focalSpecies, {
+          includeCapture: isFeatureIncluded(BiohubFeatureType.CAPTURE),
+          includeMortality: isFeatureIncluded(BiohubFeatureType.MORTALITY),
+          includeEcologicalUnit: isFeatureIncluded(BiohubFeatureType.ECOLOGICAL_UNIT),
+          includeMarking: isFeatureIncluded(BiohubFeatureType.MARKING),
+          includeMeasurement: isFeatureIncluded(BiohubFeatureType.MEASUREMENT),
+          includeRelease: isFeatureIncluded(BiohubFeatureType.RELEASE)
+        })
+    );
 
     // Create sampling features
     const samplingSiteFeatures = mapOrEmpty(
       samplingSites,
-      (samplingSite) => new PostSurveySamplingSiteToBiohubObject(samplingSite, strata)
+      (samplingSite) =>
+        new PostSurveySamplingSiteToBiohubObject(samplingSite, strata, {
+          includeBlock: isFeatureIncluded(BiohubFeatureType.BLOCK),
+          includeStratum: isFeatureIncluded(BiohubFeatureType.STRATUM)
+        })
     );
 
     const samplingPeriodFeatures = mapOrEmpty(
@@ -1254,7 +1318,7 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
           animalRecords,
           codesetExportContext,
           includeTelemetry: isFeatureIncluded(BiohubFeatureType.TELEMETRY),
-          includeTelemetryFrequency: isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEPLOYMENT)
+          includeTelemetryFrequency: isFeatureIncluded(BiohubFeatureType.TELEMETRY_FREQUENCY)
         })
     );
 
@@ -1303,17 +1367,17 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     };
     this.child_features = [
       ...(isFeatureIncluded(BiohubFeatureType.OBSERVATION) ? observationFeatures : []),
-      ...reportAttachmentFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.REPORT) ? reportAttachmentFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.FILE) ? attachmentFeatures : []),
-      ...animalFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.ANIMAL) ? animalFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_SITE) ? samplingSiteFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_PERIOD) ? samplingPeriodFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.SAMPLE_TECHNIQUE) ? samplingTechniqueFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.HABITAT_FEATURE) ? habitatFeatureFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEVICE) ? telemetryDeviceFeatures : []),
       ...(isFeatureIncluded(BiohubFeatureType.TELEMETRY_DEPLOYMENT) ? telemetryDeploymentFeatures : []),
-      ...studyAreaFeature,
-      ...stratumFeatures,
+      ...(isFeatureIncluded(BiohubFeatureType.STUDY_AREA) ? studyAreaFeature : []),
+      ...(isFeatureIncluded(BiohubFeatureType.STRATUM) ? stratumFeatures : []),
       ...codesetFeature
     ];
   }
@@ -1649,19 +1713,41 @@ export enum BiohubFeatureType {
 }
 
 export const PUBLISHABLE_FEATURE_TYPES = [
+  BiohubFeatureType.ANIMAL,
+  BiohubFeatureType.BLOCK,
+  BiohubFeatureType.CAPTURE,
+  BiohubFeatureType.ECOLOGICAL_UNIT,
+  BiohubFeatureType.FILE,
+  BiohubFeatureType.HABITAT_FEATURE,
+  BiohubFeatureType.MARKING,
+  BiohubFeatureType.MEASUREMENT,
+  BiohubFeatureType.MORTALITY,
+  BiohubFeatureType.OBSERVATION,
+  BiohubFeatureType.RELEASE,
+  BiohubFeatureType.REPORT,
   BiohubFeatureType.SAMPLE_SITE,
   BiohubFeatureType.SAMPLE_PERIOD,
   BiohubFeatureType.SAMPLE_TECHNIQUE,
-  BiohubFeatureType.OBSERVATION,
+  BiohubFeatureType.STRATUM,
+  BiohubFeatureType.STUDY_AREA,
   BiohubFeatureType.TELEMETRY,
   BiohubFeatureType.TELEMETRY_DEVICE,
   BiohubFeatureType.TELEMETRY_DEPLOYMENT,
-  BiohubFeatureType.HABITAT_FEATURE,
-  BiohubFeatureType.FILE
+  BiohubFeatureType.TELEMETRY_FREQUENCY
 ] as const;
 
 export const PUBLISHABLE_FEATURE_TYPE_PARENTS: Partial<Record<BiohubFeatureType, BiohubFeatureType[]>> = {
+  [BiohubFeatureType.BLOCK]: [BiohubFeatureType.SAMPLE_SITE],
+  [BiohubFeatureType.CAPTURE]: [BiohubFeatureType.ANIMAL],
+  [BiohubFeatureType.ECOLOGICAL_UNIT]: [BiohubFeatureType.ANIMAL],
+  [BiohubFeatureType.MARKING]: [BiohubFeatureType.CAPTURE],
+  [BiohubFeatureType.MEASUREMENT]: [BiohubFeatureType.CAPTURE],
+  [BiohubFeatureType.MORTALITY]: [BiohubFeatureType.ANIMAL],
+  [BiohubFeatureType.RELEASE]: [BiohubFeatureType.CAPTURE],
   [BiohubFeatureType.SAMPLE_PERIOD]: [BiohubFeatureType.SAMPLE_SITE],
+  [BiohubFeatureType.SAMPLE_TECHNIQUE]: [BiohubFeatureType.SAMPLE_SITE],
+  [BiohubFeatureType.STRATUM]: [BiohubFeatureType.SAMPLE_SITE],
   [BiohubFeatureType.TELEMETRY_DEPLOYMENT]: [BiohubFeatureType.TELEMETRY_DEVICE],
-  [BiohubFeatureType.TELEMETRY]: [BiohubFeatureType.TELEMETRY_DEPLOYMENT]
+  [BiohubFeatureType.TELEMETRY]: [BiohubFeatureType.TELEMETRY_DEPLOYMENT],
+  [BiohubFeatureType.TELEMETRY_FREQUENCY]: [BiohubFeatureType.TELEMETRY_DEPLOYMENT]
 };

--- a/api/src/models/publish-feature-contract.test.ts
+++ b/api/src/models/publish-feature-contract.test.ts
@@ -1,0 +1,188 @@
+import fs from 'fs';
+import path from 'path';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+describe('Publish feature contract between api and app', () => {
+  const sortValues = (values: string[]) => [...values].sort((left, right) => left.localeCompare(right));
+
+  const normalizeParents = (graph: Partial<Record<string, string[]>>) => {
+    const entries = Object.entries(graph)
+      .map(([featureType, parents]) => [featureType, sortValues(parents || [])] as const)
+      .sort(([left], [right]) => left.localeCompare(right));
+
+    return Object.fromEntries(entries);
+  };
+
+  const apiBiohubCreatePath = path.resolve(process.cwd(), 'src/models/biohub-create.ts');
+  const appPublishFeatureTypesPath = path.resolve(process.cwd(), '../app/src/components/publish/publishFeatureTypes.ts');
+  const appFeatureDependenciesPath = path.resolve(process.cwd(), '../app/src/components/publish/featureDependencies.ts');
+
+  const apiBiohubCreateSource = fs.readFileSync(apiBiohubCreatePath, 'utf8');
+  const appPublishFeatureTypesSource = fs.readFileSync(appPublishFeatureTypesPath, 'utf8');
+  const appFeatureDependenciesSource = fs.readFileSync(appFeatureDependenciesPath, 'utf8');
+
+  const extractBlockBody = (source: string, startToken: string): string => {
+    const startIndex = source.indexOf(startToken);
+    if (startIndex === -1) {
+      throw new Error(`Unable to find token: ${startToken}`);
+    }
+
+    const braceStart = source.indexOf('{', startIndex);
+    if (braceStart === -1) {
+      throw new Error(`Unable to find opening brace for token: ${startToken}`);
+    }
+
+    let depth = 1;
+    let index = braceStart + 1;
+    while (index < source.length && depth > 0) {
+      const char = source[index];
+      if (char === '{') {
+        depth += 1;
+      } else if (char === '}') {
+        depth -= 1;
+      }
+      index += 1;
+    }
+
+    if (depth !== 0) {
+      throw new Error(`Unable to find matching closing brace for token: ${startToken}`);
+    }
+
+    return source.slice(braceStart + 1, index - 1);
+  };
+
+  const extractArrayBody = (source: string, startToken: string): string => {
+    const startIndex = source.indexOf(startToken);
+    if (startIndex === -1) {
+      throw new Error(`Unable to find token: ${startToken}`);
+    }
+
+    const bracketStart = source.indexOf('[', startIndex);
+    if (bracketStart === -1) {
+      throw new Error(`Unable to find opening bracket for token: ${startToken}`);
+    }
+
+    let depth = 1;
+    let index = bracketStart + 1;
+    while (index < source.length && depth > 0) {
+      const char = source[index];
+      if (char === '[') {
+        depth += 1;
+      } else if (char === ']') {
+        depth -= 1;
+      }
+      index += 1;
+    }
+
+    if (depth !== 0) {
+      throw new Error(`Unable to find matching closing bracket for token: ${startToken}`);
+    }
+
+    return source.slice(bracketStart + 1, index - 1);
+  };
+
+  const parseBiohubEnum = (): Record<string, string> => {
+    const enumBody = extractBlockBody(apiBiohubCreateSource, 'export enum BiohubFeatureType');
+    const pairs = [...enumBody.matchAll(/([A-Z_]+)\s*=\s*'([^']+)'/g)];
+
+    return Object.fromEntries(pairs.map(([, key, value]) => [key, value]));
+  };
+
+  const parseApiPublishableFeatures = (enumMap: Record<string, string>): string[] => {
+    const arrayBody = extractArrayBody(apiBiohubCreateSource, 'export const PUBLISHABLE_FEATURE_TYPES =');
+    const symbolMatches = [...arrayBody.matchAll(/BiohubFeatureType\.([A-Z_]+)/g)].map(([, symbol]) => symbol);
+
+    return symbolMatches.map((symbol) => enumMap[symbol]).filter((value): value is string => Boolean(value));
+  };
+
+  const parseApiParents = (enumMap: Record<string, string>): Partial<Record<string, string[]>> => {
+    const objectBody = extractBlockBody(apiBiohubCreateSource, 'export const PUBLISHABLE_FEATURE_TYPE_PARENTS');
+    const entries = [...objectBody.matchAll(/\[BiohubFeatureType\.([A-Z_]+)\]\s*:\s*\[([^\]]*)\]/g)];
+
+    const graph: Partial<Record<string, string[]>> = {};
+    for (const [, childSymbol, parentsBody] of entries) {
+      const parentSymbols = [...parentsBody.matchAll(/BiohubFeatureType\.([A-Z_]+)/g)].map(([, symbol]) => symbol);
+      graph[enumMap[childSymbol]] = parentSymbols
+        .map((parentSymbol) => enumMap[parentSymbol])
+        .filter((value): value is string => Boolean(value));
+    }
+
+    return graph;
+  };
+
+  const parseFrontendFeatureTypes = (): Record<string, string> => {
+    const objectBody = extractBlockBody(appPublishFeatureTypesSource, 'export const PUBLISH_FEATURE_TYPES =');
+    const pairs = [...objectBody.matchAll(/([A-Z_]+)\s*:\s*'([^']+)'/g)];
+
+    return Object.fromEntries(pairs.map(([, key, value]) => [key, value]));
+  };
+
+  const parseFrontendDependencyGraph = (
+    source: string,
+    token: string,
+    frontendFeatureTypeMap: Record<string, string>
+  ): Partial<Record<string, string[]>> => {
+    const objectBody = extractBlockBody(source, token);
+    const entries = [...objectBody.matchAll(/\[PUBLISH_FEATURE_TYPES\.([A-Z_]+)\]\s*:\s*\[([^\]]*)\]/g)];
+
+    const graph: Partial<Record<string, string[]>> = {};
+    for (const [, childSymbol, parentsBody] of entries) {
+      const dependencySymbols = [...parentsBody.matchAll(/PUBLISH_FEATURE_TYPES\.([A-Z_]+)/g)].map(([, symbol]) => symbol);
+      graph[frontendFeatureTypeMap[childSymbol]] = dependencySymbols
+        .map((dependencySymbol) => frontendFeatureTypeMap[dependencySymbol])
+        .filter((value): value is string => Boolean(value));
+    }
+
+    return graph;
+  };
+
+  const apiEnumMap = parseBiohubEnum();
+  const apiPublishableFeatures = parseApiPublishableFeatures(apiEnumMap);
+  const apiParentGraph = parseApiParents(apiEnumMap);
+  const frontendFeatureTypeMap = parseFrontendFeatureTypes();
+  const frontendFeatures = Object.values(frontendFeatureTypeMap);
+  const frontendParentGraph = parseFrontendDependencyGraph(
+    appFeatureDependenciesSource,
+    'export const PARENTS',
+    frontendFeatureTypeMap
+  );
+  const frontendChildrenGraph = parseFrontendDependencyGraph(
+    appFeatureDependenciesSource,
+    'export const CHILDREN',
+    frontendFeatureTypeMap
+  );
+
+  it('keeps publish feature values in sync', () => {
+    expect(sortValues(frontendFeatures)).to.deep.equal(sortValues(apiPublishableFeatures));
+  });
+
+  it('keeps parent dependency graph in sync', () => {
+    expect(normalizeParents(frontendParentGraph)).to.deep.equal(normalizeParents(apiParentGraph));
+  });
+
+  it('keeps CHILDREN graph as inverse of PARENTS', () => {
+    for (const featureType of frontendFeatures) {
+      const expectedChildren = Object.entries(frontendParentGraph)
+        .filter(([, parentFeatureTypes]) => parentFeatureTypes?.includes(featureType))
+        .map(([childFeatureType]) => childFeatureType);
+      const actualChildren = frontendChildrenGraph[featureType] || [];
+
+      expect(sortValues(actualChildren), `Children mismatch for ${featureType}`).to.deep.equal(
+        sortValues(expectedChildren)
+      );
+    }
+  });
+
+  it('keeps backend parent graph values valid publishable features', () => {
+    const publishableFeatures = new Set<string>(apiPublishableFeatures);
+
+    for (const [featureType, parents] of Object.entries(apiParentGraph)) {
+      expect(publishableFeatures.has(featureType), `${featureType} is not publishable`).to.equal(true);
+
+      for (const parentFeatureType of parents || []) {
+        expect(publishableFeatures.has(parentFeatureType), `${parentFeatureType} is not publishable`).to.equal(true);
+      }
+    }
+  });
+});

--- a/api/src/models/publish-feature-contract.test.ts
+++ b/api/src/models/publish-feature-contract.test.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
 import { expect } from 'chai';
+import fs from 'fs';
 import { describe, it } from 'mocha';
+import path from 'path';
 
 describe('Publish feature contract between api and app', () => {
   const sortValues = (values: string[]) => [...values].sort((left, right) => left.localeCompare(right));
@@ -15,8 +15,14 @@ describe('Publish feature contract between api and app', () => {
   };
 
   const apiBiohubCreatePath = path.resolve(process.cwd(), 'src/models/biohub-create.ts');
-  const appPublishFeatureTypesPath = path.resolve(process.cwd(), '../app/src/components/publish/publishFeatureTypes.ts');
-  const appFeatureDependenciesPath = path.resolve(process.cwd(), '../app/src/components/publish/featureDependencies.ts');
+  const appPublishFeatureTypesPath = path.resolve(
+    process.cwd(),
+    '../app/src/components/publish/publishFeatureTypes.ts'
+  );
+  const appFeatureDependenciesPath = path.resolve(
+    process.cwd(),
+    '../app/src/components/publish/featureDependencies.ts'
+  );
 
   const apiBiohubCreateSource = fs.readFileSync(apiBiohubCreatePath, 'utf8');
   const appPublishFeatureTypesSource = fs.readFileSync(appPublishFeatureTypesPath, 'utf8');
@@ -128,7 +134,9 @@ describe('Publish feature contract between api and app', () => {
 
     const graph: Partial<Record<string, string[]>> = {};
     for (const [, childSymbol, parentsBody] of entries) {
-      const dependencySymbols = [...parentsBody.matchAll(/PUBLISH_FEATURE_TYPES\.([A-Z_]+)/g)].map(([, symbol]) => symbol);
+      const dependencySymbols = [...parentsBody.matchAll(/PUBLISH_FEATURE_TYPES\.([A-Z_]+)/g)].map(
+        ([, symbol]) => symbol
+      );
       graph[frontendFeatureTypeMap[childSymbol]] = dependencySymbols
         .map((dependencySymbol) => frontendFeatureTypeMap[dependencySymbol])
         .filter((value): value is string => Boolean(value));

--- a/api/src/models/telemetry-features.test.ts
+++ b/api/src/models/telemetry-features.test.ts
@@ -241,6 +241,54 @@ describe('Telemetry Features BioHub Integration', () => {
       expect(frequencyFeature.properties.frequency).to.equal(6);
       expect(frequencyFeature.properties.frequency_unit).to.equal('code::frequency_unit::99');
     });
+
+    it('skips telemetry and frequency children when include flags are false', () => {
+      const deploymentRecord = {
+        deployment_id: 459,
+        survey_id: 1,
+        critter_id: 792,
+        device_id: 125,
+        device_key: 'device-key-126',
+        frequency: 6,
+        frequency_unit_id: 99,
+        attachment_start_date: '2024-05-01',
+        attachment_start_time: '12:00:00',
+        attachment_start_timestamp: '2024-05-01T12:00:00Z',
+        attachment_end_date: null,
+        attachment_end_time: null,
+        attachment_end_timestamp: null,
+        critterbase_start_capture_id: null,
+        critterbase_end_capture_id: null,
+        critterbase_end_mortality_id: null,
+        serial: 'UNKNOWN-UNIT-002',
+        device_make_id: 3,
+        model: 'GPS-6000',
+        critterbase_critter_id: 'test-critter-uuid'
+      };
+
+      const deploymentObj = new PostTelemetryDeploymentToBiohubObject(deploymentRecord, {
+        telemetry: [
+          {
+            telemetry_id: 't-1',
+            deployment_id: 459,
+            critter_id: 1,
+            vendor: TelemetryVendorEnum.MANUAL,
+            serial: 'a',
+            acquisition_date: '2024-01-01',
+            latitude: 1,
+            longitude: 1,
+            elevation: null,
+            temperature: null,
+            dop: null
+          }
+        ],
+        codesetExportContext: minimalCodesetExportContext,
+        includeTelemetry: false,
+        includeTelemetryFrequency: false
+      });
+
+      expect(deploymentObj.child_features).to.deep.equal([]);
+    });
   });
 
   describe('PostSurveyToBiohubObject with telemetry features', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
@@ -5,6 +5,7 @@ import sinonChai from 'sinon-chai';
 import * as db from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { PlatformService } from '../../../../../../services/platform-service';
+import { SurveyService } from '../../../../../../services/survey-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
 import { getSurveyPublishableFeatures } from './features';
 
@@ -20,6 +21,7 @@ describe('survey/{surveyId}/publish/features', () => {
       const dbConnectionObj = getMockDBConnection({ release: sinon.stub() });
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 1 } as any);
       sinon.stub(PlatformService.prototype, 'getSurveyPublishableFeatures').resolves({
         featureTypes: ['animal', 'sample_site'] as any
       });
@@ -46,6 +48,7 @@ describe('survey/{surveyId}/publish/features', () => {
       const dbConnectionObj = getMockDBConnection({ release: sinon.stub() });
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 1 } as any);
       sinon.stub(PlatformService.prototype, 'getSurveyPublishableFeatures').rejects(new Error('a test error'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -61,6 +64,30 @@ describe('survey/{surveyId}/publish/features', () => {
       } catch (error) {
         expect(dbConnectionObj.release).to.have.been.calledOnce;
         expect((error as HTTPError).message).to.equal('a test error');
+      }
+    });
+
+    it('throws bad request when survey does not belong to project', async () => {
+      const dbConnectionObj = getMockDBConnection({ release: sinon.stub() });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 99 } as any);
+      const getSurveyPublishableFeaturesStub = sinon.stub(PlatformService.prototype, 'getSurveyPublishableFeatures');
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = {
+        projectId: '1',
+        surveyId: '2'
+      };
+
+      try {
+        const requestHandler = getSurveyPublishableFeatures();
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect((error as HTTPError).message).to.equal('Invalid project or survey identifier.');
+        expect(dbConnectionObj.release).to.have.been.calledOnce;
+        expect(getSurveyPublishableFeaturesStub).to.not.have.been.called;
       }
     });
   });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
@@ -1,0 +1,67 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../../../../../database/db';
+import { HTTPError } from '../../../../../../errors/http-error';
+import { PlatformService } from '../../../../../../services/platform-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
+import { getSurveyPublishableFeatures } from './features';
+
+chai.use(sinonChai);
+
+describe('survey/{surveyId}/publish/features', () => {
+  describe('getSurveyPublishableFeatures', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns publishable feature types', async () => {
+      const dbConnectionObj = getMockDBConnection({ release: sinon.stub() });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(PlatformService.prototype, 'getSurveyPublishableFeatures').resolves({
+        featureTypes: ['animal', 'sample_site'] as any
+      });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = {
+        projectId: '1',
+        surveyId: '2'
+      };
+
+      try {
+        const requestHandler = getSurveyPublishableFeatures();
+        await requestHandler(mockReq, mockRes, mockNext);
+      } catch (_error) {
+        expect.fail();
+      }
+
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.eql({ featureTypes: ['animal', 'sample_site'] });
+      expect(dbConnectionObj.release).to.have.been.calledOnce;
+    });
+
+    it('catches and rethrows errors while releasing connection', async () => {
+      const dbConnectionObj = getMockDBConnection({ release: sinon.stub() });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(PlatformService.prototype, 'getSurveyPublishableFeatures').rejects(new Error('a test error'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = {
+        projectId: '1',
+        surveyId: '2'
+      };
+
+      try {
+        const requestHandler = getSurveyPublishableFeatures();
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect(dbConnectionObj.release).to.have.been.calledOnce;
+        expect((error as HTTPError).message).to.equal('a test error');
+      }
+    });
+  });
+});

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.ts
@@ -2,8 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../database/db';
+import { HTTP400 } from '../../../../../../errors/http-error';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
 import { PlatformService } from '../../../../../../services/platform-service';
+import { SurveyService } from '../../../../../../services/survey-service';
 import { getLogger } from '../../../../../../utils/logger';
 
 const defaultLog = getLogger('paths/project/{projectId}/survey/{surveyId}/publish/features');
@@ -65,10 +67,18 @@ GET.apiDoc = {
 export function getSurveyPublishableFeatures(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
+    const projectId = Number(req.params.projectId);
     const surveyId = Number(req.params.surveyId);
 
     try {
       await connection.open();
+
+      const surveyService = new SurveyService(connection);
+      const surveyData = await surveyService.getSurveyData(surveyId);
+
+      if (surveyData.project_id !== projectId) {
+        throw new HTTP400('Invalid project or survey identifier.');
+      }
 
       const platformService = new PlatformService(connection);
       const response = await platformService.getSurveyPublishableFeatures(surveyId);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.ts
@@ -1,0 +1,84 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../database/db';
+import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
+import { PlatformService } from '../../../../../../services/platform-service';
+import { getLogger } from '../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/project/{projectId}/survey/{surveyId}/publish/features');
+
+export const GET: Operation = [
+  authorizeRequestHandler((req) => {
+    return {
+      or: [
+        {
+          validProjectPermissions: [PROJECT_PERMISSION.COORDINATOR, PROJECT_PERMISSION.COLLABORATOR],
+          surveyId: Number(req.params.surveyId),
+          discriminator: 'ProjectPermission'
+        },
+        {
+          validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+          discriminator: 'SystemRole'
+        }
+      ]
+    };
+  }),
+  getSurveyPublishableFeatures()
+];
+
+GET.apiDoc = {
+  description: 'Get survey publishable feature types.',
+  tags: ['survey', 'biohub'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    { in: 'path', name: 'projectId', required: true, schema: { type: 'integer', minimum: 1 } },
+    { in: 'path', name: 'surveyId', required: true, schema: { type: 'integer', minimum: 1 } }
+  ],
+  responses: {
+    200: {
+      description: 'Publishable feature types for the survey.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['featureTypes'],
+            properties: {
+              featureTypes: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    401: { $ref: '#/components/responses/401' },
+    403: { $ref: '#/components/responses/403' },
+    500: { $ref: '#/components/responses/500' }
+  }
+};
+
+export function getSurveyPublishableFeatures(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const surveyId = Number(req.params.surveyId);
+
+    try {
+      await connection.open();
+
+      const platformService = new PlatformService(connection);
+      const response = await platformService.getSurveyPublishableFeatures(surveyId);
+
+      return res.status(200).json(response);
+    } catch (error) {
+      defaultLog.error({ label: 'getSurveyPublishableFeatures', message: 'error', error });
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/publish/survey.test.ts
+++ b/api/src/paths/publish/survey.test.ts
@@ -6,6 +6,7 @@ import sinonChai from 'sinon-chai';
 import * as db from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { PlatformService } from '../../services/platform-service';
+import { SurveyService } from '../../services/survey-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { POST, publishSurvey } from './survey';
 
@@ -29,6 +30,7 @@ describe('survey', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 1 } as any);
 
       sinon
         .stub(PlatformService.prototype, 'submitSurveyToBioHub')
@@ -37,6 +39,7 @@ describe('survey', () => {
       const sampleReq = {
         keycloak_token: {},
         body: {
+          projectId: 1,
           surveyId: 1,
           data: {
             submissionComment: 'test'
@@ -69,10 +72,18 @@ describe('survey', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: sinon.stub(), release: sinon.stub() });
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 1 } as any);
 
       sinon.stub(PlatformService.prototype, 'submitSurveyToBioHub').rejects(new Error('a test error'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.body = {
+        projectId: 1,
+        surveyId: 1,
+        data: {
+          submissionComment: 'test'
+        }
+      };
 
       try {
         const requestHandler = publishSurvey();
@@ -84,6 +95,39 @@ describe('survey', () => {
         expect(dbConnectionObj.release).to.have.been.called;
 
         expect((actualError as HTTPError).message).to.equal('a test error');
+      }
+    });
+
+    it('throws bad request when survey does not belong to project', async () => {
+      const dbConnectionObj = getMockDBConnection({ rollback: sinon.stub(), release: sinon.stub() });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ project_id: 999 } as any);
+      const submitSurveyToBioHubStub = sinon.stub(PlatformService.prototype, 'submitSurveyToBioHub');
+
+      const sampleReq = {
+        keycloak_token: {},
+        body: {
+          projectId: 1,
+          surveyId: 1,
+          data: {
+            submissionComment: 'test'
+          }
+        },
+        params: {}
+      } as any;
+
+      const { mockRes, mockNext } = getRequestHandlerMocks();
+
+      try {
+        const requestHandler = publishSurvey();
+        await requestHandler(sampleReq, mockRes, mockNext);
+        expect.fail();
+      } catch (actualError) {
+        expect((actualError as HTTPError).message).to.equal('Invalid project or survey identifier.');
+        expect(dbConnectionObj.rollback).to.have.been.called;
+        expect(dbConnectionObj.release).to.have.been.called;
+        expect(submitSurveyToBioHubStub).to.not.have.been.called;
       }
     });
   });

--- a/api/src/paths/publish/survey.ts
+++ b/api/src/paths/publish/survey.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../constants/roles';
 import { getDBConnection } from '../../database/db';
+import { BiohubFeatureType, PUBLISHABLE_FEATURE_TYPES } from '../../models/biohub-create';
 import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
 import { PlatformService } from '../../services/platform-service';
 import { getLogger } from '../../utils/logger';
@@ -43,8 +44,12 @@ POST.apiDoc = {
         schema: {
           type: 'object',
           additionalProperties: false,
-          required: ['surveyId', 'data'],
+          required: ['projectId', 'surveyId', 'data'],
           properties: {
+            projectId: {
+              type: 'integer',
+              minimum: 1
+            },
             surveyId: {
               type: 'integer',
               minimum: 1
@@ -74,6 +79,14 @@ POST.apiDoc = {
                   type: 'boolean',
                   enum: [true],
                   description: 'Publishing agreement 3. Agreement must be accepted.'
+                },
+                featureTypes: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    enum: [...PUBLISHABLE_FEATURE_TYPES]
+                  },
+                  description: 'Selected survey feature types to include in the BioHub submission package.'
                 }
               }
             }
@@ -128,7 +141,10 @@ export function publishSurvey(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
 
-    const { surveyId, data } = req.body;
+    const { surveyId, data } = req.body as {
+      surveyId: number;
+      data: { submissionComment: string; featureTypes?: BiohubFeatureType[] };
+    };
 
     try {
       await connection.open();

--- a/api/src/paths/publish/survey.ts
+++ b/api/src/paths/publish/survey.ts
@@ -2,9 +2,11 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { PROJECT_PERMISSION, SYSTEM_ROLE } from '../../constants/roles';
 import { getDBConnection } from '../../database/db';
+import { HTTP400 } from '../../errors/http-error';
 import { BiohubFeatureType, PUBLISHABLE_FEATURE_TYPES } from '../../models/biohub-create';
 import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
 import { PlatformService } from '../../services/platform-service';
+import { SurveyService } from '../../services/survey-service';
 import { getLogger } from '../../utils/logger';
 
 const defaultLog = getLogger('/api/publish/survey');
@@ -141,13 +143,21 @@ export function publishSurvey(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
 
-    const { surveyId, data } = req.body as {
+    const { projectId, surveyId, data } = req.body as {
+      projectId: number;
       surveyId: number;
       data: { submissionComment: string; featureTypes?: BiohubFeatureType[] };
     };
 
     try {
       await connection.open();
+
+      const surveyService = new SurveyService(connection);
+      const surveyData = await surveyService.getSurveyData(surveyId);
+
+      if (surveyData.project_id !== projectId) {
+        throw new HTTP400('Invalid project or survey identifier.');
+      }
 
       const platformService = new PlatformService(connection);
       const response = await platformService.submitSurveyToBioHub(surveyId, data);

--- a/api/src/repositories/attachment-repository.test.ts
+++ b/api/src/repositories/attachment-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ATTACHMENT_TYPE } from '../constants/attachments';
 import { PostReportAttachmentMetadata, PutReportAttachmentMetadata } from '../models/project-survey-attachments';
 import { AttachmentRepository } from '../repositories/attachment-repository';
 import { getMockDBConnection } from '../__mocks__/db';
@@ -547,6 +548,47 @@ describe('AttachmentRepository', () => {
           const response = await repository.getSurveyAttachmentsByIds(1, [1, 2]);
 
           expect(response).to.eql([{ id: 1 }, { id: 2 }]);
+        });
+      });
+
+      describe('getSurveyAttachmentsForBioHubSubmission', () => {
+        it('should filter to publishable attachment type', async () => {
+          let capturedSql: any;
+          const mockResponse = { rows: [{ id: 1 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+          const dbConnection = getMockDBConnection({
+            sql: (statement: any) => {
+              capturedSql = statement;
+              return mockResponse;
+            }
+          });
+
+          const repository = new AttachmentRepository(dbConnection);
+
+          await repository.getSurveyAttachmentsForBioHubSubmission(1);
+
+          expect(capturedSql.text).to.include('file_type');
+          expect(capturedSql.values).to.include(ATTACHMENT_TYPE.OTHER);
+        });
+      });
+
+      describe('getSurveyAttachmentsForBioHubSubmissionCount', () => {
+        it('should filter to publishable attachment type', async () => {
+          let capturedSql: any;
+          const mockResponse = { rows: [{ count: 3 }], rowCount: 1 } as any as Promise<QueryResult<any>>;
+          const dbConnection = getMockDBConnection({
+            sql: (statement: any) => {
+              capturedSql = statement;
+              return mockResponse;
+            }
+          });
+
+          const repository = new AttachmentRepository(dbConnection);
+
+          const response = await repository.getSurveyAttachmentsForBioHubSubmissionCount(1);
+
+          expect(response).to.equal(3);
+          expect(capturedSql.text).to.include('file_type');
+          expect(capturedSql.values).to.include(ATTACHMENT_TYPE.OTHER);
         });
       });
 

--- a/api/src/repositories/attachment-repository.ts
+++ b/api/src/repositories/attachment-repository.ts
@@ -1,6 +1,7 @@
 import { QueryResult } from 'pg';
 import SQL from 'sql-template-strings';
 import { z } from 'zod';
+import { ATTACHMENT_TYPE } from '../constants/attachments';
 import { getKnex } from '../database/db';
 import { ApiExecuteSQLError } from '../errors/api-error';
 import { PostReportAttachmentMetadata, PutReportAttachmentMetadata } from '../models/project-survey-attachments';
@@ -475,7 +476,9 @@ export class AttachmentRepository extends BaseRepository {
       FROM
         survey_attachment
       WHERE
-        survey_id = ${surveyId};
+        survey_id = ${surveyId}
+      AND
+        file_type = ${ATTACHMENT_TYPE.OTHER};
     `;
 
     const response = await this.connection.sql<ISurveyAttachment>(sqlStatement);
@@ -499,7 +502,9 @@ export class AttachmentRepository extends BaseRepository {
       FROM
         survey_attachment
       WHERE
-        survey_id = ${surveyId};
+        survey_id = ${surveyId}
+      AND
+        file_type = ${ATTACHMENT_TYPE.OTHER};
     `;
 
     const response = await this.connection.sql<{ count: number }>(sqlStatement);

--- a/api/src/repositories/attachment-repository.ts
+++ b/api/src/repositories/attachment-repository.ts
@@ -484,6 +484,30 @@ export class AttachmentRepository extends BaseRepository {
   }
 
   /**
+   * Get count of survey attachments that are publishable to BioHub.
+   *
+   * @param {number} surveyId
+   * @return {Promise<number>}
+   * @memberof AttachmentRepository
+   */
+  async getSurveyAttachmentsForBioHubSubmissionCount(surveyId: number): Promise<number> {
+    defaultLog.debug({ label: 'getSurveyAttachmentsForBioHubSubmissionCount' });
+
+    const sqlStatement = SQL`
+      SELECT
+        COUNT(*)::integer AS count
+      FROM
+        survey_attachment
+      WHERE
+        survey_id = ${surveyId};
+    `;
+
+    const response = await this.connection.sql<{ count: number }>(sqlStatement);
+
+    return response.rows[0]?.count ?? 0;
+  }
+
+  /**
    * Query to return all survey report attachments belonging to the given survey.
    * @param {number} surveyId the ID of the survey
    * @return {Promise<ISurveyReportAttachment[]>} Promise resolving all of the attachments for the

--- a/api/src/repositories/sample-period-repository.ts
+++ b/api/src/repositories/sample-period-repository.ts
@@ -117,7 +117,7 @@ export class SamplePeriodRepository extends BaseRepository {
     const queryBuilder = knex.queryBuilder();
 
     queryBuilder
-      .select('count(*)::integer as count')
+      .select(knex.raw('count(*)::integer as count'))
       .from('survey_sample_period')
       .leftJoin('method_technique', 'method_technique.method_technique_id', 'survey_sample_period.method_technique_id')
       .leftJoin(

--- a/api/src/services/attachment-service.test.ts
+++ b/api/src/services/attachment-service.test.ts
@@ -710,6 +710,39 @@ describe('AttachmentService', () => {
         });
       });
 
+      describe('getSurveyAttachmentsForBioHubSubmission', () => {
+        it('should return publishable survey attachments', async () => {
+          const dbConnection = getMockDBConnection();
+          const service = new AttachmentService(dbConnection);
+
+          const data = [{ id: 1 } as unknown as ISurveyAttachment];
+          const repoStub = sinon
+            .stub(AttachmentRepository.prototype, 'getSurveyAttachmentsForBioHubSubmission')
+            .resolves(data);
+
+          const response = await service.getSurveyAttachmentsForBioHubSubmission(1);
+
+          expect(repoStub).to.have.been.calledOnceWith(1);
+          expect(response).to.eql(data);
+        });
+      });
+
+      describe('getSurveyAttachmentsForBioHubSubmissionCount', () => {
+        it('should return publishable survey attachment count', async () => {
+          const dbConnection = getMockDBConnection();
+          const service = new AttachmentService(dbConnection);
+
+          const repoStub = sinon
+            .stub(AttachmentRepository.prototype, 'getSurveyAttachmentsForBioHubSubmissionCount')
+            .resolves(2);
+
+          const response = await service.getSurveyAttachmentsForBioHubSubmissionCount(1);
+
+          expect(repoStub).to.have.been.calledOnceWith(1);
+          expect(response).to.equal(2);
+        });
+      });
+
       describe('_deleteSurveyAttachmentRecord', () => {
         it('should return key string', async () => {
           const dbConnection = getMockDBConnection();

--- a/api/src/services/attachment-service.ts
+++ b/api/src/services/attachment-service.ts
@@ -230,6 +230,17 @@ export class AttachmentService extends DBService {
   }
 
   /**
+   * Get count of survey attachments publishable to BioHub.
+   *
+   * @param {number} surveyId
+   * @return {Promise<number>}
+   * @memberof AttachmentService
+   */
+  async getSurveyAttachmentsForBioHubSubmissionCount(surveyId: number): Promise<number> {
+    return this.attachmentRepository.getSurveyAttachmentsForBioHubSubmissionCount(surveyId);
+  }
+
+  /**
    * Finds all of the survey report attachments for the given survey ID.
    * @param {number} surveyId the ID of the survey
    * @return {Promise<ISurveyReportAttachment[]>} Promise resolving all survey report attachments.

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -175,12 +175,15 @@ describe('PlatformService', () => {
         await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
         expect.fail('Should have thrown an error');
       } catch (error) {
+        const noSurveyAttachments: unknown[] = [];
+        const noReportAttachments: unknown[] = [];
+
         expect((error as Error).message).to.include('Failed to initiate submission upload to BioHub');
         expect(getKeycloakServiceTokenStub).to.have.been.calledOnce;
         expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(
           1,
-          [],
-          [],
+          noSurveyAttachments,
+          noReportAttachments,
           'test',
           sinon.match((value) => value instanceof Set)
         );
@@ -247,11 +250,14 @@ describe('PlatformService', () => {
 
       const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
 
+      const noSurveyAttachments: unknown[] = [];
+      const noReportAttachments: unknown[] = [];
+
       expect(getKeycloakServiceTokenStub).to.have.been.calledOnce;
       expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(
         1,
-        [],
-        [],
+        noSurveyAttachments,
+        noReportAttachments,
         'test',
         sinon.match((value) => value instanceof Set)
       );

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -6,6 +6,7 @@ import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ApiError, ApiErrorType } from '../errors/api-error';
+import { BiohubFeatureType } from '../models/biohub-create';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
 import * as envConfig from '../utils/env-config';
 import * as featureFlagUtils from '../utils/feature-flag-utils';
@@ -25,6 +26,7 @@ import { SurveyCritterService } from './survey-critter-service';
 import { SurveyService } from './survey-service';
 import { TelemetryDeploymentService } from './telemetry-services/telemetry-deployment-service';
 import { TelemetryDeviceService } from './telemetry-services/telemetry-device-service';
+import { TelemetryVendorService } from './telemetry-services/telemetry-vendor-service';
 
 chai.use(sinonChai);
 
@@ -175,7 +177,13 @@ describe('PlatformService', () => {
       } catch (error) {
         expect((error as Error).message).to.include('Failed to initiate submission upload to BioHub');
         expect(getKeycloakServiceTokenStub).to.have.been.calledOnce;
-        expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(1, [], [], 'test');
+        expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(
+          1,
+          [],
+          [],
+          'test',
+          sinon.match((value) => value instanceof Set)
+        );
         expect(_initiateSubmissionUploadStub).to.have.been.calledOnce;
       }
     });
@@ -240,7 +248,13 @@ describe('PlatformService', () => {
       const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
 
       expect(getKeycloakServiceTokenStub).to.have.been.calledOnce;
-      expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(1, [], [], 'test');
+      expect(_generateSurveyDataPackageStub).to.have.been.calledOnceWith(
+        1,
+        [],
+        [],
+        'test',
+        sinon.match((value) => value instanceof Set)
+      );
       expect(_initiateSubmissionUploadStub).to.have.been.calledOnce;
       expect(_uploadTarFilePartsStub).to.have.been.calledOnce;
       expect(_completeSubmissionUploadStub).to.have.been.calledOnceWith(
@@ -318,6 +332,33 @@ describe('PlatformService', () => {
         submission_uuid: existingSubmissionUuid
       });
       expect(response).to.eql({ submission_uuid: existingSubmissionUuid });
+    });
+  });
+
+  describe('getSurveyPublishableFeatures', () => {
+    it('includes parent feature types when only child data exists', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const platformService = new PlatformService(mockDBConnection);
+
+      sinon.stub(SampleSiteService.prototype, 'getSampleSitesCountBySurveyId').resolves(0);
+      sinon.stub(SamplePeriodService.prototype, 'getSamplePeriodsCountForSurvey').resolves(1);
+      sinon.stub(SampleTechniqueService.prototype, 'getSamplingTechniquesCountForSurvey').resolves(0);
+      sinon.stub(ObservationService.prototype, 'getSurveyObservationsCount').resolves(0);
+      sinon.stub(SurveyHabitatFeatureService.prototype, 'getSurveyHabitatFeaturesCount').resolves(0);
+      sinon.stub(TelemetryDeviceService.prototype, 'getDevicesCount').resolves(0);
+      sinon.stub(TelemetryDeploymentService.prototype, 'getDeploymentsCount').resolves(1);
+      sinon.stub(AttachmentService.prototype, 'getSurveyAttachmentsForBioHubSubmissionCount').resolves(0);
+      sinon
+        .stub(TelemetryVendorService.prototype, 'getTelemetryForSurvey')
+        .resolves([[], { count: 1, start_date: null, end_date: null }]);
+
+      const response = await platformService.getSurveyPublishableFeatures(1);
+
+      expect(response.featureTypes).to.include(BiohubFeatureType.SAMPLE_PERIOD);
+      expect(response.featureTypes).to.include(BiohubFeatureType.SAMPLE_SITE);
+      expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY);
+      expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY_DEPLOYMENT);
+      expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY_DEVICE);
     });
   });
 

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -348,6 +348,14 @@ describe('PlatformService', () => {
       sinon.stub(TelemetryDeviceService.prototype, 'getDevicesCount').resolves(0);
       sinon.stub(TelemetryDeploymentService.prototype, 'getDeploymentsCount').resolves(1);
       sinon.stub(AttachmentService.prototype, 'getSurveyAttachmentsForBioHubSubmissionCount').resolves(0);
+      sinon.stub(SurveyService.prototype, 'getSurveyLocationsData').resolves([]);
+      sinon.stub(AttachmentService.prototype, 'getSurveyReportAttachments').resolves([]);
+      sinon.stub(SurveyCritterService.prototype, 'getCritterbaseSurveyCritters').resolves([]);
+      sinon.stub(SampleSiteService.prototype, 'getSampleSitesForSurveyId').resolves([]);
+      sinon.stub(SiteSelectionStrategyService.prototype, 'getSiteSelectionDataForBioHubSubmission').resolves({
+        stratums: [],
+        strategies: []
+      });
       sinon
         .stub(TelemetryVendorService.prototype, 'getTelemetryForSurvey')
         .resolves([[], { count: 1, start_date: null, end_date: null }]);
@@ -359,6 +367,7 @@ describe('PlatformService', () => {
       expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY);
       expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY_DEPLOYMENT);
       expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY_DEVICE);
+      expect(response.featureTypes).to.include(BiohubFeatureType.TELEMETRY_FREQUENCY);
     });
   });
 

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -511,6 +511,41 @@ describe('PlatformService', () => {
       expect(response.content).to.have.property('type', 'dataset');
       expect(response.content.properties).to.have.property('survey_id', 1);
     });
+
+    it('loads animal records when telemetry deployments are selected without animal feature type', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const platformService = new PlatformService(mockDBConnection);
+
+      sinon.stub(SurveyService.prototype, 'getSurveyData').resolves({ id: 1, uuid: '1', survey_types: [] } as any);
+      sinon
+        .stub(SurveyService.prototype, 'getSurveyPurposeAndMethodology')
+        .resolves({ additional_details: 'a description of the purpose' } as any);
+      sinon.stub(SurveyService.prototype, 'getSurveyPartnershipsData').resolves({
+        indigenous_partnerships: [],
+        stakeholder_partnerships: []
+      });
+      sinon.stub(SurveyService.prototype, 'getSpeciesData').resolves({ focal_species: [] } as any);
+      sinon.stub(CodeService.prototype, 'getAllCodeSets').resolves({} as any);
+      sinon.stub(CodeService.prototype, 'getAllCodesetCategories').resolves([]);
+      sinon
+        .stub(SiteSelectionStrategyService.prototype, 'getSiteSelectionDataForBioHubSubmission')
+        .resolves({ strategies: [], stratums: [] });
+      sinon.stub(TelemetryDeploymentService.prototype, 'getDeploymentsForSurvey').resolves([]);
+
+      const getCritterbaseSurveyCrittersStub = sinon
+        .stub(SurveyCritterService.prototype, 'getCritterbaseSurveyCritters')
+        .resolves([]);
+
+      await platformService._generateSurveyDataPackage(
+        1,
+        [],
+        [],
+        'a comment about the submission',
+        new Set([BiohubFeatureType.TELEMETRY_DEPLOYMENT])
+      );
+
+      expect(getCritterbaseSurveyCrittersStub).to.have.been.calledOnceWith(1);
+    });
   });
 
   describe('_flattenToBlockModel', () => {

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -153,6 +153,8 @@ export class PlatformService extends DBService {
     const sampleSiteService = new SampleSiteService(this.connection);
     const samplePeriodService = new SamplePeriodService(this.connection);
     const sampleTechniqueService = new SampleTechniqueService(this.connection);
+    const surveyService = new SurveyService(this.connection);
+    const surveyCritterService = new SurveyCritterService(this.connection);
     const habitatFeatureService = new SurveyHabitatFeatureService(this.connection);
     const telemetryDeviceService = new TelemetryDeviceService(this.connection);
     const telemetryDeploymentService = new TelemetryDeploymentService(this.connection);
@@ -166,7 +168,12 @@ export class PlatformService extends DBService {
       habitatFeatureCount,
       telemetryDeviceCount,
       telemetryDeploymentCount,
-      surveyAttachmentCount
+      surveyAttachmentCount,
+      surveyLocations,
+      surveyReportAttachments,
+      surveyAnimals,
+      sampleSitesForBlocks,
+      siteSelectionData
     ] = await Promise.all([
       sampleSiteService.getSampleSitesCountBySurveyId(surveyId),
       samplePeriodService.getSamplePeriodsCountForSurvey(surveyId),
@@ -175,7 +182,12 @@ export class PlatformService extends DBService {
       habitatFeatureService.getSurveyHabitatFeaturesCount(surveyId),
       telemetryDeviceService.getDevicesCount(surveyId),
       telemetryDeploymentService.getDeploymentsCount(surveyId),
-      this.attachmentService.getSurveyAttachmentsForBioHubSubmissionCount(surveyId)
+      this.attachmentService.getSurveyAttachmentsForBioHubSubmissionCount(surveyId),
+      surveyService.getSurveyLocationsData(surveyId),
+      this.attachmentService.getSurveyReportAttachments(surveyId),
+      surveyCritterService.getCritterbaseSurveyCritters(surveyId),
+      sampleSiteService.getSampleSitesForSurveyId(surveyId, {}),
+      surveyService.siteSelectionStrategyService.getSiteSelectionDataForBioHubSubmission(surveyId)
     ]);
 
     let telemetryCount = 0;
@@ -226,6 +238,40 @@ export class PlatformService extends DBService {
 
     if (surveyAttachmentCount > 0) {
       featureTypes.add(BiohubFeatureType.FILE);
+    }
+
+    if (surveyLocations.length > 0) {
+      featureTypes.add(BiohubFeatureType.STUDY_AREA);
+    }
+
+    if (surveyReportAttachments.length > 0) {
+      featureTypes.add(BiohubFeatureType.REPORT);
+    }
+
+    if (siteSelectionData.stratums.length > 0) {
+      featureTypes.add(BiohubFeatureType.STRATUM);
+    }
+
+    if (
+      sampleSitesForBlocks.some(
+        (sampleSite: { blocks?: unknown[] }) => Array.isArray(sampleSite.blocks) && sampleSite.blocks.length > 0
+      )
+    ) {
+      featureTypes.add(BiohubFeatureType.BLOCK);
+    }
+
+    if (surveyAnimals.length > 0) {
+      featureTypes.add(BiohubFeatureType.ANIMAL);
+      featureTypes.add(BiohubFeatureType.CAPTURE);
+      featureTypes.add(BiohubFeatureType.MORTALITY);
+      featureTypes.add(BiohubFeatureType.ECOLOGICAL_UNIT);
+      featureTypes.add(BiohubFeatureType.MARKING);
+      featureTypes.add(BiohubFeatureType.MEASUREMENT);
+      featureTypes.add(BiohubFeatureType.RELEASE);
+    }
+
+    if (telemetryDeploymentCount > 0) {
+      featureTypes.add(BiohubFeatureType.TELEMETRY_FREQUENCY);
     }
 
     return { featureTypes: [...this.normalizePublishFeatureTypes([...featureTypes])] };
@@ -353,7 +399,9 @@ export class PlatformService extends DBService {
       : [];
 
     // Get survey report attachments
-    const surveyReportAttachments = await this.attachmentService.getSurveyReportAttachments(surveyId);
+    const surveyReportAttachments = includeFeatureTypes.has(BiohubFeatureType.REPORT)
+      ? await this.attachmentService.getSurveyReportAttachments(surveyId)
+      : [];
 
     // Generate survey data package
     const surveyDataPackage = await this._generateSurveyDataPackage(
@@ -510,7 +558,10 @@ export class PlatformService extends DBService {
         };
     const surveyObservations = observationData.surveyObservations;
     const purposeAndMethodology = await surveyService.getSurveyPurposeAndMethodology(surveyId);
-    const surveyLocation = await surveyService.getSurveyLocationsData(surveyId);
+    const surveyLocation =
+      (includeFeatureTypes?.has(BiohubFeatureType.STUDY_AREA) ?? true)
+        ? await surveyService.getSurveyLocationsData(surveyId)
+        : [];
 
     // Get partnerships and focal species data for BioHub submission
     const partnerships = await surveyService.getSurveyPartnershipsData(surveyId);
@@ -591,7 +642,10 @@ export class PlatformService extends DBService {
     const codesetCategories = await codeService.getAllCodesetCategories();
 
     // Get survey animals from Critterbase (via SIMS survey-critter associations)
-    const surveyAnimals = await surveyCritterService.getCritterbaseSurveyCritters(surveyId);
+    const surveyAnimals =
+      (includeFeatureTypes?.has(BiohubFeatureType.ANIMAL) ?? true)
+        ? await surveyCritterService.getCritterbaseSurveyCritters(surveyId)
+        : [];
 
     // Enrich mortality data with detailed information
     const enrichedSurveyAnimals: ICritterDetailed[] = await Promise.all(
@@ -653,7 +707,7 @@ export class PlatformService extends DBService {
         focalSpecies,
         surveyLocation,
         firstNations: allCodes.first_nations,
-        strata: siteSelectionData.stratums,
+        strata: (includeFeatureTypes?.has(BiohubFeatureType.STRATUM) ?? true) ? siteSelectionData.stratums : [],
         siteSelectionStrategies: siteSelectionData.strategies,
         codesetCategories,
         includeFeatureTypes

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -714,10 +714,10 @@ export class PlatformService extends DBService {
     const codesetCategories = await codeService.getAllCodesetCategories();
 
     // Get survey animals from Critterbase (via SIMS survey-critter associations)
-    const surveyAnimals =
-      (includeFeatureTypes?.has(BiohubFeatureType.ANIMAL) ?? true)
-        ? await surveyCritterService.getCritterbaseSurveyCritters(surveyId)
-        : [];
+    const shouldIncludeAnimals =
+      (includeFeatureTypes?.has(BiohubFeatureType.ANIMAL) ?? true) ||
+      includeFeatureTypes?.has(BiohubFeatureType.TELEMETRY_DEPLOYMENT) === true;
+    const surveyAnimals = shouldIncludeAnimals ? await surveyCritterService.getCritterbaseSurveyCritters(surveyId) : [];
 
     // Enrich mortality data with detailed information
     const enrichedSurveyAnimals: ICritterDetailed[] = await Promise.all(

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -202,6 +202,81 @@ export class PlatformService extends DBService {
       telemetryCount = surveyTelemetry[1].count;
     }
 
+    const featureTypes = this._collectPublishableFeatureTypes({
+      sampleSiteCount,
+      samplePeriodCount,
+      sampleTechniqueCount,
+      observationCount,
+      habitatFeatureCount,
+      telemetryDeviceCount,
+      telemetryDeploymentCount,
+      telemetryCount,
+      surveyAttachmentCount,
+      surveyLocations,
+      surveyReportAttachments,
+      surveyAnimals,
+      sampleSitesForBlocks,
+      siteSelectionData
+    });
+
+    return { featureTypes: [...this.normalizePublishFeatureTypes([...featureTypes])] };
+  }
+
+  /**
+   * Collect publishable feature types from survey data presence signals.
+   *
+   * @param {{
+   *     sampleSiteCount: number;
+   *     samplePeriodCount: number;
+   *     sampleTechniqueCount: number;
+   *     observationCount: number;
+   *     habitatFeatureCount: number;
+   *     telemetryDeviceCount: number;
+   *     telemetryDeploymentCount: number;
+   *     telemetryCount: number;
+   *     surveyAttachmentCount: number;
+   *     surveyLocations: unknown[];
+   *     surveyReportAttachments: ISurveyReportAttachment[];
+   *     surveyAnimals: ICritterDetailed[];
+   *     sampleSitesForBlocks: { blocks?: unknown[] }[];
+   *     siteSelectionData: { stratums: { name: string; description: string }[] };
+   *   }} params
+   * @return {Set<BiohubFeatureType>}
+   * @memberof PlatformService
+   */
+  private _collectPublishableFeatureTypes(params: {
+    sampleSiteCount: number;
+    samplePeriodCount: number;
+    sampleTechniqueCount: number;
+    observationCount: number;
+    habitatFeatureCount: number;
+    telemetryDeviceCount: number;
+    telemetryDeploymentCount: number;
+    telemetryCount: number;
+    surveyAttachmentCount: number;
+    surveyLocations: unknown[];
+    surveyReportAttachments: ISurveyReportAttachment[];
+    surveyAnimals: ICritterDetailed[];
+    sampleSitesForBlocks: { blocks?: unknown[] }[];
+    siteSelectionData: { stratums: { name: string; description: string }[] };
+  }): Set<BiohubFeatureType> {
+    const {
+      sampleSiteCount,
+      samplePeriodCount,
+      sampleTechniqueCount,
+      observationCount,
+      habitatFeatureCount,
+      telemetryDeviceCount,
+      telemetryDeploymentCount,
+      telemetryCount,
+      surveyAttachmentCount,
+      surveyLocations,
+      surveyReportAttachments,
+      surveyAnimals,
+      sampleSitesForBlocks,
+      siteSelectionData
+    } = params;
+
     const featureTypes = new Set<BiohubFeatureType>();
 
     if (sampleSiteCount > 0) {
@@ -230,6 +305,7 @@ export class PlatformService extends DBService {
 
     if (telemetryDeploymentCount > 0) {
       featureTypes.add(BiohubFeatureType.TELEMETRY_DEPLOYMENT);
+      featureTypes.add(BiohubFeatureType.TELEMETRY_FREQUENCY);
     }
 
     if (telemetryCount > 0) {
@@ -270,11 +346,7 @@ export class PlatformService extends DBService {
       featureTypes.add(BiohubFeatureType.RELEASE);
     }
 
-    if (telemetryDeploymentCount > 0) {
-      featureTypes.add(BiohubFeatureType.TELEMETRY_FREQUENCY);
-    }
-
-    return { featureTypes: [...this.normalizePublishFeatureTypes([...featureTypes])] };
+    return featureTypes;
   }
 
   /**

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -487,7 +487,7 @@ export class PlatformService extends DBService {
     } finally {
       // Clean up TAR file
       try {
-        fs.unlinkSync(tarFilePath);
+        //fs.unlinkSync(tarFilePath);
         defaultLog.info({
           label: 'submitSurveyToBioHub',
           message: 'TAR file cleaned up',

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -487,7 +487,7 @@ export class PlatformService extends DBService {
     } finally {
       // Clean up TAR file
       try {
-        //fs.unlinkSync(tarFilePath);
+        fs.unlinkSync(tarFilePath);
         defaultLog.info({
           label: 'submitSurveyToBioHub',
           message: 'TAR file cleaned up',

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -8,7 +8,12 @@ import { URL } from 'url';
 import { IDBConnection } from '../database/db';
 import { ApiError, ApiErrorType, ApiGeneralError } from '../errors/api-error';
 import { formatAxiosError } from '../errors/axios-error';
-import { PostSurveySubmissionToBioHubObject } from '../models/biohub-create';
+import {
+  BiohubFeatureType,
+  PostSurveySubmissionToBioHubObject,
+  PUBLISHABLE_FEATURE_TYPES,
+  PUBLISHABLE_FEATURE_TYPE_PARENTS
+} from '../models/biohub-create';
 import { ISurveyAttachment, ISurveyReportAttachment } from '../repositories/attachment-repository';
 import { getEnvironmentVariable } from '../utils/env-config';
 import { isFeatureFlagPresent } from '../utils/feature-flag-utils';
@@ -62,6 +67,11 @@ export interface ITaxonomyWithEcologicalUnits extends ITaxonomy {
   ecological_units: IPostCollectionUnit[];
 }
 
+export type PublishSurveyData = {
+  submissionComment: string;
+  featureTypes?: BiohubFeatureType[];
+};
+
 interface IFlattenedBlock {
   id: string;
   type: string;
@@ -97,6 +107,128 @@ export class PlatformService extends DBService {
 
     this.historyPublishService = new HistoryPublishService(this.connection);
     this.attachmentService = new AttachmentService(connection);
+  }
+
+  /**
+   * Normalize selected feature types by expanding parent dependencies.
+   *
+   * @param {(BiohubFeatureType[] | undefined)} featureTypes
+   * @return {Set<BiohubFeatureType>}
+   * @memberof PlatformService
+   */
+  normalizePublishFeatureTypes(featureTypes?: BiohubFeatureType[]): Set<BiohubFeatureType> {
+    const seedFeatureTypes = featureTypes?.length ? featureTypes : [...PUBLISHABLE_FEATURE_TYPES];
+    const allowedFeatureTypes = new Set<BiohubFeatureType>(PUBLISHABLE_FEATURE_TYPES);
+    const normalizedFeatureTypes = new Set<BiohubFeatureType>(
+      seedFeatureTypes.filter((featureType): featureType is BiohubFeatureType => allowedFeatureTypes.has(featureType))
+    );
+
+    const addParents = (featureType: BiohubFeatureType) => {
+      const parentFeatureTypes = PUBLISHABLE_FEATURE_TYPE_PARENTS[featureType] || [];
+
+      parentFeatureTypes.forEach((parentFeatureType) => {
+        if (!normalizedFeatureTypes.has(parentFeatureType)) {
+          normalizedFeatureTypes.add(parentFeatureType);
+          addParents(parentFeatureType);
+        }
+      });
+    };
+
+    [...normalizedFeatureTypes].forEach((featureType) => addParents(featureType));
+
+    return normalizedFeatureTypes;
+  }
+
+  /**
+   * Get publishable survey feature types that exist for the survey.
+   *
+   * If a child feature exists, its parent feature type is automatically included.
+   *
+   * @param {number} surveyId
+   * @return {Promise<{ featureTypes: BiohubFeatureType[] }>}
+   * @memberof PlatformService
+   */
+  async getSurveyPublishableFeatures(surveyId: number): Promise<{ featureTypes: BiohubFeatureType[] }> {
+    const observationService = new ObservationService(this.connection);
+    const sampleSiteService = new SampleSiteService(this.connection);
+    const samplePeriodService = new SamplePeriodService(this.connection);
+    const sampleTechniqueService = new SampleTechniqueService(this.connection);
+    const habitatFeatureService = new SurveyHabitatFeatureService(this.connection);
+    const telemetryDeviceService = new TelemetryDeviceService(this.connection);
+    const telemetryDeploymentService = new TelemetryDeploymentService(this.connection);
+    const telemetryVendorService = new TelemetryVendorService(this.connection);
+
+    const [
+      sampleSiteCount,
+      samplePeriodCount,
+      sampleTechniqueCount,
+      observationCount,
+      habitatFeatureCount,
+      telemetryDeviceCount,
+      telemetryDeploymentCount,
+      surveyAttachmentCount
+    ] = await Promise.all([
+      sampleSiteService.getSampleSitesCountBySurveyId(surveyId),
+      samplePeriodService.getSamplePeriodsCountForSurvey(surveyId),
+      sampleTechniqueService.getSamplingTechniquesCountForSurvey(surveyId),
+      observationService.getSurveyObservationsCount(surveyId),
+      habitatFeatureService.getSurveyHabitatFeaturesCount(surveyId),
+      telemetryDeviceService.getDevicesCount(surveyId),
+      telemetryDeploymentService.getDeploymentsCount(surveyId),
+      this.attachmentService.getSurveyAttachmentsForBioHubSubmissionCount(surveyId)
+    ]);
+
+    let telemetryCount = 0;
+    if (telemetryDeploymentCount > 0) {
+      const surveyTelemetry = await telemetryVendorService.getTelemetryForSurvey(surveyId, {
+        pagination: {
+          page: 1,
+          limit: 1
+        }
+      });
+
+      telemetryCount = surveyTelemetry[1].count;
+    }
+
+    const featureTypes = new Set<BiohubFeatureType>();
+
+    if (sampleSiteCount > 0) {
+      featureTypes.add(BiohubFeatureType.SAMPLE_SITE);
+    }
+
+    if (samplePeriodCount > 0) {
+      featureTypes.add(BiohubFeatureType.SAMPLE_PERIOD);
+    }
+
+    if (sampleTechniqueCount > 0) {
+      featureTypes.add(BiohubFeatureType.SAMPLE_TECHNIQUE);
+    }
+
+    if (observationCount > 0) {
+      featureTypes.add(BiohubFeatureType.OBSERVATION);
+    }
+
+    if (habitatFeatureCount > 0) {
+      featureTypes.add(BiohubFeatureType.HABITAT_FEATURE);
+    }
+
+    if (telemetryDeviceCount > 0) {
+      featureTypes.add(BiohubFeatureType.TELEMETRY_DEVICE);
+    }
+
+    if (telemetryDeploymentCount > 0) {
+      featureTypes.add(BiohubFeatureType.TELEMETRY_DEPLOYMENT);
+    }
+
+    if (telemetryCount > 0) {
+      featureTypes.add(BiohubFeatureType.TELEMETRY);
+    }
+
+    if (surveyAttachmentCount > 0) {
+      featureTypes.add(BiohubFeatureType.FILE);
+    }
+
+    return { featureTypes: [...this.normalizePublishFeatureTypes([...featureTypes])] };
   }
 
   /**
@@ -198,10 +330,9 @@ export class PlatformService extends DBService {
    * @return {*}  {Promise<{ submission_uuid: string }>}
    * @memberof PlatformService
    */
-  async submitSurveyToBioHub(
-    surveyId: number,
-    data: { submissionComment: string }
-  ): Promise<{ submission_uuid: string }> {
+  async submitSurveyToBioHub(surveyId: number, data: PublishSurveyData): Promise<{ submission_uuid: string }> {
+    const includeFeatureTypes = this.normalizePublishFeatureTypes(data.featureTypes);
+
     defaultLog.debug({ label: 'submitSurveyToBioHub', message: 'params', surveyId });
 
     if (isFeatureFlagPresent(['API_FF_SUBMIT_BIOHUB'])) {
@@ -217,7 +348,9 @@ export class PlatformService extends DBService {
     const token = await keycloakService.getKeycloakServiceToken();
 
     // Get survey attachments
-    const surveyAttachments = await this.attachmentService.getSurveyAttachmentsForBioHubSubmission(surveyId);
+    const surveyAttachments = includeFeatureTypes.has(BiohubFeatureType.FILE)
+      ? await this.attachmentService.getSurveyAttachmentsForBioHubSubmission(surveyId)
+      : [];
 
     // Get survey report attachments
     const surveyReportAttachments = await this.attachmentService.getSurveyReportAttachments(surveyId);
@@ -227,7 +360,8 @@ export class PlatformService extends DBService {
       surveyId,
       surveyAttachments,
       surveyReportAttachments,
-      data.submissionComment
+      data.submissionComment,
+      includeFeatureTypes
     );
 
     // Flatten and save the survey data package grouped by type
@@ -344,7 +478,8 @@ export class PlatformService extends DBService {
     surveyId: number,
     surveyAttachments: ISurveyAttachment[],
     surveyReportAttachments: ISurveyReportAttachment[],
-    submissionComment: string
+    submissionComment: string,
+    includeFeatureTypes?: Set<BiohubFeatureType>
   ): Promise<PostSurveySubmissionToBioHubObject> {
     const observationService = new ObservationService(this.connection);
     const surveyService = new SurveyService(this.connection);
@@ -361,9 +496,18 @@ export class PlatformService extends DBService {
     // Get survey data
     const survey = await surveyService.getSurveyData(surveyId);
 
-    // Get all survey observations with environmental data
-    const observationData =
-      await observationService.getSurveyObservationsWithSupplementaryAndSamplingDataAndAttributeData(surveyId);
+    const shouldIncludeObservations = includeFeatureTypes?.has(BiohubFeatureType.OBSERVATION) ?? true;
+    const observationData = shouldIncludeObservations
+      ? await observationService.getSurveyObservationsWithSupplementaryAndSamplingDataAndAttributeData(surveyId)
+      : {
+          surveyObservations: [],
+          supplementaryObservationData: {
+            qualitative_environments: [],
+            quantitative_environments: [],
+            qualitative_measurements: [],
+            quantitative_measurements: []
+          }
+        };
     const surveyObservations = observationData.surveyObservations;
     const purposeAndMethodology = await surveyService.getSurveyPurposeAndMethodology(surveyId);
     const surveyLocation = await surveyService.getSurveyLocationsData(surveyId);
@@ -392,10 +536,22 @@ export class PlatformService extends DBService {
     };
 
     // Get sampling sites and periods data for survey
-    const surveySamplingSitesNonSpatial = await sampleSiteService.getSampleSitesForSurveyId(surveyId, {});
-    const surveySamplingSitesGeometry = await sampleSiteService.getSampleSitesGeometryBySurveyId(surveyId);
-    const surveySamplingPeriods = await samplePeriodService.getSamplePeriodsForSurvey(surveyId, {});
-    const surveySamplingTechniques = await sampleTechniqueService.getSamplingTechniquesForSurvey(surveyId);
+    const surveySamplingSitesNonSpatial =
+      (includeFeatureTypes?.has(BiohubFeatureType.SAMPLE_SITE) ?? true)
+        ? await sampleSiteService.getSampleSitesForSurveyId(surveyId, {})
+        : [];
+    const surveySamplingSitesGeometry =
+      (includeFeatureTypes?.has(BiohubFeatureType.SAMPLE_SITE) ?? true)
+        ? await sampleSiteService.getSampleSitesGeometryBySurveyId(surveyId)
+        : [];
+    const surveySamplingPeriods =
+      (includeFeatureTypes?.has(BiohubFeatureType.SAMPLE_PERIOD) ?? true)
+        ? await samplePeriodService.getSamplePeriodsForSurvey(surveyId, {})
+        : [];
+    const surveySamplingTechniques =
+      (includeFeatureTypes?.has(BiohubFeatureType.SAMPLE_TECHNIQUE) ?? true)
+        ? await sampleTechniqueService.getSamplingTechniquesForSurvey(surveyId)
+        : [];
 
     // Merge sampling sites with their geometry data
     const surveysamplingSites = surveySamplingSitesNonSpatial.map((site) => {
@@ -409,16 +565,27 @@ export class PlatformService extends DBService {
     });
 
     // Get habitat features data for survey
-    const surveyHabitatFeatures = await habitatFeatureService.getSurveyHabitatFeatures(surveyId);
+    const surveyHabitatFeatures =
+      (includeFeatureTypes?.has(BiohubFeatureType.HABITAT_FEATURE) ?? true)
+        ? await habitatFeatureService.getSurveyHabitatFeatures(surveyId)
+        : [];
 
     // Get telemetry data for survey
-    const surveyTelemetryDevices = await telemetryDeviceService.getDevicesForSurvey(surveyId);
-    const surveyTelemetryDeployments = await telemetryDeploymentService.getDeploymentsForSurvey(surveyId);
+    const surveyTelemetryDevices =
+      (includeFeatureTypes?.has(BiohubFeatureType.TELEMETRY_DEVICE) ?? true)
+        ? await telemetryDeviceService.getDevicesForSurvey(surveyId)
+        : [];
+    const surveyTelemetryDeployments =
+      (includeFeatureTypes?.has(BiohubFeatureType.TELEMETRY_DEPLOYMENT) ?? true)
+        ? await telemetryDeploymentService.getDeploymentsForSurvey(surveyId)
+        : [];
 
     // Get telemetry data points for deployments
     const deploymentIds = surveyTelemetryDeployments.map((deployment) => deployment.deployment_id);
     const surveyTelemetry =
-      deploymentIds.length > 0 ? await telemetryVendorService.getTelemetryForDeployments(surveyId, deploymentIds) : [];
+      (includeFeatureTypes?.has(BiohubFeatureType.TELEMETRY) ?? true) && deploymentIds.length > 0
+        ? await telemetryVendorService.getTelemetryForDeployments(surveyId, deploymentIds)
+        : [];
 
     // Get all codeset categories for BioHub submission
     const codesetCategories = await codeService.getAllCodesetCategories();
@@ -488,7 +655,8 @@ export class PlatformService extends DBService {
         firstNations: allCodes.first_nations,
         strata: siteSelectionData.stratums,
         siteSelectionStrategies: siteSelectionData.strategies,
-        codesetCategories
+        codesetCategories,
+        includeFeatureTypes
       }
     );
 

--- a/api/src/services/sample-technique-service.ts
+++ b/api/src/services/sample-technique-service.ts
@@ -1,5 +1,6 @@
 import { IDBConnection } from '../database/db';
 import { SurveyRepository } from '../repositories/survey-repository';
+import { TechniqueRepository } from '../repositories/technique-repository';
 import { getLogger } from '../utils/logger';
 
 const defaultLog = getLogger('services/sample-technique-service');
@@ -32,9 +33,11 @@ export interface SampleTechniqueRecord {
 
 export class SampleTechniqueService {
   connection: IDBConnection;
+  techniqueRepository: TechniqueRepository;
 
   constructor(connection: IDBConnection) {
     this.connection = connection;
+    this.techniqueRepository = new TechniqueRepository(connection);
   }
 
   /**
@@ -80,5 +83,16 @@ export class SampleTechniqueService {
         vantage_id: vantage.vantage_id || null
       }))
     }));
+  }
+
+  /**
+   * Get sampling techniques count for a survey.
+   *
+   * @param {number} surveyId
+   * @return {Promise<number>}
+   * @memberof SampleTechniqueService
+   */
+  async getSamplingTechniquesCountForSurvey(surveyId: number): Promise<number> {
+    return this.techniqueRepository.getTechniquesCountForSurveyId(surveyId);
   }
 }

--- a/app/src/components/publish/PublishSurveyDialog.tsx
+++ b/app/src/components/publish/PublishSurveyDialog.tsx
@@ -18,7 +18,7 @@ import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import yup from 'utils/YupSchema';
-import PublishSurveyIdContent from './components/PublishSurveyContent';
+import PublishSurveyContent from './components/PublishSurveyContent';
 import { PublishFeatureType } from './publishFeatureTypes';
 
 export interface ISubmitSurvey {
@@ -101,14 +101,6 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
   }, [publishFeaturesDataLoader.data]);
 
   const handleSubmit = async (values: ISubmitSurvey) => {
-    if (values === surveySubmitFormInitialValues) {
-      showErrorDialog({
-        dialogTitle: SubmitBiohubI18N.noInformationDialogTitle,
-        dialogText: SubmitBiohubI18N.noInformationDialogText
-      });
-      return;
-    }
-
     setIsSubmitting(true);
 
     return biohubApi.publish
@@ -166,7 +158,7 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
                 {SubmitSurveyBiohubI18N.submitSurveyBiohubDialogTitle}
               </DialogTitle>
               <DialogContent>
-                <PublishSurveyIdContent
+                <PublishSurveyContent
                   availableFeatureTypes={(publishFeaturesDataLoader.data?.featureTypes as PublishFeatureType[]) || []}
                 />
               </DialogContent>

--- a/app/src/components/publish/PublishSurveyDialog.tsx
+++ b/app/src/components/publish/PublishSurveyDialog.tsx
@@ -15,15 +15,18 @@ import { DialogContext } from 'contexts/dialogContext';
 import { SurveyContext } from 'contexts/surveyContext';
 import { Formik, FormikProps } from 'formik';
 import { useBiohubApi } from 'hooks/useBioHubApi';
-import { useContext, useRef, useState } from 'react';
+import useDataLoader from 'hooks/useDataLoader';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import yup from 'utils/YupSchema';
 import PublishSurveyIdContent from './components/PublishSurveyContent';
+import { PublishFeatureType } from './publishFeatureTypes';
 
 export interface ISubmitSurvey {
   submissionComment: string;
   agreement1: boolean;
   agreement2: boolean;
   agreement3: boolean;
+  featureTypes: PublishFeatureType[];
 }
 
 interface IPublishSurveyIdDialogProps {
@@ -35,14 +38,16 @@ const surveySubmitFormInitialValues: ISubmitSurvey = {
   submissionComment: '',
   agreement1: false,
   agreement2: false,
-  agreement3: false
+  agreement3: false,
+  featureTypes: []
 };
 
 const surveySubmitFormYupSchema = yup.object().shape({
   submissionComment: yup.string(),
   agreement1: yup.boolean().oneOf([true], 'You must accept all agreements.'),
   agreement2: yup.boolean().oneOf([true], 'You must accept all agreements.'),
-  agreement3: yup.boolean().oneOf([true], 'You must accept all agreements.')
+  agreement3: yup.boolean().oneOf([true], 'You must accept all agreements.'),
+  featureTypes: yup.array(yup.string()).min(1, 'Select at least one feature type.')
 });
 
 /**
@@ -76,6 +81,24 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
   const formikRef = useRef<FormikProps<ISubmitSurvey>>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+  const publishFeaturesDataLoader = useDataLoader(biohubApi.publish.getSurveyPublishableFeatures);
+  const { refresh: refreshPublishFeatures, clearData: clearPublishFeaturesData } = publishFeaturesDataLoader;
+
+  useEffect(() => {
+    if (!props.open) {
+      clearPublishFeaturesData();
+      return;
+    }
+
+    refreshPublishFeatures(surveyContext.projectId, surveyContext.surveyId);
+  }, [clearPublishFeaturesData, props.open, refreshPublishFeatures, surveyContext.projectId, surveyContext.surveyId]);
+
+  const initialValues = useMemo<ISubmitSurvey>(() => {
+    return {
+      ...surveySubmitFormInitialValues,
+      featureTypes: (publishFeaturesDataLoader.data?.featureTypes as PublishFeatureType[] | undefined) || []
+    };
+  }, [publishFeaturesDataLoader.data]);
 
   const handleSubmit = async (values: ISubmitSurvey) => {
     if (values === surveySubmitFormInitialValues) {
@@ -89,7 +112,7 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
     setIsSubmitting(true);
 
     return biohubApi.publish
-      .publishSurveyData(surveyContext.surveyId, values)
+      .publishSurveyData(surveyContext.projectId, surveyContext.surveyId, values)
       .then(() => {
         setShowSuccessDialog(true);
       })
@@ -107,7 +130,7 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
       });
   };
 
-  if (!surveyWithDetails) {
+  if (!surveyWithDetails || (props.open && publishFeaturesDataLoader.isLoading && !publishFeaturesDataLoader.data)) {
     return <CircularProgress className="pageProgress" size={40} />;
   }
 
@@ -131,7 +154,8 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
         scroll="body">
         <Formik<ISubmitSurvey>
           innerRef={formikRef}
-          initialValues={surveySubmitFormInitialValues}
+          initialValues={initialValues}
+          enableReinitialize={true}
           validationSchema={surveySubmitFormYupSchema}
           validateOnBlur={true}
           validateOnChange={false}
@@ -142,7 +166,9 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
                 {SubmitSurveyBiohubI18N.submitSurveyBiohubDialogTitle}
               </DialogTitle>
               <DialogContent>
-                <PublishSurveyIdContent />
+                <PublishSurveyIdContent
+                  availableFeatureTypes={(publishFeaturesDataLoader.data?.featureTypes as PublishFeatureType[]) || []}
+                />
               </DialogContent>
               <DialogActions>
                 <LoadingButton
@@ -153,7 +179,8 @@ const PublishSurveyDialog = (props: IPublishSurveyIdDialogProps) => {
                     !(
                       formikProps.values.agreement1 &&
                       formikProps.values.agreement2 &&
-                      formikProps.values.agreement3
+                      formikProps.values.agreement3 &&
+                      formikProps.values.featureTypes.length > 0
                     ) || isSubmitting
                   }
                   loading={isSubmitting}>

--- a/app/src/components/publish/components/PublishSurveyContent.tsx
+++ b/app/src/components/publish/components/PublishSurveyContent.tsx
@@ -7,6 +7,8 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import CustomTextField from 'components/fields/CustomTextField';
 import { useFormikContext } from 'formik';
+import { applyFeatureToggle, CHILDREN, PARENTS } from '../featureDependencies';
+import { PUBLISH_FEATURE_TYPE_LABELS, PUBLISH_FEATURE_TYPES, PublishFeatureType } from '../publishFeatureTypes';
 import { ISubmitSurvey } from '../PublishSurveyDialog';
 
 /**
@@ -14,8 +16,77 @@ import { ISubmitSurvey } from '../PublishSurveyDialog';
  *
  * @return {*}
  */
-const PublishSurveyContent = () => {
+interface IPublishSurveyContentProps {
+  availableFeatureTypes: PublishFeatureType[];
+}
+
+const PublishSurveyContent = (props: IPublishSurveyContentProps) => {
   const { values, setFieldValue } = useFormikContext<ISubmitSurvey>();
+  const parentFeatureTypes = Object.values(PUBLISH_FEATURE_TYPES)
+    .filter((featureType) => !PARENTS[featureType]?.length)
+    .filter((featureType) => props.availableFeatureTypes.includes(featureType))
+    .sort((featureTypeA, featureTypeB) =>
+      PUBLISH_FEATURE_TYPE_LABELS[featureTypeA].localeCompare(PUBLISH_FEATURE_TYPE_LABELS[featureTypeB], undefined, {
+        sensitivity: 'base'
+      })
+    );
+  const renderFeatureRow = (featureType: PublishFeatureType, depth = 0) => {
+    const childFeatureTypes = (CHILDREN[featureType] || []).filter((childFeatureType) =>
+      props.availableFeatureTypes.includes(childFeatureType)
+    );
+
+    const nestedRowSpacingSx =
+      depth === 1
+        ? {
+            my: -0.1,
+            mt: -1.5,
+            '& .MuiTypography-root': { lineHeight: 1.3 },
+            '& .MuiCheckbox-root': { mr: 0.5, py: '4px' }
+          }
+        : depth > 1
+          ? {
+              my: -0.15,
+              '& .MuiTypography-root': { lineHeight: 1.25 },
+              '& .MuiCheckbox-root': { mr: 0.5, py: '3px' }
+            }
+          : {};
+
+    return (
+      <Box key={featureType} sx={{ mb: depth === 0 && childFeatureTypes.length ? 0.35 : 0 }}>
+        <FormControlLabel
+          sx={{
+            ml: `${4 + depth * 32}px`,
+            '& .MuiCheckbox-root': { mr: 0.5 },
+            ...nestedRowSpacingSx
+          }}
+          label={PUBLISH_FEATURE_TYPE_LABELS[featureType]}
+          control={
+            <Checkbox
+              checked={values.featureTypes.includes(featureType)}
+              onClick={() => {
+                const isChecked = values.featureTypes.includes(featureType);
+                const nextSelection = applyFeatureToggle(featureType, !isChecked, values.featureTypes);
+                setFieldValue('featureTypes', nextSelection);
+              }}
+              name={`featureTypes.${featureType}`}
+            />
+          }
+        />
+
+        {childFeatureTypes.map((childFeatureType) => renderFeatureRow(childFeatureType, depth + 1))}
+      </Box>
+    );
+  };
+  const sectionLayoutSx = {
+    display: 'grid',
+    gridTemplateColumns: {
+      xs: '1fr',
+      md: 'minmax(240px, 300px) 1fr'
+    },
+    columnGap: 6,
+    rowGap: 2,
+    alignItems: 'start'
+  } as const;
 
   return (
     <Stack
@@ -42,24 +113,27 @@ const PublishSurveyContent = () => {
       </Box>
 
       <Stack gap={4}>
-        <Box component="fieldset">
-          <Typography component="legend">Additional Information</Typography>
-          <Typography variant="body1" color="textSecondary" sx={{ mt: -0.75, mb: 3 }}>
-            Information about this survey that data stewards should be aware of, including any reasons why this survey
-            should be secured.
-          </Typography>
-          <CustomTextField
-            name="submissionComment"
-            label=""
-            other={{
-              placeholder: 'Submission comment',
-              multiline: true,
-              rows: 3
-            }}
-          />
+        <Box component="section" sx={sectionLayoutSx}>
+          <Box>
+            <Typography component="h3" sx={{ fontWeight: 700 }}>
+              Data
+            </Typography>
+            <Typography variant="body1" color="textSecondary">
+              Survey data included in this publish request.
+            </Typography>
+          </Box>
+          <FormGroup>{parentFeatureTypes.map((parentFeatureType) => renderFeatureRow(parentFeatureType))}</FormGroup>
         </Box>
-        <Box component="fieldset">
-          <Typography component="legend">Agreements</Typography>
+
+        <Box component="section" sx={sectionLayoutSx}>
+          <Box>
+            <Typography component="h3" sx={{ fontWeight: 700 }}>
+              Agreements
+            </Typography>
+            <Typography variant="body1" color="textSecondary">
+              You must acknowledge your responsibilities as a data contributor.
+            </Typography>
+          </Box>
           <FormGroup>
             <FormControlLabel
               slotProps={{ typography: { variant: 'body1' } }}
@@ -139,6 +213,27 @@ const PublishSurveyContent = () => {
               }
             />
           </FormGroup>
+        </Box>
+
+        <Box component="section" sx={sectionLayoutSx}>
+          <Box>
+            <Typography component="h3" sx={{ fontWeight: 700 }}>
+              Additional Information
+            </Typography>
+            <Typography variant="body1" color="textSecondary">
+              Information about this survey that data stewards should be aware of, including any reasons why this survey
+              should be secured.
+            </Typography>
+          </Box>
+          <CustomTextField
+            name="submissionComment"
+            label=""
+            other={{
+              placeholder: 'Submission comment',
+              multiline: true,
+              rows: 3
+            }}
+          />
         </Box>
       </Stack>
     </Stack>

--- a/app/src/components/publish/components/PublishSurveyContent.tsx
+++ b/app/src/components/publish/components/PublishSurveyContent.tsx
@@ -35,21 +35,21 @@ const PublishSurveyContent = (props: IPublishSurveyContentProps) => {
       props.availableFeatureTypes.includes(childFeatureType)
     );
 
-    const nestedRowSpacingSx =
-      depth === 1
-        ? {
-            my: -0.1,
-            mt: -1.5,
-            '& .MuiTypography-root': { lineHeight: 1.3 },
-            '& .MuiCheckbox-root': { mr: 0.5, py: '4px' }
-          }
-        : depth > 1
-          ? {
-              my: -0.15,
-              '& .MuiTypography-root': { lineHeight: 1.25 },
-              '& .MuiCheckbox-root': { mr: 0.5, py: '3px' }
-            }
-          : {};
+    let nestedRowSpacingSx = {};
+    if (depth === 1) {
+      nestedRowSpacingSx = {
+        my: -0.1,
+        mt: -1.5,
+        '& .MuiTypography-root': { lineHeight: 1.3 },
+        '& .MuiCheckbox-root': { mr: 0.5, py: '4px' }
+      };
+    } else if (depth > 1) {
+      nestedRowSpacingSx = {
+        my: -0.15,
+        '& .MuiTypography-root': { lineHeight: 1.25 },
+        '& .MuiCheckbox-root': { mr: 0.5, py: '3px' }
+      };
+    }
 
     return (
       <Box key={featureType} sx={{ mb: depth === 0 && childFeatureTypes.length ? 0.35 : 0 }}>

--- a/app/src/components/publish/featureDependencies.test.ts
+++ b/app/src/components/publish/featureDependencies.test.ts
@@ -22,11 +22,73 @@ describe('applyFeatureToggle', () => {
     const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE, false, [
       PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE,
       PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT,
-      PUBLISH_FEATURE_TYPES.TELEMETRY
+      PUBLISH_FEATURE_TYPES.TELEMETRY,
+      PUBLISH_FEATURE_TYPES.TELEMETRY_FREQUENCY
     ]);
 
     expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE);
     expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT);
     expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_FREQUENCY);
+  });
+
+  it('removes parent sampling site when sampling period is unselected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD, false, [
+      PUBLISH_FEATURE_TYPES.SAMPLE_SITE,
+      PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD
+    ]);
+
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.SAMPLE_SITE);
+  });
+
+  it('removes transitive telemetry parents when telemetry is unselected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.TELEMETRY, false, [
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE,
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT,
+      PUBLISH_FEATURE_TYPES.TELEMETRY
+    ]);
+
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE);
+  });
+
+  it('adds transitive animal parents when marking is selected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.MARKING, true, []);
+
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.MARKING);
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.CAPTURE);
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.ANIMAL);
+  });
+
+  it('removes animal subtree when animal is unselected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.ANIMAL, false, [
+      PUBLISH_FEATURE_TYPES.ANIMAL,
+      PUBLISH_FEATURE_TYPES.CAPTURE,
+      PUBLISH_FEATURE_TYPES.MARKING,
+      PUBLISH_FEATURE_TYPES.MEASUREMENT,
+      PUBLISH_FEATURE_TYPES.RELEASE,
+      PUBLISH_FEATURE_TYPES.MORTALITY,
+      PUBLISH_FEATURE_TYPES.ECOLOGICAL_UNIT
+    ]);
+
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.ANIMAL);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.CAPTURE);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.MARKING);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.MEASUREMENT);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.RELEASE);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.MORTALITY);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.ECOLOGICAL_UNIT);
+  });
+
+  it('removes sample site when last sample site child is unselected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.BLOCK, false, [
+      PUBLISH_FEATURE_TYPES.SAMPLE_SITE,
+      PUBLISH_FEATURE_TYPES.BLOCK
+    ]);
+
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.BLOCK);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.SAMPLE_SITE);
   });
 });

--- a/app/src/components/publish/featureDependencies.test.ts
+++ b/app/src/components/publish/featureDependencies.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { applyFeatureToggle } from './featureDependencies';
+import { PUBLISH_FEATURE_TYPES } from './publishFeatureTypes';
+
+describe('applyFeatureToggle', () => {
+  it('adds parent sampling site when sampling period is selected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD, true, []);
+
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD);
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.SAMPLE_SITE);
+  });
+
+  it('adds transitive telemetry parents when telemetry is selected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.TELEMETRY, true, []);
+
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.TELEMETRY);
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT);
+    expect(selection).toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE);
+  });
+
+  it('removes telemetry children when telemetry device is unselected', () => {
+    const selection = applyFeatureToggle(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE, false, [
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE,
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT,
+      PUBLISH_FEATURE_TYPES.TELEMETRY
+    ]);
+
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT);
+    expect(selection).not.toContain(PUBLISH_FEATURE_TYPES.TELEMETRY);
+  });
+});

--- a/app/src/components/publish/featureDependencies.ts
+++ b/app/src/components/publish/featureDependencies.ts
@@ -1,0 +1,53 @@
+import { PUBLISH_FEATURE_TYPES, PublishFeatureType } from './publishFeatureTypes';
+
+export const PARENTS: Partial<Record<PublishFeatureType, PublishFeatureType[]>> = {
+  [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD]: [PUBLISH_FEATURE_TYPES.SAMPLE_SITE],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]
+};
+
+export const CHILDREN: Partial<Record<PublishFeatureType, PublishFeatureType[]>> = {
+  [PUBLISH_FEATURE_TYPES.SAMPLE_SITE]: [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: [PUBLISH_FEATURE_TYPES.TELEMETRY]
+};
+
+const addParents = (current: Set<PublishFeatureType>, featureType: PublishFeatureType) => {
+  const parentFeatureTypes = PARENTS[featureType] || [];
+
+  parentFeatureTypes.forEach((parentFeatureType) => {
+    if (!current.has(parentFeatureType)) {
+      current.add(parentFeatureType);
+      addParents(current, parentFeatureType);
+    }
+  });
+};
+
+const removeChildren = (current: Set<PublishFeatureType>, featureType: PublishFeatureType) => {
+  const childFeatureTypes = CHILDREN[featureType] || [];
+
+  childFeatureTypes.forEach((childFeatureType) => {
+    if (current.has(childFeatureType)) {
+      current.delete(childFeatureType);
+      removeChildren(current, childFeatureType);
+    }
+  });
+};
+
+export const applyFeatureToggle = (
+  featureType: PublishFeatureType,
+  isChecked: boolean,
+  selectedFeatureTypes: PublishFeatureType[]
+) => {
+  const nextSelection = new Set<PublishFeatureType>(selectedFeatureTypes);
+
+  if (isChecked) {
+    nextSelection.add(featureType);
+    addParents(nextSelection, featureType);
+  } else {
+    nextSelection.delete(featureType);
+    removeChildren(nextSelection, featureType);
+  }
+
+  return [...nextSelection];
+};

--- a/app/src/components/publish/featureDependencies.ts
+++ b/app/src/components/publish/featureDependencies.ts
@@ -1,15 +1,43 @@
 import { PUBLISH_FEATURE_TYPES, PublishFeatureType } from './publishFeatureTypes';
 
 export const PARENTS: Partial<Record<PublishFeatureType, PublishFeatureType[]>> = {
+  [PUBLISH_FEATURE_TYPES.BLOCK]: [PUBLISH_FEATURE_TYPES.SAMPLE_SITE],
+  [PUBLISH_FEATURE_TYPES.CAPTURE]: [PUBLISH_FEATURE_TYPES.ANIMAL],
+  [PUBLISH_FEATURE_TYPES.ECOLOGICAL_UNIT]: [PUBLISH_FEATURE_TYPES.ANIMAL],
+  [PUBLISH_FEATURE_TYPES.MARKING]: [PUBLISH_FEATURE_TYPES.CAPTURE],
+  [PUBLISH_FEATURE_TYPES.MEASUREMENT]: [PUBLISH_FEATURE_TYPES.CAPTURE],
+  [PUBLISH_FEATURE_TYPES.MORTALITY]: [PUBLISH_FEATURE_TYPES.ANIMAL],
+  [PUBLISH_FEATURE_TYPES.RELEASE]: [PUBLISH_FEATURE_TYPES.CAPTURE],
   [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD]: [PUBLISH_FEATURE_TYPES.SAMPLE_SITE],
+  [PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE]: [PUBLISH_FEATURE_TYPES.SAMPLE_SITE],
+  [PUBLISH_FEATURE_TYPES.STRATUM]: [PUBLISH_FEATURE_TYPES.SAMPLE_SITE],
   [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE],
-  [PUBLISH_FEATURE_TYPES.TELEMETRY]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]
+  [PUBLISH_FEATURE_TYPES.TELEMETRY]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_FREQUENCY]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]
 };
 
 export const CHILDREN: Partial<Record<PublishFeatureType, PublishFeatureType[]>> = {
-  [PUBLISH_FEATURE_TYPES.SAMPLE_SITE]: [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD],
-  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT],
-  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: [PUBLISH_FEATURE_TYPES.TELEMETRY]
+  [PUBLISH_FEATURE_TYPES.ANIMAL]: [
+    PUBLISH_FEATURE_TYPES.CAPTURE,
+    PUBLISH_FEATURE_TYPES.ECOLOGICAL_UNIT,
+    PUBLISH_FEATURE_TYPES.MORTALITY
+  ],
+  [PUBLISH_FEATURE_TYPES.CAPTURE]: [
+    PUBLISH_FEATURE_TYPES.MARKING,
+    PUBLISH_FEATURE_TYPES.MEASUREMENT,
+    PUBLISH_FEATURE_TYPES.RELEASE
+  ],
+  [PUBLISH_FEATURE_TYPES.SAMPLE_SITE]: [
+    PUBLISH_FEATURE_TYPES.BLOCK,
+    PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD,
+    PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE,
+    PUBLISH_FEATURE_TYPES.STRATUM
+  ],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: [
+    PUBLISH_FEATURE_TYPES.TELEMETRY,
+    PUBLISH_FEATURE_TYPES.TELEMETRY_FREQUENCY
+  ],
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]
 };
 
 const addParents = (current: Set<PublishFeatureType>, featureType: PublishFeatureType) => {
@@ -34,6 +62,29 @@ const removeChildren = (current: Set<PublishFeatureType>, featureType: PublishFe
   });
 };
 
+const hasAnySelectedDescendant = (current: Set<PublishFeatureType>, featureType: PublishFeatureType): boolean => {
+  const childFeatureTypes = CHILDREN[featureType] || [];
+
+  for (const childFeatureType of childFeatureTypes) {
+    if (current.has(childFeatureType) || hasAnySelectedDescendant(current, childFeatureType)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const removeOrphanedParents = (current: Set<PublishFeatureType>, featureType: PublishFeatureType) => {
+  const parentFeatureTypes = PARENTS[featureType] || [];
+
+  parentFeatureTypes.forEach((parentFeatureType) => {
+    if (current.has(parentFeatureType) && !hasAnySelectedDescendant(current, parentFeatureType)) {
+      current.delete(parentFeatureType);
+      removeOrphanedParents(current, parentFeatureType);
+    }
+  });
+};
+
 export const applyFeatureToggle = (
   featureType: PublishFeatureType,
   isChecked: boolean,
@@ -47,6 +98,7 @@ export const applyFeatureToggle = (
   } else {
     nextSelection.delete(featureType);
     removeChildren(nextSelection, featureType);
+    removeOrphanedParents(nextSelection, featureType);
   }
 
   return [...nextSelection];

--- a/app/src/components/publish/publishFeatureTypes.ts
+++ b/app/src/components/publish/publishFeatureTypes.ts
@@ -1,52 +1,49 @@
 export const PUBLISH_FEATURE_TYPES = {
+  ANIMAL: 'animal',
+  BLOCK: 'block',
+  CAPTURE: 'capture',
+  ECOLOGICAL_UNIT: 'ecological_unit',
+  FILE: 'file',
+  HABITAT_FEATURE: 'habitat_feature',
+  MARKING: 'marking',
+  MEASUREMENT: 'measurement',
+  MORTALITY: 'mortality',
+  OBSERVATION: 'species_observation',
+  RELEASE: 'release',
+  REPORT: 'report',
   SAMPLE_SITE: 'sample_site',
   SAMPLE_PERIOD: 'sample_period',
   SAMPLE_TECHNIQUE: 'sample_technique',
-  OBSERVATION: 'species_observation',
+  STRATUM: 'stratum',
+  STUDY_AREA: 'study_area',
   TELEMETRY: 'telemetry',
   TELEMETRY_DEVICE: 'telemetry_device',
   TELEMETRY_DEPLOYMENT: 'telemetry_deployment',
-  HABITAT_FEATURE: 'habitat_feature',
-  FILE: 'file'
+  TELEMETRY_FREQUENCY: 'telemetry_frequency'
 } as const;
 
 export type PublishFeatureType = (typeof PUBLISH_FEATURE_TYPES)[keyof typeof PUBLISH_FEATURE_TYPES];
 
 export const PUBLISH_FEATURE_TYPE_LABELS: Record<PublishFeatureType, string> = {
+  [PUBLISH_FEATURE_TYPES.ANIMAL]: 'Animals',
+  [PUBLISH_FEATURE_TYPES.BLOCK]: 'Blocks',
+  [PUBLISH_FEATURE_TYPES.CAPTURE]: 'Captures',
+  [PUBLISH_FEATURE_TYPES.ECOLOGICAL_UNIT]: 'Ecological units',
+  [PUBLISH_FEATURE_TYPES.FILE]: 'Attachments',
+  [PUBLISH_FEATURE_TYPES.HABITAT_FEATURE]: 'Habitat features',
+  [PUBLISH_FEATURE_TYPES.MARKING]: 'Markings',
+  [PUBLISH_FEATURE_TYPES.MEASUREMENT]: 'Measurements',
+  [PUBLISH_FEATURE_TYPES.MORTALITY]: 'Mortalities',
+  [PUBLISH_FEATURE_TYPES.OBSERVATION]: 'Observations',
+  [PUBLISH_FEATURE_TYPES.RELEASE]: 'Releases',
+  [PUBLISH_FEATURE_TYPES.REPORT]: 'Reports',
   [PUBLISH_FEATURE_TYPES.SAMPLE_SITE]: 'Sampling sites',
   [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD]: 'Sampling periods',
-  [PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE]: 'Techniques',
-  [PUBLISH_FEATURE_TYPES.OBSERVATION]: 'Observations',
+  [PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE]: 'Sampling techniques',
+  [PUBLISH_FEATURE_TYPES.STRATUM]: 'Strata',
+  [PUBLISH_FEATURE_TYPES.STUDY_AREA]: 'Study area',
   [PUBLISH_FEATURE_TYPES.TELEMETRY]: 'Telemetry',
-  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: 'Devices',
-  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: 'Deployments',
-  [PUBLISH_FEATURE_TYPES.HABITAT_FEATURE]: 'Habitat features',
-  [PUBLISH_FEATURE_TYPES.FILE]: 'Attachments'
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: 'Telemetry deployments',
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: 'Telemetry devices',
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_FREQUENCY]: 'Telemetry frequencies'
 };
-
-export const PUBLISH_FEATURE_GROUPS: { title: string; featureTypes: PublishFeatureType[] }[] = [
-  {
-    title: 'Sampling',
-    featureTypes: [
-      PUBLISH_FEATURE_TYPES.SAMPLE_SITE,
-      PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD,
-      PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE
-    ]
-  },
-  {
-    title: 'Data',
-    featureTypes: [PUBLISH_FEATURE_TYPES.OBSERVATION, PUBLISH_FEATURE_TYPES.HABITAT_FEATURE]
-  },
-  {
-    title: 'Telemetry',
-    featureTypes: [
-      PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE,
-      PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT,
-      PUBLISH_FEATURE_TYPES.TELEMETRY
-    ]
-  },
-  {
-    title: 'Attachments',
-    featureTypes: [PUBLISH_FEATURE_TYPES.FILE]
-  }
-];

--- a/app/src/components/publish/publishFeatureTypes.ts
+++ b/app/src/components/publish/publishFeatureTypes.ts
@@ -1,0 +1,52 @@
+export const PUBLISH_FEATURE_TYPES = {
+  SAMPLE_SITE: 'sample_site',
+  SAMPLE_PERIOD: 'sample_period',
+  SAMPLE_TECHNIQUE: 'sample_technique',
+  OBSERVATION: 'species_observation',
+  TELEMETRY: 'telemetry',
+  TELEMETRY_DEVICE: 'telemetry_device',
+  TELEMETRY_DEPLOYMENT: 'telemetry_deployment',
+  HABITAT_FEATURE: 'habitat_feature',
+  FILE: 'file'
+} as const;
+
+export type PublishFeatureType = (typeof PUBLISH_FEATURE_TYPES)[keyof typeof PUBLISH_FEATURE_TYPES];
+
+export const PUBLISH_FEATURE_TYPE_LABELS: Record<PublishFeatureType, string> = {
+  [PUBLISH_FEATURE_TYPES.SAMPLE_SITE]: 'Sampling sites',
+  [PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD]: 'Sampling periods',
+  [PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE]: 'Techniques',
+  [PUBLISH_FEATURE_TYPES.OBSERVATION]: 'Observations',
+  [PUBLISH_FEATURE_TYPES.TELEMETRY]: 'Telemetry',
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE]: 'Devices',
+  [PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT]: 'Deployments',
+  [PUBLISH_FEATURE_TYPES.HABITAT_FEATURE]: 'Habitat features',
+  [PUBLISH_FEATURE_TYPES.FILE]: 'Attachments'
+};
+
+export const PUBLISH_FEATURE_GROUPS: { title: string; featureTypes: PublishFeatureType[] }[] = [
+  {
+    title: 'Sampling',
+    featureTypes: [
+      PUBLISH_FEATURE_TYPES.SAMPLE_SITE,
+      PUBLISH_FEATURE_TYPES.SAMPLE_PERIOD,
+      PUBLISH_FEATURE_TYPES.SAMPLE_TECHNIQUE
+    ]
+  },
+  {
+    title: 'Data',
+    featureTypes: [PUBLISH_FEATURE_TYPES.OBSERVATION, PUBLISH_FEATURE_TYPES.HABITAT_FEATURE]
+  },
+  {
+    title: 'Telemetry',
+    featureTypes: [
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEVICE,
+      PUBLISH_FEATURE_TYPES.TELEMETRY_DEPLOYMENT,
+      PUBLISH_FEATURE_TYPES.TELEMETRY
+    ]
+  },
+  {
+    title: 'Attachments',
+    featureTypes: [PUBLISH_FEATURE_TYPES.FILE]
+  }
+];

--- a/app/src/contexts/surveyContext.tsx
+++ b/app/src/contexts/surveyContext.tsx
@@ -84,10 +84,6 @@ export const SurveyContextProvider = (props: PropsWithChildren<Record<never, any
   const projectId = Number(urlParams['id']);
   const surveyId = Number(urlParams['survey_id']);
 
-  surveyDataLoader.load(projectId, surveyId);
-  artifactDataLoader.load(projectId, surveyId);
-  critterDataLoader.load(projectId, surveyId);
-
   /**
    * Refreshes the current survey object whenever the current survey ID changes from the currently loaded survey.
    */
@@ -100,7 +96,6 @@ export const SurveyContextProvider = (props: PropsWithChildren<Record<never, any
     ) {
       surveyDataLoader.refresh(projectId, surveyId);
       artifactDataLoader.refresh(projectId, surveyId);
-      critterDataLoader.refresh(projectId, surveyId);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/src/features/surveys/view/SurveyHeader.test.tsx
+++ b/app/src/features/surveys/view/SurveyHeader.test.tsx
@@ -25,6 +25,9 @@ vi.mock('../../../hooks/useBioHubApi');
 const mockBiohubApi = useBiohubApi as Mock;
 
 const mockUseApi = {
+  publish: {
+    getSurveyPublishableFeatures: vi.fn().mockResolvedValue({ featureTypes: [] })
+  },
   survey: {
     publishSurvey: vi.fn(),
     deleteSurvey: vi.fn()

--- a/app/src/features/surveys/view/survey-spatial/SurveySpatialContainer.tsx
+++ b/app/src/features/surveys/view/survey-spatial/SurveySpatialContainer.tsx
@@ -7,11 +7,7 @@ import {
   SurveySpatialToolbar
 } from 'features/surveys/view/survey-spatial/components/SurveySpatialToolbar';
 import { SurveySpatialTelemetry } from 'features/surveys/view/survey-spatial/components/telemetry/SurveySpatialTelemetry';
-import { useBiohubApi } from 'hooks/useBioHubApi';
-import { useSurveyContext, useTaxonomyContext } from 'hooks/useContext';
-import useDataLoader from 'hooks/useDataLoader';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { ApiPaginationRequestOptions } from 'types/misc';
+import { useMemo, useState } from 'react';
 import { SurveySpatialHabitatFeature } from './components/habitat-feature/SurveySpatialHabitatFeature';
 import { useSamplingSiteStaticLayer } from './components/map/useSamplingSiteStaticLayer';
 import { useStudyAreaStaticLayer } from './components/map/useStudyAreaStaticLayer';
@@ -24,15 +20,6 @@ import { useStudyAreaStaticLayer } from './components/map/useStudyAreaStaticLaye
  * @returns {JSX.Element} The rendered component.
  */
 export const SurveySpatialContainer = (): JSX.Element => {
-  const surveyContext = useSurveyContext();
-  const taxonomyContext = useTaxonomyContext();
-
-  const biohubApi = useBiohubApi();
-
-  const observationsDataLoader = useDataLoader((pagination?: ApiPaginationRequestOptions) =>
-    biohubApi.observation.getFlattenedObservationRecords(surveyContext.projectId, surveyContext.surveyId, pagination)
-  );
-
   const [activeView, setActiveView] = useState<SurveySpatialDatasetViewEnum>(SurveySpatialDatasetViewEnum.OBSERVATIONS);
 
   const studyAreaStaticLayer = useStudyAreaStaticLayer();
@@ -42,34 +29,6 @@ export const SurveySpatialContainer = (): JSX.Element => {
     () => [studyAreaStaticLayer, samplingSiteStaticLayer],
     [samplingSiteStaticLayer, studyAreaStaticLayer]
   );
-
-  const loadRef = useRef(observationsDataLoader.load);
-  loadRef.current = observationsDataLoader.load;
-  useEffect(() => {
-    loadRef.current();
-  }, [surveyContext.projectId, surveyContext.surveyId]);
-
-  // Fetch and cache all taxonomic data required for the observations.
-  useEffect(() => {
-    const cacheTaxonomicData = async () => {
-      if (observationsDataLoader.data) {
-        // Fetch all unique ITIS TSNs from observations to retrieve taxonomic names
-        const taxonomicIds = [
-          ...new Set(observationsDataLoader.data.surveyObservations.map((item) => item.itis_tsn))
-        ].filter((tsn): tsn is number => tsn !== null);
-
-        if (!taxonomicIds.length) {
-          return;
-        }
-
-        await taxonomyContext.cacheSpeciesTaxonomyByIds(taxonomicIds);
-      }
-    };
-
-    cacheTaxonomicData();
-    // Should not re-run this effect on `taxonomyContext` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [observationsDataLoader.data]);
 
   return (
     <>

--- a/app/src/hooks/api/usePublishApi.ts
+++ b/app/src/hooks/api/usePublishApi.ts
@@ -18,15 +18,35 @@ const usePublishApi = (axios: AxiosInstance) => {
    * @return {*}  {Promise<{ submission_id: number }>}
    */
   const publishSurveyData = async (
+    projectId: number,
     surveyId: number,
     dataSubmission: ISubmitSurvey
-  ): Promise<{ submission_id: number }> => {
+  ): Promise<{ submission_uuid: string }> => {
     const sendData = {
+      projectId: projectId,
       surveyId: surveyId,
       data: dataSubmission
     };
 
     const { data } = await axios.post('/api/publish/survey', sendData);
+    return data;
+  };
+
+  /**
+   * Get survey publishable feature types.
+   *
+   * @param {number} projectId
+   * @param {number} surveyId
+   * @return {*}  {Promise<{ featureTypes: string[] }>}
+   */
+  const getSurveyPublishableFeatures = async (
+    projectId: number,
+    surveyId: number
+  ): Promise<{ featureTypes: string[] }> => {
+    const { data } = await axios.get<{ featureTypes: string[] }>(
+      `/api/project/${projectId}/survey/${surveyId}/publish/features`
+    );
+
     return data;
   };
 
@@ -72,6 +92,7 @@ const usePublishApi = (axios: AxiosInstance) => {
 
   return {
     publishSurveyData,
+    getSurveyPublishableFeatures,
     publishProject,
     getSubmissionHistory,
     deleteSubmissionUpload


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-970](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-970)

## Description of Changes

- Added support for publishing selected parts of a survey instead of always publishing everything.
- Added an endpoint to return publishable feature types for a survey, and wired the publish dialog to load and submit selected feature types.
- Enforced feature dependency rules (parent/child) in UI and backend normalization so payloads are valid and consistent.
- Updated BioHub submission packaging flow to include only selected feature types, and added coverage for feature filtering and multipart upload behavior.

## Testing Notes

- In the survey view, open the Publish dialog and verify only available feature types are shown for the current survey.
- Verify feature dependency behavior in the dialog:
  - selecting a child auto-selects required parent(s)
  - unselecting a parent removes dependent children
- Publish with different feature subsets (for example: only observations, only sampling-related data, telemetry-related data) and confirm submission succeeds.
- Confirm publish history/submission behavior still works for republish and no regressions in survey header actions.
- Spot-check that attachment publishing includes only intended publishable attachment types.