### PR TITLE
SIMSBIOHUB-978: ESM migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ telemetry-cronjob: ## Run the telemetry cronjob
 	@echo "==============================================="
 	@echo "Telemetry Cronjob"
 	@echo "==============================================="
-	@docker compose exec api npx ts-node src/cronjobs/telemetry/index --deviceLimit=2 -- $(args)
+	@docker compose exec api npx tsx src/cronjobs/telemetry/index.ts --deviceLimit=2 -- $(args)
 ## ------------------------------------------------------------------------------
 ## Database migration commands
 ## ------------------------------------------------------------------------------

--- a/api/.mocharc.json
+++ b/api/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["ts"],
   "spec": "src/{*.@(test|spec).ts,!(__mocks__)/**/*.@(test|spec).ts}",
-  "require": "ts-node/register, mocha-fixtures.ts"
+  "require": ["./mocha-fixtures.ts"]
 }

--- a/api/.swcrc
+++ b/api/.swcrc
@@ -1,0 +1,15 @@
+{
+  "sourceMaps": true,
+  "jsc": {
+    "target": "es2023",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": false
+    }
+  },
+  "module": {
+    "type": "es6",
+    "resolveFully": true,
+    "outFileExtension": "js"
+  }
+}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -100,4 +100,4 @@ EXPOSE 6100
 USER 1001
 
 # Application Entry point
-CMD ["node", "src/app.js"]
+CMD ["node", "--experimental-specifier-resolution=node", "src/app.js"]

--- a/api/mocha-fixtures.ts
+++ b/api/mocha-fixtures.ts
@@ -1,8 +1,8 @@
 import { setLogLevel } from './src/utils/logger';
 
 // See https://mochajs.org/#global-setup-fixtures
-exports.mochaGlobalSetup = async function () {
+export async function mochaGlobalSetup() {
   // Disable winston logging before mocha unit tests run, to prevent winston from cluttering the test log with test
   // error messages.
   setLogLevel('silent');
-};
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -56,6 +56,8 @@
       "devDependencies": {
         "@eslint/js": "^9.23.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
+        "@swc/cli": "^0.7.8",
+        "@swc/core": "^1.13.5",
         "@types/adm-zip": "^0.4.34",
         "@types/archiver": "^6.0.2",
         "@types/chai": "^4.3.14",
@@ -80,15 +82,13 @@
         "eslint-plugin-mocha": "^10.5.0",
         "eslint-plugin-prettier": "^5.2.5",
         "mocha": "^10.4.0",
-        "nodemon": "^3.1.0",
         "npm-run-all": "^4.1.5",
         "nyc": "^15.1.0",
         "prettier": "^3.5.3",
         "prettier-plugin-organize-imports": "^4.1.0",
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
-        "ts-mocha": "^10.0.0",
-        "ts-node": "^10.9.2",
+        "tsx": "^4.20.6",
         "typescript-eslint": "^8.28.0"
       },
       "engines": {
@@ -1321,6 +1321,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -1328,30 +1339,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -1363,6 +1350,448 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1875,6 +2304,350 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/nice": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
+      "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/nice-android-arm-eabi": "1.1.1",
+        "@napi-rs/nice-android-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-x64": "1.1.1",
+        "@napi-rs/nice-freebsd-x64": "1.1.1",
+        "@napi-rs/nice-linux-arm-gnueabihf": "1.1.1",
+        "@napi-rs/nice-linux-arm64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-arm64-musl": "1.1.1",
+        "@napi-rs/nice-linux-ppc64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-riscv64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-s390x-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-musl": "1.1.1",
+        "@napi-rs/nice-openharmony-arm64": "1.1.1",
+        "@napi-rs/nice-win32-arm64-msvc": "1.1.1",
+        "@napi-rs/nice-win32-ia32-msvc": "1.1.1",
+        "@napi-rs/nice-win32-x64-msvc": "1.1.1"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm-eabi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
+      "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
+      "integrity": "sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-freebsd-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
+      "integrity": "sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
+      "integrity": "sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
+      "integrity": "sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
+      "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
+      "integrity": "sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
+      "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-s390x-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
+      "integrity": "sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
+      "integrity": "sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
+      "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-openharmony-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
+      "integrity": "sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-arm64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
+      "integrity": "sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-ia32-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
+      "integrity": "sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-x64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
+      "integrity": "sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1942,6 +2715,19 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -2722,31 +3508,377 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+    "node_modules/@swc/cli": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.7.10.tgz",
+      "integrity": "sha512-QQ36Q1VwGTT2YzvMeNe/j1x4DKS277DscNhWc57dIwQn//C+zAgvuSupMB/XkmYqPKQX+8hjn5/cHRJrMvWy0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@xhmikosr/bin-wrapper": "^13.0.5",
+        "commander": "^8.3.0",
+        "minimatch": "^9.0.3",
+        "piscina": "^4.3.1",
+        "semver": "^7.3.8",
+        "slash": "3.0.0",
+        "source-map": "^0.7.3",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "spack": "bin/spack.js",
+        "swc": "bin/swc.js",
+        "swcx": "bin/swcx.js"
+      },
+      "engines": {
+        "node": ">= 16.14.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.2.66",
+        "chokidar": "^4.0.1"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+    "node_modules/@swc/cli/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+    "node_modules/@swc/cli/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+    "node_modules/@swc/core": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.32.tgz",
+      "integrity": "sha512-/eWL0n43D64QWEUHLtTE+jDqjkJhyidjkDhv6f0uJohOUAhywxQ9wXYp845DNNds0JpCdI4Uo0a9bl+vbXf+ew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.32",
+        "@swc/core-darwin-x64": "1.15.32",
+        "@swc/core-linux-arm-gnueabihf": "1.15.32",
+        "@swc/core-linux-arm64-gnu": "1.15.32",
+        "@swc/core-linux-arm64-musl": "1.15.32",
+        "@swc/core-linux-ppc64-gnu": "1.15.32",
+        "@swc/core-linux-s390x-gnu": "1.15.32",
+        "@swc/core-linux-x64-gnu": "1.15.32",
+        "@swc/core-linux-x64-musl": "1.15.32",
+        "@swc/core-win32-arm64-msvc": "1.15.32",
+        "@swc/core-win32-ia32-msvc": "1.15.32",
+        "@swc/core-win32-x64-msvc": "1.15.32"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.32.tgz",
+      "integrity": "sha512-/YWMvJDPu+AAwuUsM2G+DNQ/7zhodURGzdQyewEqcvgklAdDHs3LwQmLLnyn6SJl8DT8UOxkbzK+D1PmPeelRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.32.tgz",
+      "integrity": "sha512-KOTXJXdAhWL+hZ77MYP3z+4pcMFaQhQ74yqyN1uz093q0YnbxpqMtYpPISbYvMHzVRNNx5kN+9RZAXEaadhWVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.32.tgz",
+      "integrity": "sha512-oOoxLweljlc0A4X8ybsgxV7cVaYTwBOg2iMDJcFR3Sr48C+lsv9VzSmqdK/IVIXF4W4GjLc3VqTAdSMXlfVLuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.32.tgz",
+      "integrity": "sha512-oDzEkdl6D6BAWdMtU5KGO7y3HR5fJcvByNLyEk9+ugj8nP5Ovb7P4kBcStBXc4MPExFGQryehiINMlmY8HlclA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.32.tgz",
+      "integrity": "sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.32.tgz",
+      "integrity": "sha512-KGkTMyz/Tbn3PBNu0AVZ4GTDFKnICrYcTiNPZq8DrvK42pnFsf3GNDrIG9E5AtQlTmC0YigkWKmu0eMcfTrmgA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.32.tgz",
+      "integrity": "sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.32.tgz",
+      "integrity": "sha512-ERsjfGcj6CBmj3vJnGDO8m8rTvw6RqMcWo1dogOtNx3/+/0+NNpJiXDobJrr1GwInI/BHAEkvSFIH6d2LqPcUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.32.tgz",
+      "integrity": "sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.32.tgz",
+      "integrity": "sha512-01yN0o9jvo8xBTP12aPK2wW8b41jmOlGbDDlAnoynotc4pO6xA0zby9f1z6j++qXDpGBttLySq1omgVrlQKYcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.32.tgz",
+      "integrity": "sha512-fLagI9XZYNpTcmlqAcp3KBtmj7E19WCmYD80Jxj1Kn5tGNa7yxNLd3NNdWxuZGUPl5iC0/KqZru7g08gF6Fsrw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.32.tgz",
+      "integrity": "sha512-gbc2bQ/T2CiR+w0OvcVKwLOFAcPZBvmWmolbwpg1E8UrpeC03DGtyMUApOHNXNYWA3SHFrYXCQtosrcMza1YFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2917,6 +4049,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -2939,14 +4078,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "8.5.9",
@@ -3327,6 +4458,163 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@xhmikosr/archive-type": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.1.0.tgz",
+      "integrity": "sha512-xZEpnGplg1sNPyEgFh0zbHxqlw5dtYg6viplmWSxUj12+QjU9SKu3U/2G73a15pEjLaOqTefNSZ1fOPUOT4Xgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^20.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/bin-check": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.1.0.tgz",
+      "integrity": "sha512-y1O95J4mnl+6MpVmKfMYXec17hMEwE/yeCglFNdx+QvLLtP0yN4rSYcbkXnth+lElBuKKek2NbvOfOGPpUXCvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "isexe": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/bin-wrapper": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.2.0.tgz",
+      "integrity": "sha512-t9U9X0sDPRGDk5TGx4dv5xiOvniVJpXnfTuynVKwHgtib95NYEw4MkZdJqhoSiz820D9m0o6PCqOPMXz0N9fIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xhmikosr/bin-check": "^7.1.0",
+        "@xhmikosr/downloader": "^15.2.0",
+        "@xhmikosr/os-filter-obj": "^3.0.0",
+        "bin-version-check": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/decompress": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.2.0.tgz",
+      "integrity": "sha512-MmDBvu0+GmADyQWHolcZuIWffgfnuTo4xpr2I/Qw5Ox0gt+e1Be7oYqJM4te5ylL6mzlcoicnHVDvP27zft8tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xhmikosr/decompress-tar": "^8.1.0",
+        "@xhmikosr/decompress-tarbz2": "^8.1.0",
+        "@xhmikosr/decompress-targz": "^8.1.0",
+        "@xhmikosr/decompress-unzip": "^7.1.0",
+        "graceful-fs": "^4.2.11",
+        "strip-dirs": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-tar": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.1.0.tgz",
+      "integrity": "sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^20.5.0",
+        "is-stream": "^2.0.1",
+        "tar-stream": "^3.1.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-tarbz2": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.1.0.tgz",
+      "integrity": "sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xhmikosr/decompress-tar": "^8.0.1",
+        "file-type": "^20.5.0",
+        "is-stream": "^2.0.1",
+        "seek-bzip": "^2.0.0",
+        "unbzip2-stream": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-targz": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.1.0.tgz",
+      "integrity": "sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xhmikosr/decompress-tar": "^8.0.1",
+        "file-type": "^20.5.0",
+        "is-stream": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-unzip": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.1.0.tgz",
+      "integrity": "sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^20.5.0",
+        "get-stream": "^6.0.1",
+        "yauzl": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/downloader": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.2.0.tgz",
+      "integrity": "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xhmikosr/archive-type": "^7.1.0",
+        "@xhmikosr/decompress": "^10.2.0",
+        "content-disposition": "^0.5.4",
+        "defaults": "^2.0.2",
+        "ext-name": "^5.0.0",
+        "file-type": "^20.5.0",
+        "filenamify": "^6.0.0",
+        "get-stream": "^6.0.1",
+        "got": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/os-filter-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/os-filter-obj/-/os-filter-obj-3.0.0.tgz",
+      "integrity": "sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.14.0 || >=16.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3358,6 +4646,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3374,19 +4663,6 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/adm-zip": {
@@ -3512,6 +4788,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/arch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -3552,13 +4849,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3612,16 +4902,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/asn1": {
@@ -3738,6 +5018,41 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bin-version": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
+      "integrity": "sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "find-versions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bin-version-check": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-5.1.0.tgz",
+      "integrity": "sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-version": "^6.0.0",
+        "semver": "^7.5.3",
+        "semver-truncate": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/binary-extensions": {
@@ -3931,6 +5246,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -4083,44 +5427,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/clamscan": {
@@ -4454,13 +5760,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4638,6 +5937,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -4682,6 +6010,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+      "integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -4985,6 +6336,48 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5418,6 +6811,37 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -5509,6 +6933,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.28.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/eyes": {
@@ -5643,6 +7094,13 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5664,6 +7122,54 @@
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.1"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -5751,6 +7257,22 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver-regex": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5859,6 +7381,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
       }
     },
     "node_modules/forwarded": {
@@ -6046,6 +7578,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -6062,6 +7607,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/getopts": {
@@ -6145,6 +7703,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -6303,6 +7887,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6357,6 +7948,30 @@
         }
       }
     },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6398,13 +8013,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -6476,6 +8084,16 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/inspect-with-kind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
+      "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7191,8 +8809,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -7311,9 +8928,18 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/knex": {
@@ -7640,6 +9266,19 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7688,13 +9327,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7730,6 +9362,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7794,6 +9433,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -7877,6 +9539,31 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -7917,6 +9604,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mocha/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -7928,6 +9628,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/mocha/node_modules/string-width": {
@@ -8143,82 +9856,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nodemon": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
-      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -8249,6 +9886,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-all": {
@@ -8450,6 +10100,19 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc": {
@@ -8726,6 +10389,22 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-default-setter": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-9.3.1.tgz",
@@ -8883,6 +10562,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -9081,6 +10770,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.13.1",
@@ -9306,6 +11002,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.2.tgz",
+      "integrity": "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@napi-rs/nice": "^1.0.1"
       }
     },
     "node_modules/pkg-dir": {
@@ -9598,13 +11304,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9657,6 +11356,19 @@
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/rambda": {
       "version": "7.5.0",
@@ -9824,19 +11536,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -9956,6 +11655,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -9965,6 +11671,32 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -10163,6 +11895,30 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/seek-bzip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+      "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.0.0"
+      },
+      "bin": {
+        "seek-bunzip": "bin/seek-bunzip",
+        "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/seek-bzip/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -10173,6 +11929,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semver-truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-3.0.0.tgz",
+      "integrity": "sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/send": {
@@ -10454,19 +12239,6 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sinon": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
@@ -10497,6 +12269,52 @@
         "sinon": ">=4.0.0"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10505,17 +12323,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawn-wrap": {
@@ -10885,6 +12692,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-3.0.0.tgz",
+      "integrity": "sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inspect-with-kind": "^1.0.5",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "node_modules/strip-dirs/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10903,6 +12741,23 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -11066,6 +12921,13 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -11073,6 +12935,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -11096,14 +13006,23 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/triple-beam": {
@@ -11134,169 +13053,31 @@
       "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
       "license": "MIT"
     },
-    "node_modules/ts-mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.0.0.tgz",
-      "integrity": "sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ts-node": "7.0.1"
-      },
-      "bin": {
-        "ts-mocha": "bin/ts-mocha"
-      },
-      "engines": {
-        "node": ">= 6.X.X"
-      },
-      "optionalDependencies": {
-        "tsconfig-paths": "^3.5.0"
-      },
-      "peerDependencies": {
-        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-ssh": {
       "version": "4.1.6",
@@ -11510,6 +13291,19 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -11529,12 +13323,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -11626,13 +13424,6 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12191,14 +13982,28 @@
         "node": ">=6"
       }
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+    "node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": "*"
       }
     },
     "node_modules/yocto-queue": {

--- a/api/package.json
+++ b/api/package.json
@@ -3,25 +3,26 @@
   "version": "0.0.0",
   "description": "API for SIMS Web App",
   "license": "Apache-2.0",
+  "type": "module",
   "main": "app",
   "repository": {
     "type": "git",
     "url": "https://github.com/bcgov/biohubbc.git"
   },
   "scripts": {
-    "start": "ts-node src/app",
+    "start": "tsx src/app.ts",
     "typecheck": "tsc --project tsconfig.production.json",
-    "build": "tsc --project tsconfig.production.json",
-    "start-reload": "./node_modules/.bin/nodemon src/app.ts --exec ts-node",
-    "test": "mocha",
-    "test-watch": "mocha --watch",
-    "coverage": "nyc mocha",
+    "build": "swc src --out-dir dist --strip-leading-paths && node ./scripts/add-js-extensions.mjs",
+    "start-reload": "tsx watch src/app.ts",
+    "test": "TSX_TSCONFIG_PATH=tsconfig.mocha.json node --import tsx ./node_modules/mocha/bin/mocha.js",
+    "test-watch": "TSX_TSCONFIG_PATH=tsconfig.mocha.json node --import tsx ./node_modules/mocha/bin/mocha.js --watch",
+    "coverage": "TSX_TSCONFIG_PATH=tsconfig.mocha.json nyc node --import tsx ./node_modules/mocha/bin/mocha.js",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "format": "prettier --log-level=warn --check \"./src/**/*.{js,jsx,ts,tsx,css,scss}\"",
     "format-fix": "prettier --log-level=warn --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss}\"",
     "fix": "npm-run-all -l -s lint-fix format-fix",
-    "telemetry-cronjob": "node src/cronjobs/telemetry/index"
+    "telemetry-cronjob": "tsx src/cronjobs/telemetry/index.ts"
   },
   "engines": {
     "node": ">= 20.0.0",
@@ -99,15 +100,15 @@
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-prettier": "^5.2.5",
     "mocha": "^10.4.0",
-    "nodemon": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^3.5.3",
     "prettier-plugin-organize-imports": "^4.1.0",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
-    "ts-mocha": "^10.0.0",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
+    "@swc/cli": "^0.7.8",
+    "@swc/core": "^1.13.5",
     "typescript-eslint": "^8.28.0"
   }
 }

--- a/api/scripts/add-js-extensions.mjs
+++ b/api/scripts/add-js-extensions.mjs
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const distDir = new URL('../dist', import.meta.url);
+
+const needsJsExtension = (specifier) => {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return false;
+  }
+
+  return path.extname(specifier) === '';
+};
+
+const patchImports = (content) => {
+  const rewrite = (_, prefix, specifier, suffix) => {
+    if (!needsJsExtension(specifier)) {
+      return `${prefix}${specifier}${suffix}`;
+    }
+
+    return `${prefix}${specifier}.js${suffix}`;
+  };
+
+  const importExportPattern = /((?:from|import)\s*['"])([^'"]+)(['"])/g;
+  const dynamicImportPattern = /((?:import\s*\(\s*['"]))([^'"]+)(['"]\s*\))/g;
+
+  return content.replace(importExportPattern, rewrite).replace(dynamicImportPattern, rewrite);
+};
+
+const walk = async (dir) => {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      await walk(fullPath);
+      continue;
+    }
+
+    if (!entry.isFile() || !entry.name.endsWith('.js')) {
+      continue;
+    }
+
+    const original = await fs.readFile(fullPath, 'utf8');
+    const updated = patchImports(original);
+
+    if (updated !== original) {
+      await fs.writeFile(fullPath, updated, 'utf8');
+    }
+  }
+};
+
+await walk(distDir.pathname);

--- a/api/scripts/add-js-extensions.mjs
+++ b/api/scripts/add-js-extensions.mjs
@@ -2,13 +2,21 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const distDir = new URL('../dist', import.meta.url);
+const runtimeExtensions = new Set(['.js', '.mjs', '.cjs', '.json', '.node']);
 
 const needsJsExtension = (specifier) => {
-  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+  const isRelative = specifier.startsWith('./') || specifier.startsWith('../');
+  // dayjs ships plugins as files under node_modules; Node ESM needs explicit ".js".
+  const isDayjsPlugin = specifier.startsWith('dayjs/plugin/');
+
+  if (!isRelative && !isDayjsPlugin) {
     return false;
   }
 
-  return path.extname(specifier) === '';
+  // Treat only real Node-resolvable runtime extensions as complete.
+  // Specifiers like "./foo.interface" still need ".js" appended.
+  const currentExtension = path.extname(specifier);
+  return !runtimeExtensions.has(currentExtension);
 };
 
 const patchImports = (content) => {

--- a/api/src/__mocks__/db.ts
+++ b/api/src/__mocks__/db.ts
@@ -1,8 +1,7 @@
 import { Request, Response } from 'express';
 import { PoolClient, QueryResult } from 'pg';
 import sinon from 'sinon';
-import * as db from '../database/db';
-import { IDBConnection } from '../database/db';
+import { dbDependencies as db, IDBConnection } from '../database/db';
 
 /**
  * Registers and returns a mock `IDBConnection` with empty methods.

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,7 +4,7 @@ import multer from 'multer';
 import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 import swaggerUIExperss from 'swagger-ui-express';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { getDefaultPoolConfig, initDBPool } from './database/db';
 import { ensureHTTPError, HTTP400, HTTP500 } from './errors/http-error';
 import {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,6 +4,7 @@ import multer from 'multer';
 import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 import swaggerUIExperss from 'swagger-ui-express';
+import { fileURLToPath } from 'url';
 import { getDefaultPoolConfig, initDBPool } from './database/db';
 import { ensureHTTPError, HTTP400, HTTP500 } from './errors/http-error';
 import {
@@ -22,6 +23,8 @@ import { getLogger } from './utils/logger';
 loadEnvironmentVariables();
 
 const defaultLog = getLogger('app');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const HOST = process.env.API_HOST;
 const PORT = process.env.API_PORT;

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,10 +1,10 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { initialize } from 'express-openapi';
 import multer from 'multer';
+import { fileURLToPath } from 'node:url';
 import { OpenAPIV3 } from 'openapi-types';
 import path from 'path';
 import swaggerUIExperss from 'swagger-ui-express';
-import { fileURLToPath } from 'node:url';
 import { getDefaultPoolConfig, initDBPool } from './database/db';
 import { ensureHTTPError, HTTP400, HTTP500 } from './errors/http-error';
 import {

--- a/api/src/cronjobs/telemetry/cronjob.test.ts
+++ b/api/src/cronjobs/telemetry/cronjob.test.ts
@@ -2,10 +2,10 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { TelemetryLotekService } from '../../services/telemetry-services/telemetry-lotek-service';
 import { TelemetryVectronicService } from '../../services/telemetry-services/telemetry-vectronic-service';
-import * as cronjob from './cronjob';
+import { telemetryCronjobDependencies as cronjob, telemetryCronjob } from './cronjob';
 
 chai.use(sinonChai);
 
@@ -45,7 +45,7 @@ describe('Telemetry Cronjob', () => {
       lotekProcessStub.resolves([{ task: { serial: 1 }, value: { new: 1, created: 1 } }]);
       vectronicProcessStub.resolves([{ task: { serial: 1, key: 'test-collar-key' }, value: { new: 1, created: 1 } }]);
 
-      await cronjob.telemetryCronjob();
+      await telemetryCronjob();
 
       expect(mockConnection.open).to.have.been.calledOnceWithExactly({ transaction: false });
 
@@ -88,7 +88,7 @@ describe('Telemetry Cronjob', () => {
       sinon.stub(TelemetryLotekService.prototype, 'fetchDevicesFromLotek').rejects('failed');
 
       try {
-        await cronjob.telemetryCronjob();
+        await telemetryCronjob();
         expect.fail();
       } catch (_error) {
         expect(mockConnection.open).to.have.been.calledOnce;

--- a/api/src/cronjobs/telemetry/cronjob.ts
+++ b/api/src/cronjobs/telemetry/cronjob.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'util';
 import { z } from 'zod';
-import { getAPIUserDBConnection, getDefaultPoolConfig, initDBPool } from '../../database/db';
+import { dbDependencies } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';
 import { TelemetryLotekService } from '../../services/telemetry-services/telemetry-lotek-service';
 import { TelemetryVectronicService } from '../../services/telemetry-services/telemetry-vectronic-service';
@@ -44,12 +44,12 @@ const PROCESS_ALL_DEVICES = -1;
  */
 export async function telemetryCronjob() {
   // 0. SETUP - Parse CLI arguments, initialize the database and get a connection
-  const args = parseArguments();
+  const args = telemetryCronjobDependencies.parseArguments();
   defaultLog.info({ message: 'Cronjob starting.', args });
 
-  initDBPool(getDefaultPoolConfig());
+  dbDependencies.initDBPool(dbDependencies.getDefaultPoolConfig());
 
-  const connection = getAPIUserDBConnection();
+  const connection = dbDependencies.getAPIUserDBConnection();
 
   try {
     await connection.open({ transaction: false }); // Open a non-transaction database connection
@@ -179,4 +179,8 @@ export const parseArguments = () => {
     })
     .strict()
     .parse(parsedArgs.values);
+};
+
+export const telemetryCronjobDependencies = {
+  parseArguments
 };

--- a/api/src/database/db-utils.ts
+++ b/api/src/database/db-utils.ts
@@ -1,4 +1,4 @@
-import { DatabaseError } from 'pg';
+import pg from 'pg';
 import { z } from 'zod';
 import { SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { ApiExecuteSQLError } from '../errors/api-error';
@@ -9,6 +9,8 @@ import {
   isServiceClientUserInformation,
   KeycloakUserInformation
 } from '../utils/keycloak-utils';
+
+const { DatabaseError } = pg;
 
 /**
  * A type for a set of generic keycloak user information properties.

--- a/api/src/database/db.test.ts
+++ b/api/src/database/db.test.ts
@@ -7,8 +7,8 @@ import { SOURCE_SYSTEM, SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { ApiExecuteSQLError } from '../errors/api-error';
 import { HTTPError } from '../errors/http-error';
 import { DatabaseUserInformation, IdirUserInformation, KeycloakUserInformation } from '../utils/keycloak-utils';
-import * as db from './db';
 import {
+  dbDependencies as db,
   getAPIUserDBConnection,
   getDBConnection,
   getDBPool,
@@ -362,7 +362,7 @@ describe('db', () => {
     it('returns a Knex instance', () => {
       const knex = getKnex();
 
-      expect(knex.client.config).to.eql({ client: db.DB_CLIENT });
+      expect(knex.client.config).to.eql({ client: 'pg' });
     });
   });
 });

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -27,6 +27,7 @@ const getDbDatabase = () => process.env.DB_DATABASE;
 const DB_POOL_SIZE = 20;
 const DB_CONNECTION_TIMEOUT = 0;
 const DB_IDLE_TIMEOUT = 10000;
+const pgModule = (pg as any).default ?? pg;
 
 export const DB_CLIENT = 'pg';
 
@@ -52,21 +53,21 @@ export const getDefaultPoolConfig = (): pg.PoolConfig => ({
 // This Can lead to unexpected behavior when the original psql `DATE` value was intentionally omitting time/zone information.
 // PSQL date types: https://www.postgresql.org/docs/12/datatype-datetime.html
 // node-postgres type handling (see bottom of page): https://node-postgres.com/features/types
-pg.types.setTypeParser(pg.types.builtins.DATE, (stringValue: string) => {
+pgModule.types.setTypeParser(pgModule.types.builtins.DATE, (stringValue: string) => {
   return stringValue; // 1082 for `DATE` type
 });
 
 // Adding a TIMESTAMP type parser to keep all dates used in the system consistent
-pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (stringValue: string) => {
+pgModule.types.setTypeParser(pgModule.types.builtins.TIMESTAMP, (stringValue: string) => {
   return stringValue; // 1082 for `TIMESTAMP` type
 });
 // Adding a TIMESTAMPTZ type parser to keep all dates used in the system consistent
-pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (stringValue: string) => {
+pgModule.types.setTypeParser(pgModule.types.builtins.TIMESTAMPTZ, (stringValue: string) => {
   return stringValue; // 1082 for `DATE` type
 });
 // NUMERIC column types return as strings to maintain precision. Converting this to a float so it is usable by the system
 // Explanation of why Numeric returns as a string: https://github.com/brianc/node-postgres/issues/811
-pg.types.setTypeParser(pg.types.builtins.NUMERIC, (stringValue: string) => {
+pgModule.types.setTypeParser(pgModule.types.builtins.NUMERIC, (stringValue: string) => {
   return parseFloat(stringValue);
 });
 
@@ -81,7 +82,7 @@ let DBPool: pg.Pool | undefined;
  *
  * @param {pg.PoolConfig} poolConfig
  */
-export const initDBPool = function (poolConfig: pg.PoolConfig): void {
+const initDBPoolCore = function (poolConfig: pg.PoolConfig): void {
   if (DBPool) {
     // the pool has already been initialized, do nothing
     return;
@@ -90,7 +91,7 @@ export const initDBPool = function (poolConfig: pg.PoolConfig): void {
   defaultLog.debug({ label: 'create db pool', message: 'pool config', poolConfig: { ...poolConfig, password: '***' } });
 
   try {
-    DBPool = new pg.Pool(poolConfig);
+    DBPool = new pgModule.Pool(poolConfig);
   } catch (error) {
     defaultLog.error({ label: 'create db pool', message: 'failed to create db pool', error });
     process.exit(1);
@@ -104,7 +105,7 @@ export const initDBPool = function (poolConfig: pg.PoolConfig): void {
  *
  * @return {*}  {(pg.Pool | undefined)}
  */
-export const getDBPool = function (): pg.Pool | undefined {
+const getDBPoolCore = function (): pg.Pool | undefined {
   return DBPool;
 };
 
@@ -240,7 +241,7 @@ export interface IDBConnection {
  * @param {object} keycloakToken
  * @return {*} {IDBConnection}
  */
-export const getDBConnection = function (keycloakToken?: KeycloakUserInformation): IDBConnection {
+const getDBConnectionCore = function (keycloakToken?: KeycloakUserInformation): IDBConnection {
   if (!keycloakToken) {
     throw Error('Keycloak token is undefined');
   }
@@ -629,7 +630,7 @@ export const getDBConnection = function (keycloakToken?: KeycloakUserInformation
  * @param {SOURCE_SYSTEM} sourceSystem
  * @return {*}  {IDBConnection}
  */
-export const getServiceClientDBConnection = (sourceSystem: SOURCE_SYSTEM): IDBConnection => {
+const getServiceClientDBConnectionCore = (sourceSystem: SOURCE_SYSTEM): IDBConnection => {
   return getDBConnection({
     database_user_guid: sourceSystem,
     identity_provider: SYSTEM_IDENTITY_SOURCE.SYSTEM.toLowerCase(),
@@ -648,7 +649,7 @@ export const getServiceClientDBConnection = (sourceSystem: SOURCE_SYSTEM): IDBCo
  *
  * @return {*}  {IDBConnection}
  */
-export const getAPIUserDBConnection = (): IDBConnection => {
+const getAPIUserDBConnectionCore = (): IDBConnection => {
   return getDBConnection({
     database_user_guid: getDbUsername(),
     identity_provider: SYSTEM_IDENTITY_SOURCE.DATABASE.toLowerCase(),
@@ -668,4 +669,37 @@ export const getKnex = <TRecord extends Record<string, any> = any, TResult = Rec
   TResult
 > => {
   return knex<TRecord, TResult>({ client: DB_CLIENT });
+};
+
+export const initDBPool = function (poolConfig: pg.PoolConfig): void {
+  return dbDependencies.initDBPool(poolConfig);
+};
+
+export const getDBPool = function (): pg.Pool | undefined {
+  return dbDependencies.getDBPool();
+};
+
+export const getDBConnection = function (keycloakToken?: KeycloakUserInformation): IDBConnection {
+  return dbDependencies.getDBConnection(keycloakToken);
+};
+
+export const getServiceClientDBConnection = (sourceSystem: SOURCE_SYSTEM): IDBConnection => {
+  return dbDependencies.getServiceClientDBConnection(sourceSystem);
+};
+
+export const getAPIUserDBConnection = (): IDBConnection => {
+  return dbDependencies.getAPIUserDBConnection();
+};
+
+/**
+ * Mutable seam object for tests that need to stub db dependencies under ESM.
+ */
+export const dbDependencies = {
+  getDBConnection: getDBConnectionCore,
+  initDBPool: initDBPoolCore,
+  getDBPool: getDBPoolCore,
+  getServiceClientDBConnection: getServiceClientDBConnectionCore,
+  getAPIUserDBConnection: getAPIUserDBConnectionCore,
+  getKnex,
+  getDefaultPoolConfig
 };

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -19,7 +19,7 @@ import { asyncErrorWrapper, getGenericizedKeycloakUserInformation, syncErrorWrap
 const defaultLog = getLogger('database/db');
 
 const getDbHost = () => process.env.DB_HOST;
-const getDbPort = () => process.env.DB_PORT;
+const getDbPort = () => Number(process.env.DB_PORT);
 const getDbUsername = () => process.env.DB_USER_API;
 const getDbPassword = () => process.env.DB_USER_API_PASS;
 const getDbDatabase = () => process.env.DB_DATABASE;
@@ -28,6 +28,7 @@ const DB_POOL_SIZE = 20;
 const DB_CONNECTION_TIMEOUT = 0;
 const DB_IDLE_TIMEOUT = 10000;
 const pgModule = (pg as any).default ?? pg;
+const DB_POOL_GLOBAL_KEY = '__sims_db_pool__';
 
 export const DB_CLIENT = 'pg';
 
@@ -72,11 +73,11 @@ pgModule.types.setTypeParser(pgModule.types.builtins.NUMERIC, (stringValue: stri
 });
 
 const getStoredDBPool = (): pg.Pool | undefined => {
-  return (globalThis as any).DBPool;
+  return (globalThis as any)[DB_POOL_GLOBAL_KEY];
 };
 
 const setStoredDBPool = (pool: pg.Pool | undefined): void => {
-  (globalThis as any).DBPool = pool;
+  (globalThis as any)[DB_POOL_GLOBAL_KEY] = pool;
 };
 
 /**

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -71,8 +71,13 @@ pgModule.types.setTypeParser(pgModule.types.builtins.NUMERIC, (stringValue: stri
   return parseFloat(stringValue);
 });
 
-// singleton pg pool instance used by the api
-let DBPool: pg.Pool | undefined;
+const getStoredDBPool = (): pg.Pool | undefined => {
+  return (globalThis as any).DBPool;
+};
+
+const setStoredDBPool = (pool: pg.Pool | undefined): void => {
+  (globalThis as any).DBPool = pool;
+};
 
 /**
  * Initializes the singleton pg pool instance used by the api.
@@ -83,7 +88,7 @@ let DBPool: pg.Pool | undefined;
  * @param {pg.PoolConfig} poolConfig
  */
 const initDBPoolCore = function (poolConfig: pg.PoolConfig): void {
-  if (DBPool) {
+  if (getStoredDBPool()) {
     // the pool has already been initialized, do nothing
     return;
   }
@@ -91,7 +96,7 @@ const initDBPoolCore = function (poolConfig: pg.PoolConfig): void {
   defaultLog.debug({ label: 'create db pool', message: 'pool config', poolConfig: { ...poolConfig, password: '***' } });
 
   try {
-    DBPool = new pgModule.Pool(poolConfig);
+    setStoredDBPool(new pgModule.Pool(poolConfig));
   } catch (error) {
     defaultLog.error({ label: 'create db pool', message: 'failed to create db pool', error });
     process.exit(1);
@@ -106,7 +111,7 @@ const initDBPoolCore = function (poolConfig: pg.PoolConfig): void {
  * @return {*}  {(pg.Pool | undefined)}
  */
 const getDBPoolCore = function (): pg.Pool | undefined {
-  return DBPool;
+  return getStoredDBPool();
 };
 
 export interface IDBConnection {

--- a/api/src/errors/http-error.test.ts
+++ b/api/src/errors/http-error.test.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { DatabaseError } from 'pg';
+import pg from 'pg';
 import { ApiError, ApiErrorType } from './api-error';
 import { ensureHTTPError, HTTP400, HTTP401, HTTP403, HTTP409, HTTP500, HTTPError, isAjvError } from './http-error';
+
+const { DatabaseError } = pg;
 
 describe('HTTPError', () => {
   describe('No error value provided', () => {

--- a/api/src/errors/http-error.ts
+++ b/api/src/errors/http-error.ts
@@ -1,7 +1,9 @@
-import { DatabaseError } from 'pg';
+import pg from 'pg';
 import { CSVError } from '../utils/csv-utils/csv-config-validation.interface';
 import { ApiConflictError, ApiError } from './api-error';
 import { BaseError } from './base-error';
+
+const { DatabaseError } = pg;
 
 export enum HTTPErrorType {
   BAD_REQUEST = 'Bad Request',

--- a/api/src/middleware/critterbase-proxy.test.ts
+++ b/api/src/middleware/critterbase-proxy.test.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { Request } from 'express';
 import sinon from 'sinon';
-import * as CritterbaseProxy from './critterbase-proxy';
-import { proxyFilter } from './critterbase-proxy';
+import { critterbaseProxyDependencies as CritterbaseProxy, proxyFilter } from './critterbase-proxy';
 
 describe('CritterbaseProxy', () => {
   describe('proxyFilter', () => {

--- a/api/src/middleware/critterbase-proxy.ts
+++ b/api/src/middleware/critterbase-proxy.ts
@@ -39,12 +39,12 @@ export const proxyFilter = (pathname: string, req: Request) => {
   const origin = (req.headers.origin ?? '').replace('https://', '');
 
   // Reject requests NOT coming directly from SIMS APP / frontend.
-  if (origin !== getSimsAppHost()) {
+  if (origin !== critterbaseProxyDependencies.getSimsAppHost()) {
     defaultLog.debug({
       label: 'proxyFilter',
       message: `${req.method} ${pathname} -> Invalid origin`,
       requestOrigin: req.headers.origin,
-      allowedOrigin: getSimsAppHost()
+      allowedOrigin: critterbaseProxyDependencies.getSimsAppHost()
     });
 
     return false;
@@ -84,6 +84,10 @@ export const proxyFilter = (pathname: string, req: Request) => {
  */
 export const getSimsAppHost = () => {
   return (process.env.APP_HOST as string).replace('https://', '');
+};
+
+export const critterbaseProxyDependencies = {
+  getSimsAppHost
 };
 
 /**

--- a/api/src/paths/administrative-activities.test.ts
+++ b/api/src/paths/administrative-activities.test.ts
@@ -5,7 +5,7 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../__mocks__/db';
-import * as db from '../database/db';
+import { dbDependencies as db } from '../database/db';
 import { GET, getAdministrativeActivities } from './administrative-activities';
 
 chai.use(sinonChai);

--- a/api/src/paths/administrative-activity.test.ts
+++ b/api/src/paths/administrative-activity.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../__mocks__/db';
-import * as db from '../database/db';
+import { dbDependencies as db } from '../database/db';
 import { HTTPError } from '../errors/http-error';
 import {
   IAdministrativeActivityStanding,

--- a/api/src/paths/administrative-activity/system-access/{administrativeActivityId}/approve.test.ts
+++ b/api/src/paths/administrative-activity/system-access/{administrativeActivityId}/approve.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { ADMINISTRATIVE_ACTIVITY_STATUS_TYPE } from '../../../../constants/administrative-activity';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { SystemUserWithRoles } from '../../../../models/system-user-view';
 import { AdministrativeActivityService } from '../../../../services/administrative-activity-service';
 import { UserService } from '../../../../services/user-service';

--- a/api/src/paths/administrative-activity/system-access/{administrativeActivityId}/reject.test.ts
+++ b/api/src/paths/administrative-activity/system-access/{administrativeActivityId}/reject.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { ADMINISTRATIVE_ACTIVITY_STATUS_TYPE } from '../../../../constants/administrative-activity';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { AdministrativeActivityService } from '../../../../services/administrative-activity-service';
 import * as reject_request from './reject';
 

--- a/api/src/paths/alert/index.test.ts
+++ b/api/src/paths/alert/index.test.ts
@@ -6,7 +6,7 @@ import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db'
 import { SYSTEM_IDENTITY_SOURCE } from '../../constants/database';
 import { SYSTEM_ROLE } from '../../constants/roles';
 import { AlertSeverity } from '../../database-units/alert_severity';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { AlertRecordWithStatus } from '../../models/alert-view';
 import { AlertService } from '../../services/alert-service';

--- a/api/src/paths/alert/{alertId}/index.test.ts
+++ b/api/src/paths/alert/{alertId}/index.test.ts
@@ -7,7 +7,7 @@ import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/
 import { SYSTEM_IDENTITY_SOURCE } from '../../../constants/database';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { AlertSeverity } from '../../../database-units/alert_severity';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { AlertRecordWithStatus } from '../../../models/alert-view';
 import { AlertService } from '../../../services/alert-service';

--- a/api/src/paths/analytics/observations.test.ts
+++ b/api/src/paths/analytics/observations.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { ObservationAnalyticsResponse } from '../../models/observation-analytics';
 import { AnalyticsService } from '../../services/analytics-service';

--- a/api/src/paths/animal/index.test.ts
+++ b/api/src/paths/animal/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindCrittersResponse, SurveyCritterService } from '../../services/survey-critter-service';
 import { KeycloakUserInformation } from '../../utils/keycloak-utils';

--- a/api/src/paths/codes.test.ts
+++ b/api/src/paths/codes.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../__mocks__/db';
-import * as db from '../database/db';
+import { dbDependencies as db } from '../database/db';
 import { HTTPError } from '../errors/http-error';
 import { CodeService } from '../services/code-service';
 import { KeycloakUserInformation } from '../utils/keycloak-utils';

--- a/api/src/paths/funding-sources/index.test.ts
+++ b/api/src/paths/funding-sources/index.test.ts
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../constants/database';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { SystemUserWithRoles } from '../../models/system-user-view';
 import { FundingSource, FundingSourceSupplementaryData } from '../../repositories/funding-source-repository';

--- a/api/src/paths/funding-sources/{fundingSourceId}.test.ts
+++ b/api/src/paths/funding-sources/{fundingSourceId}.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import {
   FundingSource,

--- a/api/src/paths/habitat-features/index.test.ts
+++ b/api/src/paths/habitat-features/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { SurveyHabitatFeatureWithTaxonsAndSampling } from '../../repositories/habitat-feature-repository/survey-habitat-feature-repository.interface';
 import { SurveyHabitatFeatureService } from '../../services/habitat-feature-services/survey-habitat-feature-service';

--- a/api/src/paths/markdown/index.test.ts
+++ b/api/src/paths/markdown/index.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMarkdownByTypeName } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { MarkdownService } from '../../services/markdown-service';
 import { KeycloakUserInformation } from '../../utils/keycloak-utils';

--- a/api/src/paths/markdown/{markdownId}/index.test.ts
+++ b/api/src/paths/markdown/{markdownId}/index.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { MarkdownService } from '../../../services/markdown-service';
 import { KeycloakUserInformation } from '../../../utils/keycloak-utils';
 import { scoreMarkdown } from './index';

--- a/api/src/paths/observation/flattened/index.test.ts
+++ b/api/src/paths/observation/flattened/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../../constants/roles';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { FlattenedObservationRecordWithSamplingAndSubcountData } from '../../../repositories/observation-repository/observation-repository.interface';
 import { ObservationService } from '../../../services/observation-services/observation-service';

--- a/api/src/paths/observation/index.test.ts
+++ b/api/src/paths/observation/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { ObservationRecordWithSamplingAndSubcountData } from '../../repositories/observation-repository/observation-repository.interface';
 import { ObservationService } from '../../services/observation-services/observation-service';

--- a/api/src/paths/periods/index.test.ts
+++ b/api/src/paths/periods/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindSamplePeriodRecord } from '../../repositories/sample-period-repository';
 import { SamplePeriodService } from '../../services/sample-period-service';

--- a/api/src/paths/project/create.test.ts
+++ b/api/src/paths/project/create.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { ProjectService } from '../../services/project-service';
 import { createProject, POST } from './create';

--- a/api/src/paths/project/index.test.ts
+++ b/api/src/paths/project/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindProjectsResponse } from '../../models/project-view';
 import { ProjectService } from '../../services/project-service';

--- a/api/src/paths/project/{projectId}/attachments/list.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/list.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { AttachmentService } from '../../../../services/attachment-service';
 import * as list from './list';

--- a/api/src/paths/project/{projectId}/attachments/report/upload.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/report/upload.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../services/attachment-service';
-import * as file_utils from '../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../utils/file-utils';
 import * as upload from './upload';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/upload.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { AttachmentService } from '../../../../services/attachment-service';
-import * as file_utils from '../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../utils/file-utils';
 import * as upload from './upload';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/attachments/{attachmentId}/delete.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/{attachmentId}/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../services/attachment-service';
 import * as deleteAttachment from './delete';

--- a/api/src/paths/project/{projectId}/attachments/{attachmentId}/getSignedUrl.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/{attachmentId}/getSignedUrl.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../services/attachment-service';
-import * as file_utils from '../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../utils/file-utils';
 import * as get_signed_url from './getSignedUrl';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/attachments/{attachmentId}/metadata/get.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/{attachmentId}/metadata/get.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import {
   IProjectReportAttachment,

--- a/api/src/paths/project/{projectId}/attachments/{attachmentId}/metadata/update.test.ts
+++ b/api/src/paths/project/{projectId}/attachments/{attachmentId}/metadata/update.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../services/attachment-service';
 import * as update_project_metadata from './update';

--- a/api/src/paths/project/{projectId}/delete.test.ts
+++ b/api/src/paths/project/{projectId}/delete.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../../constants/roles';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { ProjectService } from '../../../services/project-service';
 import * as delete_project from './delete';

--- a/api/src/paths/project/{projectId}/participants/index.test.ts
+++ b/api/src/paths/project/{projectId}/participants/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../../constants/database';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { ProjectParticipationService } from '../../../../services/project-participation-service';
 import { UserService } from '../../../../services/user-service';

--- a/api/src/paths/project/{projectId}/participants/self.test.ts
+++ b/api/src/paths/project/{projectId}/participants/self.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../../constants/database';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { ProjectParticipationService } from '../../../../services/project-participation-service';
 import { getSelf } from './self';

--- a/api/src/paths/project/{projectId}/participants/{projectParticipationId}.test.ts
+++ b/api/src/paths/project/{projectId}/participants/{projectParticipationId}.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../../constants/database';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { ProjectParticipationRepository } from '../../../../repositories/project-participation-repository';
 import { ProjectParticipationService } from '../../../../services/project-participation-service';

--- a/api/src/paths/project/{projectId}/survey/create.test.ts
+++ b/api/src/paths/project/{projectId}/survey/create.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { SurveyService } from '../../../../services/survey-service';
 import { createSurvey } from './create';

--- a/api/src/paths/project/{projectId}/survey/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getSurveys } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { SurveyService } from '../../../../services/survey-service';
 import { KeycloakUserInformation } from '../../../../utils/keycloak-utils';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/list.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/list.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../services/attachment-service';
 import * as list from './list';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/report/upload.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../../services/attachment-service';
-import * as file_utils from '../../../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../../../utils/file-utils';
 import * as upload from './upload';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/telemetry/index.test.ts
@@ -5,12 +5,12 @@ import sinonChai from 'sinon-chai';
 import { getSurveyTelemetryCredentialAttachments, postSurveyTelemetryCredentialAttachment } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
 import { TELEMETRY_CREDENTIAL_ATTACHMENT_ERROR_STRING } from '../../../../../../../constants/attachments';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { SurveyTelemetryCredentialAttachment } from '../../../../../../../repositories/attachment-repository';
 import { AttachmentService } from '../../../../../../../services/attachment-service';
 import { TelemetryVectronicService } from '../../../../../../../services/telemetry-services/telemetry-vectronic-service';
-import * as file_utils from '../../../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../../../utils/file-utils';
 import { KeycloakUserInformation } from '../../../../../../../utils/keycloak-utils';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/upload.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../services/attachment-service';
-import * as file_utils from '../../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../../utils/file-utils';
 import * as upload from './upload';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../../services/attachment-service';
 import * as deleteAttachment from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/getSignedUrl.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/getSignedUrl.test.ts
@@ -3,10 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../../services/attachment-service';
-import * as file_utils from '../../../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../../../utils/file-utils';
 import * as get_signed_url from './getSignedUrl';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/get.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/get.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../../errors/http-error';
 import {
   ISurveyReportAttachment,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/update.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/attachments/{attachmentId}/metadata/update.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../../errors/http-error';
 import { AttachmentService } from '../../../../../../../../services/attachment-service';
 import * as update_survey_metadata from './update';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/captures/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/captures/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../../errors/http-error';
 import { ImportCapturesService } from '../../../../../../../services/import-services/capture/import-captures-service';
 import { importCaptureCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/delete.test.ts
@@ -2,7 +2,7 @@ import Ajv from 'ajv';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { SurveyCritterService } from '../../../../../../services/survey-critter-service';
 import { POST, removeCrittersFromSurvey } from './delete';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { ImportCrittersService } from '../../../../../../services/import-services/critter/import-critters-service';
 import { importCritterCSV } from './import';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { addCritterToSurvey, getCrittersFromSurvey } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { CritterbaseService, ICritter } from '../../../../../../services/critterbase-service';
 import { SurveyCritterService } from '../../../../../../services/survey-critter-service';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/measurements/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/measurements/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../../errors/http-error';
 import { ImportMeasurementsService } from '../../../../../../../services/import-services/measurement/import-measurements-service';
 import { importMeasurementCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/index.test.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { deleteCritterCaptureAttachments } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../../../database/db';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
-import * as S3 from '../../../../../../../../../../utils/file-utils';
+import { fileUtilsDependencies as S3 } from '../../../../../../../../../../utils/file-utils';
 
 describe('deleteCritterCaptureAttachments', () => {
   afterEach(() => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../../../database/db';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
-import * as S3 from '../../../../../../../../../../utils/file-utils';
+import { fileUtilsDependencies as S3 } from '../../../../../../../../../../utils/file-utils';
 import { uploadCaptureAttachments } from './upload';
 
 describe('uploadCaptureAttachments', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/captures/{critterbaseCaptureId}/attachments/upload.ts
@@ -5,7 +5,7 @@ import { getDBConnection } from '../../../../../../../../../../database/db';
 import { fileSchema } from '../../../../../../../../../../openapi/schemas/file';
 import { authorizeRequestHandler } from '../../../../../../../../../../request-handlers/security/authorization';
 import { CritterAttachmentService } from '../../../../../../../../../../services/critter-attachment-service';
-import { deleteFileFromS3, generateS3FileKey, uploadFileToS3 } from '../../../../../../../../../../utils/file-utils';
+import { fileUtilsDependencies } from '../../../../../../../../../../utils/file-utils';
 import { getLogger } from '../../../../../../../../../../utils/logger';
 
 const defaultLog = getLogger(
@@ -164,13 +164,13 @@ export function uploadCaptureAttachments(): RequestHandler {
         // Delete the attachments from the database and get the S3 keys
         const s3Keys = await critterAttachmentService.deleteCritterCaptureAttachments(surveyId, deleteIds);
         // Delete the files from S3 individually (using individual deletes to avoid Content-MD5 requirement)
-        await Promise.all(s3Keys.map((key) => deleteFileFromS3(key)));
+        await Promise.all(s3Keys.map((key) => fileUtilsDependencies.deleteFileFromS3(key)));
       }
 
       // Upload each file to S3 and store the file details in the database
       const uploadPromises = rawMediaFiles.map(async (file) => {
         // Generate the S3 key for the file - used only on new inserts
-        const s3Key = generateS3FileKey({
+        const s3Key = fileUtilsDependencies.generateS3FileKey({
           projectId: projectId,
           surveyId: surveyId,
           critterId: critterId,
@@ -188,7 +188,7 @@ export function uploadCaptureAttachments(): RequestHandler {
           key: s3Key
         });
 
-        await uploadFileToS3(file, upsertResult.key);
+        await fileUtilsDependencies.uploadFileToS3(file, upsertResult.key);
 
         return upsertResult.critter_capture_attachment_id;
       });

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/deployments/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { createDeployment } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { TelemetryDeploymentService } from '../../../../../../../../services/telemetry-services/telemetry-deployment-service';
 
 describe('createDeployment', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/critters/{critterId}/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { getSurveyCritter, updateSurveyCritter } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { CritterAttachmentService } from '../../../../../../../services/critter-attachment-service';
 import { CritterbaseService } from '../../../../../../../services/critterbase-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/delete.test.ts
@@ -4,12 +4,12 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { ISurveyAttachment } from '../../../../../repositories/attachment-repository';
 import { AttachmentService } from '../../../../../services/attachment-service';
 import { SurveyService } from '../../../../../services/survey-service';
-import * as file_utils from '../../../../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../../../../utils/file-utils';
 import * as del from './delete';
 
 chai.use(sinonChai);

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { TelemetryDeploymentService } from '../../../../../../services/telemetry-services/telemetry-deployment-service';
 import { deleteDeploymentsInSurvey } from './delete';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { getDeploymentsInSurvey } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { TelemetryDeploymentService } from '../../../../../../services/telemetry-services/telemetry-deployment-service';
 
 describe('getDeploymentsInSurvey', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { getTelemetryForDeployments } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { TelemetryVendorService } from '../../../../../../../services/telemetry-services/telemetry-vendor-service';
 
 describe('getTelemetryForDeployments', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/manual/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/manual/delete.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
 import { bulkDeleteManualTelemetry } from './delete';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/manual/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/telemetry/manual/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { bulkCreateManualTelemetry, bulkUpdateManualTelemetry } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
 
 describe('index', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/{deploymentId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/{deploymentId}/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { deleteDeployment, getDeploymentById, updateDeployment } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { TelemetryDeploymentService } from '../../../../../../../services/telemetry-services/telemetry-deployment-service';
 
 describe('getDeploymentById', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/{deploymentId}/telemetry/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/deployments/{deploymentId}/telemetry/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { getTelemetryForDeployment } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { TelemetryVendorService } from '../../../../../../../../services/telemetry-services/telemetry-vendor-service';
 
 describe('getTelemetryForDeployment', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/devices/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/devices/delete.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { TelemetryDeviceService } from '../../../../../../services/telemetry-services/telemetry-device-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../.././../../__mocks__/db';
 import { deleteDevices } from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/devices/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/devices/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../errors/http-error';
 import { ImportDeviceService } from '../../../../../../services/import-services/devices/import-device-service';
 import { importTelemetryDeviceCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/devices/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/devices/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { createDevice, getDevicesInSurvey } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { ApiError, ApiGeneralError } from '../../../../../../errors/api-error';
 import { TelemetryDeviceService } from '../../../../../../services/telemetry-services/telemetry-device-service';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/devices/{deviceId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/devices/{deviceId}/index.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { deleteDevice, getDevice, updateDevice } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { TelemetryDeviceService } from '../../../../../../../services/telemetry-services/telemetry-device-service';
 
 describe('getDevice', () => {

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/export/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/export/index.test.ts
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai';
 import { exportData } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../../../../../constants/roles';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { ExportService } from '../../../../../../services/export-services/export-service';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyHabitatFeatureService } from '../../../../../../services/habitat-feature-services/survey-habitat-feature-service';
 import { deleteSurveyHabitatFeatures } from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/import.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../errors/http-error';
 import { ImportHabitatFeaturesService } from '../../../../../../services/import-services/habitat-feature/import-habitat-features-service';
 import { importHabitatFeatureCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getSurveyHabitatFeatures, postSurveyHabitatFeatures } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyHabitatFeaturesWithSupplementaryData } from '../../../../../../repositories/habitat-feature-repository/survey-habitat-feature-repository.interface';
 import { SurveyHabitatFeatureService } from '../../../../../../services/habitat-feature-services/survey-habitat-feature-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/spatial.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/spatial.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyHabitatFeaturesGeometryWithSupplementaryData } from '../../../../../../repositories/habitat-feature-repository/survey-habitat-feature-repository.interface';
 import { SurveyHabitatFeatureService } from '../../../../../../services/habitat-feature-services/survey-habitat-feature-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/{surveyHabitatFeatureId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/habitat-features/{surveyHabitatFeatureId}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { deleteSurveyHabitatFeature, getSurveyHabitatFeature, putSurveyHabitatFeature } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { SurveyHabitatFeatureWithTaxonsAndSampling } from '../../../../../../../repositories/habitat-feature-repository/survey-habitat-feature-repository.interface';
 import { SurveyHabitatFeatureService } from '../../../../../../../services/habitat-feature-services/survey-habitat-feature-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { ObservationService } from '../../../../../../services/observation-services/observation-service';
 import { deleteSurveyObservations } from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/flattened/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/flattened/index.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { FlattenedObservationRecordWithSamplingAndSubcountData } from '../../../../../../../repositories/observation-repository/observation-repository.interface';
 import { ObservationService } from '../../../../../../../services/observation-services/observation-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/import.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../errors/http-error';
 import { ImportObservationsService } from '../../../../../../services/import-services/observation/import-observations-service';
 import { importObservationCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/index.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { ObservationRecordWithSamplingAndSubcountData } from '../../../../../../repositories/observation-repository/observation-repository.interface';
 import { ObservationService } from '../../../../../../services/observation-services/observation-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/spatial.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/spatial.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import {
   ObservationCountSupplementaryData,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/subcounts/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/subcounts/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { SubCountService } from '../../../../../../../services/subcount-service';
 import { deleteObservationSubcounts } from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/observations/taxon/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/observations/taxon/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getSurveyObservedSpecies } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { ObservationService } from '../../../../../../../services/observation-services/observation-service';
 import { PlatformService } from '../../../../../../../services/platform-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/participants/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/participants/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../../../../constants/database';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyParticipationService } from '../../../../../../services/survey-participation-service';
 import * as create_survey_participants from './index';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/participants/{surveyParticipationId}.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/participants/{surveyParticipationId}.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyParticipationService } from '../../../../../../services/survey-participation-service';
 import * as delete_survey_participant from './{surveyParticipationId}';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/publish/features.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { PlatformService } from '../../../../../../services/platform-service';
 import { SurveyService } from '../../../../../../services/survey-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SamplePeriodService } from '../../../../../../services/sample-period-service';
 import { deleteSamplePeriods } from './delete';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../errors/http-error';
 import { ImportSamplePeriodsService } from '../../../../../../services/import-services/sampling-periods/import-sample-periods-service';
 import { importSamplePeriodsCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { postSamplePeriods } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SamplePeriodService } from '../../../../../../services/sample-period-service';
 

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/{surveySamplePeriodId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-period/{surveySamplePeriodId}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getSamplePeriodById, updateSamplePeriod } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { SurveySamplePeriodDetails } from '../../../../../../../repositories/sample-period-repository';
 import { SamplePeriodService } from '../../../../../../../services/sample-period-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { ObservationService } from '../../../../../../services/observation-services/observation-service';
 import { SampleSiteService } from '../../../../../../services/sample-site-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/index.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SampleSiteService } from '../../../../../../services/sample-site-service';
 import * as create_survey_sample_site_record from './index';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/spatial.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/spatial.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SampleSiteService } from '../../../../../../services/sample-site-service';
 import { getSurveySampleSitesGeometry } from './spatial';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/sample-site/{surveySampleSiteId}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { deleteSurveySampleSiteRecord, getSurveySampleSite, updateSurveySampleSite } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { ObservationService } from '../../../../../../../services/observation-services/observation-service';
 import { SampleSiteService, UpdateSampleSiteObject } from '../../../../../../../services/sample-site-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/submission/{submissionId}/history.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/submission/{submissionId}/history.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { PlatformService } from '../../../../../../../services/platform-service';
 import { KeycloakUserInformation } from '../../../../../../../utils/keycloak-utils';
 import { GET, getSubmissionHistory } from './history';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/submission/{submissionId}/upload/{submissionUploadId}.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/submission/{submissionId}/upload/{submissionUploadId}.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../../database/db';
 import { PlatformService } from '../../../../../../../../services/platform-service';
 import { KeycloakUserInformation } from '../../../../../../../../utils/keycloak-utils';
 import { DELETE, deleteSubmissionUpload } from './{submissionUploadId}';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/technique/delete.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/technique/delete.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { ApiError } from '../../../../../../errors/api-error';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { TechniqueRepository } from '../../../../../../repositories/technique-repository';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/technique/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/technique/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { createTechniques, getTechniques } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { TechniqueObject } from '../../../../../../repositories/technique-repository';
 import { TechniqueService } from '../../../../../../services/technique-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/technique/{techniqueId}/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/technique/{techniqueId}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { deleteTechnique, getTechniqueById, updateTechnique } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../../__mocks__/db';
-import * as db from '../../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../../database/db';
 import { ApiError } from '../../../../../../../errors/api-error';
 import { HTTPError } from '../../../../../../../errors/http-error';
 import { AttractantService } from '../../../../../../../services/attractants-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/import.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/import.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTP422CSVValidationError } from '../../../../../../errors/http-error';
 import { ImportTelemetryService } from '../../../../../../services/import-services/telemetry/import-telemetry-service';
 import { importTelemetryCSV } from './import';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/index.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getTelemetryInSurvey } from '.';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import {
   Telemetry,
   TelemetrySupplementary,

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/spatial.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/telemetry/spatial.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import {
   TelemetrySpatial,
   TelemetrySupplementary

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/update.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/update.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { PutSurveyObject } from '../../../../../models/survey-update';
 import { SurveyService } from '../../../../../services/survey-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/update/get.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/update/get.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../../../../__mocks__/db';
-import * as db from '../../../../../../database/db';
+import { dbDependencies as db } from '../../../../../../database/db';
 import { HTTPError } from '../../../../../../errors/http-error';
 import { SurveyObject } from '../../../../../../models/survey-view';
 import { SurveyService } from '../../../../../../services/survey-service';

--- a/api/src/paths/project/{projectId}/survey/{surveyId}/view.test.ts
+++ b/api/src/paths/project/{projectId}/survey/{surveyId}/view.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
-import * as db from '../../../../../database/db';
+import { dbDependencies as db } from '../../../../../database/db';
 import { HTTPError } from '../../../../../errors/http-error';
 import { SurveyObject } from '../../../../../models/survey-view';
 import { SurveyService } from '../../../../../services/survey-service';

--- a/api/src/paths/project/{projectId}/update.test.ts
+++ b/api/src/paths/project/{projectId}/update.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { ProjectService } from '../../../services/project-service';
 import * as update from './update';

--- a/api/src/paths/project/{projectId}/view.test.ts
+++ b/api/src/paths/project/{projectId}/view.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { IGetProject } from '../../../models/project-view';
 import { ProjectService } from '../../../services/project-service';

--- a/api/src/paths/publish/attachment/resubmit.test.ts
+++ b/api/src/paths/publish/attachment/resubmit.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { GCNotifyService } from '../../../services/gcnotify-service';
 import { POST, resubmitAttachment } from './resubmit';

--- a/api/src/paths/publish/survey.test.ts
+++ b/api/src/paths/publish/survey.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { PlatformService } from '../../services/platform-service';
 import { SurveyService } from '../../services/survey-service';

--- a/api/src/paths/reference/get/vantage.test.ts
+++ b/api/src/paths/reference/get/vantage.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { VantageService } from '../../../services/vantage-mode-service';
 import { getVantageReferenceRecords } from './vantage';

--- a/api/src/paths/resources/list.test.ts
+++ b/api/src/paths/resources/list.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getRequestHandlerMocks } from '../../__mocks__/db';
 import { HTTPError } from '../../errors/http-error';
-import * as fileUtils from '../../utils/file-utils';
+import { fileUtilsDependencies as fileUtils } from '../../utils/file-utils';
 import { listResources } from './list';
 
 chai.use(sinonChai);

--- a/api/src/paths/sites/index.test.ts
+++ b/api/src/paths/sites/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindSampleSiteRecord } from '../../repositories/sample-site-repository/sample-site-repository';
 import { SampleSiteService } from '../../services/sample-site-service';

--- a/api/src/paths/spatial/regions.test.ts
+++ b/api/src/paths/spatial/regions.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { BcgwLayerService } from '../../services/bcgw-layer-service';
 import * as regions from './regions';

--- a/api/src/paths/standards/environment/index.test.ts
+++ b/api/src/paths/standards/environment/index.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { StandardsService } from '../../../services/standards-service';
 import { getEnvironmentStandards } from './index'; // Adjust the import path based on your file structure

--- a/api/src/paths/standards/methods/index.test.ts
+++ b/api/src/paths/standards/methods/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMethodStandards } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { StandardsService } from '../../../services/standards-service';
 

--- a/api/src/paths/standards/taxon/{tsn}/index.test.ts
+++ b/api/src/paths/standards/taxon/{tsn}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getSpeciesStandards } from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { CBMeasurementUnit } from '../../../../services/critterbase-service';
 import { StandardsService } from '../../../../services/standards-service';
 

--- a/api/src/paths/survey/index.test.ts
+++ b/api/src/paths/survey/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindSurveysResponse } from '../../models/survey-view';
 import { SurveyService } from '../../services/survey-service';

--- a/api/src/paths/techniques/index.test.ts
+++ b/api/src/paths/techniques/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { FindTechniqueRecord } from '../../repositories/technique-repository';
 import { TechniqueService } from '../../services/technique-service';

--- a/api/src/paths/telemetry/index.test.ts
+++ b/api/src/paths/telemetry/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_ROLE } from '../../constants/roles';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import {
   Telemetry,

--- a/api/src/paths/user/add.test.ts
+++ b/api/src/paths/user/add.test.ts
@@ -4,10 +4,11 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../constants/database';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { SystemUserWithRoles } from '../../models/system-user-view';
 import { UserService } from '../../services/user-service';
-import * as keycloakUtils from '../../utils/keycloak-utils';
+import type { KeycloakUserInformation } from '../../utils/keycloak-utils';
+import { keycloakUtilsDependencies as keycloakUtils } from '../../utils/keycloak-utils';
 import { addSystemRoleUser } from './add';
 
 chai.use(sinonChai);
@@ -26,7 +27,7 @@ describe('user', () => {
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
-      mockReq.keycloak_token = {} as keycloakUtils.KeycloakUserInformation;
+      mockReq.keycloak_token = {} as KeycloakUserInformation;
 
       mockReq.body = {
         userGuid: 'aaaa',
@@ -75,7 +76,7 @@ describe('user', () => {
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
-      mockReq.keycloak_token = {} as keycloakUtils.KeycloakUserInformation;
+      mockReq.keycloak_token = {} as KeycloakUserInformation;
 
       mockReq.body = {
         identitySource: SYSTEM_IDENTITY_SOURCE.IDIR,

--- a/api/src/paths/user/add.ts
+++ b/api/src/paths/user/add.ts
@@ -6,7 +6,7 @@ import { getDBConnection, getServiceClientDBConnection } from '../../database/db
 import { HTTP409 } from '../../errors/http-error';
 import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
 import { UserService } from '../../services/user-service';
-import { getKeycloakSource } from '../../utils/keycloak-utils';
+import { keycloakUtilsDependencies } from '../../utils/keycloak-utils';
 import { getLogger } from '../../utils/logger';
 import { getKeycloakTokenFromRequest } from '../../utils/request';
 
@@ -140,7 +140,7 @@ export function addSystemRoleUser(): RequestHandler {
 
     const keycloakToken = getKeycloakTokenFromRequest(req);
 
-    const sourceSystem = getKeycloakSource(keycloakToken);
+    const sourceSystem = keycloakUtilsDependencies.getKeycloakSource(keycloakToken);
 
     const connection = sourceSystem ? getServiceClientDBConnection(sourceSystem) : getDBConnection(keycloakToken);
 

--- a/api/src/paths/user/list.test.ts
+++ b/api/src/paths/user/list.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { UserService } from '../../services/user-service';
 import * as users from './list';
 

--- a/api/src/paths/user/self.test.ts
+++ b/api/src/paths/user/self.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
-import * as db from '../../database/db';
+import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { UserService } from '../../services/user-service';
 import { getSelf } from './self';

--- a/api/src/paths/user/{userId}/activate.test.ts
+++ b/api/src/paths/user/{userId}/activate.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { UserService } from '../../../services/user-service';
 import * as activate_endpoint from './activate';
 

--- a/api/src/paths/user/{userId}/deactivate.test.ts
+++ b/api/src/paths/user/{userId}/deactivate.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../constants/database';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { ProjectParticipationService } from '../../../services/project-participation-service';
 import { UserService } from '../../../services/user-service';

--- a/api/src/paths/user/{userId}/delete.test.ts
+++ b/api/src/paths/user/{userId}/delete.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
 import { SYSTEM_IDENTITY_SOURCE } from '../../../constants/database';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { HTTPError } from '../../../errors/http-error';
 import { ProjectParticipationService } from '../../../services/project-participation-service';
 import { UserService } from '../../../services/user-service';

--- a/api/src/paths/user/{userId}/get.test.ts
+++ b/api/src/paths/user/{userId}/get.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
-import * as db from '../../../database/db';
+import { dbDependencies as db } from '../../../database/db';
 import { UserService } from '../../../services/user-service';
 import * as user from './get';
 

--- a/api/src/paths/user/{userId}/projects/get.test.ts
+++ b/api/src/paths/user/{userId}/projects/get.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { ProjectParticipationService } from '../../../../services/project-participation-service';
 import * as projects from './get';

--- a/api/src/paths/user/{userId}/system-roles/update.test.ts
+++ b/api/src/paths/user/{userId}/system-roles/update.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
-import * as db from '../../../../database/db';
+import { dbDependencies as db } from '../../../../database/db';
 import { HTTPError } from '../../../../errors/http-error';
 import { UserService } from '../../../../services/user-service';
 import * as system_roles from './update';

--- a/api/src/request-handlers/security/authentication.ts
+++ b/api/src/request-handlers/security/authentication.ts
@@ -1,11 +1,12 @@
 import { Request } from 'express';
-import { decode, verify } from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { JwksClient } from 'jwks-rsa';
 import { HTTP401 } from '../../errors/http-error';
 import { KeycloakUserInformation } from '../../utils/keycloak-utils';
 import { getLogger } from '../../utils/logger';
 
 const defaultLog = getLogger('request-handlers/security/authentication');
+const { decode, verify } = jwt;
 
 const KEYCLOAK_URL = `${process.env.KEYCLOAK_HOST}/realms/${process.env.KEYCLOAK_REALM}/protocol/openid-connect/certs`;
 const KEYCLOAK_ISSUER = `${process.env.KEYCLOAK_HOST}/realms/${process.env.KEYCLOAK_REALM}`;

--- a/api/src/request-handlers/security/authorization.test.ts
+++ b/api/src/request-handlers/security/authorization.test.ts
@@ -8,7 +8,7 @@ import { SYSTEM_ROLE } from '../../constants/roles';
 import { HTTPError } from '../../errors/http-error';
 import { SystemUserWithRoles } from '../../models/system-user-view';
 import { AuthorizationService } from '../../services/authorization-service';
-import * as authorization from './authorization';
+import { authorizationDependencies as authorization, authorizeRequest, authorizeRequestHandler } from './authorization';
 
 chai.use(sinonChai);
 
@@ -28,7 +28,7 @@ describe('authorizeRequestHandler', function () {
       return { or: [] };
     };
 
-    const requestHandler = authorization.authorizeRequestHandler(mockAuthorizationSchemeCallback);
+    const requestHandler = authorizeRequestHandler(mockAuthorizationSchemeCallback);
 
     try {
       await requestHandler(mockReq, mockRes, mockNext);
@@ -52,7 +52,7 @@ describe('authorizeRequestHandler', function () {
       return { or: [] };
     };
 
-    const requestHandler = authorization.authorizeRequestHandler(mockAuthorizationSchemeCallback);
+    const requestHandler = authorizeRequestHandler(mockAuthorizationSchemeCallback);
 
     await requestHandler(mockReq, mockRes, mockNext);
 
@@ -72,7 +72,7 @@ describe('authorizeRequest', function () {
     sinon.stub(AuthorizationService.prototype, 'getSystemUserObject').resolves(mockSystemUserObject);
 
     const mockReq = { authorization_scheme: {} } as unknown as Request;
-    const isAuthorized = await authorization.authorizeRequest(mockReq);
+    const isAuthorized = await authorizeRequest(mockReq);
 
     expect(isAuthorized).to.equal(false);
   });

--- a/api/src/request-handlers/security/authorization.ts
+++ b/api/src/request-handlers/security/authorization.ts
@@ -22,7 +22,7 @@ export function authorizeRequestHandler(authorizationSchemeCallback: Authorizati
   return async (req, _, next) => {
     req.authorization_scheme = authorizationSchemeCallback(req);
 
-    const isAuthorized = await authorizeRequest(req);
+    const isAuthorized = await authorizationDependencies.authorizeRequest(req);
 
     if (!isAuthorized) {
       defaultLog.warn({ label: 'authorize', message: 'User is not authorized' });
@@ -78,6 +78,10 @@ export const authorizeRequest = async (req: Request): Promise<boolean> => {
   } finally {
     connection.release();
   }
+};
+
+export const authorizationDependencies = {
+  authorizeRequest
 };
 
 /**

--- a/api/src/services/attachment-service.test.ts
+++ b/api/src/services/attachment-service.test.ts
@@ -17,7 +17,7 @@ import {
   ISurveyReportAttachmentAuthor
 } from '../repositories/attachment-repository';
 import { SurveyAttachmentPublish, SurveyReportPublish } from '../repositories/history-publish-repository';
-import * as fileUtils from './../utils/file-utils';
+import { fileUtilsDependencies as fileUtils } from './../utils/file-utils';
 import { AttachmentService } from './attachment-service';
 import { HistoryPublishService } from './history-publish-service';
 

--- a/api/src/services/authorization-service.test.ts
+++ b/api/src/services/authorization-service.test.ts
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SOURCE_SYSTEM, SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { PROJECT_PERMISSION, PROJECT_ROLE, SYSTEM_ROLE } from '../constants/roles';
-import * as db from '../database/db';
+import { dbDependencies as db } from '../database/db';
 import { SystemUserWithRoles } from '../models/system-user-view';
 import { ProjectUser } from '../repositories/project-participation-repository';
 import {

--- a/api/src/services/bcgw-layer-service.ts
+++ b/api/src/services/bcgw-layer-service.ts
@@ -1,6 +1,8 @@
 import { XMLParser } from 'fast-xml-parser';
 import { Feature } from 'geojson';
-import { flatten } from 'lodash';
+import lodash from 'lodash';
+const { flatten } = lodash;
+
 import { z } from 'zod';
 import { IDBConnection } from '../database/db';
 import { getLogger } from '../utils/logger';

--- a/api/src/services/critter-attachment-service.test.ts
+++ b/api/src/services/critter-attachment-service.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { getMockDBConnection } from '../__mocks__/db';
-import * as S3 from '../utils/file-utils';
+import { fileUtilsDependencies as S3 } from '../utils/file-utils';
 import { CritterAttachmentService } from './critter-attachment-service';
 
 describe('CritterCaptureAttachmentService', () => {

--- a/api/src/services/export-services/export-service.test.ts
+++ b/api/src/services/export-services/export-service.test.ts
@@ -7,10 +7,10 @@ import SQL from 'sql-template-strings';
 import { PassThrough } from 'stream';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { ApiError } from '../../errors/api-error';
-import * as file_utils from '../../utils/file-utils';
+import { fileUtilsDependencies as file_utils } from '../../utils/file-utils';
 import { ExportService } from './export-service';
 import { ExportConfig, ExportStrategy } from './export-strategy';
-import * as export_utils from './export-utils';
+import { exportUtilsDependencies as export_utils } from './export-utils';
 
 chai.use(sinonChai);
 

--- a/api/src/services/export-services/export-service.ts
+++ b/api/src/services/export-services/export-service.ts
@@ -1,12 +1,12 @@
 import { PassThrough } from 'stream';
 import { IDBConnection } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';
-import { getS3SignedURLs, uploadStreamToS3 } from '../../utils/file-utils';
+import { fileUtilsDependencies } from '../../utils/file-utils';
 import { getLogger } from '../../utils/logger';
 import { DBService } from '../db-service';
 import { ExportConfig } from './export-strategy';
 import {
-  getArchiveStream,
+  exportUtilsDependencies,
   getCsvTransformStream,
   getQueryStream,
   getStreamCsvTransformStream,
@@ -46,7 +46,7 @@ export class ExportService extends DBService {
     const dbClient = await this.connection.getClient();
 
     try {
-      const archiveStream = getArchiveStream();
+      const archiveStream = exportUtilsDependencies.getArchiveStream();
 
       registerStreamErrorHandler(archiveStream);
 
@@ -58,7 +58,11 @@ export class ExportService extends DBService {
       archiveStream.pipe(s3UploadStream);
 
       // Start the S3 upload
-      const uploadPromise = uploadStreamToS3(s3UploadStream, EXPORT_ARCHIVE_MIME_TYPE, exportConfig.s3Key);
+      const uploadPromise = fileUtilsDependencies.uploadStreamToS3(
+        s3UploadStream,
+        EXPORT_ARCHIVE_MIME_TYPE,
+        exportConfig.s3Key
+      );
 
       await Promise.all(
         exportConfig.exportStrategies.map(async (exportStrategy) => {
@@ -142,7 +146,7 @@ export class ExportService extends DBService {
   async _getAllSignedURLs(s3Keys: string[]): Promise<string[]> {
     defaultLog.debug({ label: '_getAllSignedURLs', message: 'Generating signed URLs for export file(s).' });
 
-    const signedURLs = await getS3SignedURLs(s3Keys);
+    const signedURLs = await Promise.all(s3Keys.map((key) => fileUtilsDependencies.getS3SignedURL(key)));
 
     if (signedURLs.some((item) => item === null)) {
       throw new ApiGeneralError('Failed to generate signed URLs for all export files.');

--- a/api/src/services/export-services/export-utils.ts
+++ b/api/src/services/export-services/export-utils.ts
@@ -30,6 +30,10 @@ export function getArchiveStream(): archiver.Archiver {
   return archiveStream;
 }
 
+export const exportUtilsDependencies = {
+  getArchiveStream
+};
+
 /**
  * Get a query stream from a SQLStatement or Knex.QueryBuilder.
  *

--- a/api/src/services/import-services/capture/import-captures-service.test.ts
+++ b/api/src/services/import-services/capture/import-captures-service.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { WorkSheet } from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVConfig, CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { SurveyCritterService } from '../../survey-critter-service';
 import { ImportCapturesService } from './import-captures-service';

--- a/api/src/services/import-services/critter/import-critters-service.test.ts
+++ b/api/src/services/import-services/critter/import-critters-service.test.ts
@@ -5,12 +5,12 @@ import xlsx from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
 import { CSVConfigUtils } from '../../../utils/csv-utils/csv-config-utils';
 import { CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
-import * as headerConfig from '../../../utils/csv-utils/csv-header-configs';
+import { csvHeaderConfigDependencies as headerConfig } from '../../../utils/csv-utils/csv-header-configs';
 import { NestedRecord } from '../../../utils/nested-record';
 import { CritterbaseService } from '../../critterbase-service';
 import { SurveyCritterService } from '../../survey-critter-service';
 import { ImportCrittersService } from './import-critters-service';
-import * as critterConfig from './utils/critter-header-configs';
+import { critterHeaderDependencies as critterConfig } from './utils/critter-header-configs';
 
 chai.use(sinonChai);
 

--- a/api/src/services/import-services/critter/import-critters-service.ts
+++ b/api/src/services/import-services/critter/import-critters-service.ts
@@ -10,9 +10,9 @@ import {
   CSVHeaderConfig,
   CSVRowValidated
 } from '../../../utils/csv-utils/csv-config-validation.interface';
-import { getDescriptionCellValidator } from '../../../utils/csv-utils/csv-header-configs';
+import { csvHeaderConfigDependencies } from '../../../utils/csv-utils/csv-header-configs';
 import { getAllAliases } from '../../../utils/csv-utils/csv-helpers';
-import { getTaxonRowValidator } from '../../../utils/csv-utils/row-validators/taxon-row-validator';
+import { taxonRowValidatorDependencies } from '../../../utils/csv-utils/row-validators/taxon-row-validator';
 import { getLogger } from '../../../utils/logger';
 import { NestedRecord } from '../../../utils/nested-record';
 import { CritterbaseService, IBulkCreate } from '../../critterbase-service';
@@ -20,13 +20,8 @@ import { DBService } from '../../db-service';
 import { PlatformService } from '../../platform-service';
 import { SurveyCritterService } from '../../survey-critter-service';
 import { getTaxonFromRowState } from '../utils/row-state';
-import { getTaxonMap, getTsnsFromTaxonMap } from '../utils/taxon';
-import {
-  getCritterAliasCellValidator,
-  getCritterCollectionUnitCellValidator,
-  getCritterSexCellValidator,
-  getWlhIDCellValidator
-} from './utils/critter-header-configs';
+import { getTsnsFromTaxonMap, taxonDependencies } from '../utils/taxon';
+import { critterHeaderDependencies } from './utils/critter-header-configs';
 
 const defaultLog = getLogger('services/import/import-critters-service');
 
@@ -128,7 +123,7 @@ export class ImportCrittersService extends DBService {
   async getCSVConfig(): Promise<CSVConfig<CritterCSVStaticHeader>> {
     // Generate the taxon map from the worksheet taxon identifiers
     const taxonIdentifiers = this.utils.getUniqueCellValues('SPECIES').filter(Boolean) as Array<string | number>;
-    const taxonMap = await getTaxonMap(taxonIdentifiers, this.platformService);
+    const taxonMap = await taxonDependencies.getTaxonMap(taxonIdentifiers, this.platformService);
 
     // this should only contain valid TSNs
     const worksheetTsns = getTsnsFromTaxonMap(taxonMap);
@@ -146,12 +141,14 @@ export class ImportCrittersService extends DBService {
       SPECIES: { validateCell: () => [] },
       ALIAS: aliasHeaderConfig,
       SEX: sexHeaderConfig,
-      WLH_ID: { validateCell: getWlhIDCellValidator(this.utils) },
-      DESCRIPTION: { validateCell: getDescriptionCellValidator({ optional: true }) }
+      WLH_ID: { validateCell: critterHeaderDependencies.getWlhIDCellValidator(this.utils) },
+      DESCRIPTION: { validateCell: csvHeaderConfigDependencies.getDescriptionCellValidator({ optional: true }) }
     });
 
     // Add the taxon row validator - validates the taxon / tsn and sets the TSN in the row state
-    this.utils.config.rowValidators = [getTaxonRowValidator(taxonMap, this.utils, 'SPECIES')];
+    this.utils.config.rowValidators = [
+      taxonRowValidatorDependencies.getTaxonRowValidator(taxonMap, this.utils, 'SPECIES')
+    ];
 
     // Set the dynamic header config - validates the collection unit columns
     this.utils.config.dynamicHeadersConfig = dynamicHeadersConfig;
@@ -221,7 +218,7 @@ export class ImportCrittersService extends DBService {
     const surveyAliases = await this.surveyCritterService.getUniqueSurveyCritterAliases(this.surveyId);
 
     return {
-      validateCell: getCritterAliasCellValidator(surveyAliases, this.utils),
+      validateCell: critterHeaderDependencies.getCritterAliasCellValidator(surveyAliases, this.utils),
       setCellValue: (params) => String(params.cell)
     };
   }
@@ -261,7 +258,7 @@ export class ImportCrittersService extends DBService {
     });
 
     return {
-      validateCell: getCritterSexCellValidator(rowDictionary)
+      validateCell: critterHeaderDependencies.getCritterSexCellValidator(rowDictionary)
     };
   }
 
@@ -295,7 +292,7 @@ export class ImportCrittersService extends DBService {
     });
 
     return {
-      validateCell: getCritterCollectionUnitCellValidator(rowDictionary)
+      validateCell: critterHeaderDependencies.getCritterCollectionUnitCellValidator(rowDictionary)
     };
   }
 }

--- a/api/src/services/import-services/critter/utils/critter-header-configs.ts
+++ b/api/src/services/import-services/critter/utils/critter-header-configs.ts
@@ -221,3 +221,10 @@ export const getWlhIDCellValidator = (configUtils: CSVConfigUtils<CritterCSVStat
     return cellErrors;
   };
 };
+
+export const critterHeaderDependencies = {
+  getCritterAliasCellValidator,
+  getCritterCollectionUnitCellValidator,
+  getCritterSexCellValidator,
+  getWlhIDCellValidator
+};

--- a/api/src/services/import-services/devices/import-device-service.test.ts
+++ b/api/src/services/import-services/devices/import-device-service.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { WorkSheet } from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVConfig, CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { ImportDeviceService } from './import-device-service';
 

--- a/api/src/services/import-services/habitat-feature/import-habitat-features-service.test.ts
+++ b/api/src/services/import-services/habitat-feature/import-habitat-features-service.test.ts
@@ -3,13 +3,13 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../../__mocks__/db';
 import { CaseInsensitiveMap } from '../../../utils/case-insensitive-map';
-import * as validate from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as validate } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { SurveyHabitatFeatureService } from '../../habitat-feature-services/survey-habitat-feature-service';
 import { IItisSearchResult, PlatformService } from '../../platform-service';
-import * as taxonMap from '../utils/taxon';
+import { taxonDependencies as taxonMap } from '../utils/taxon';
 import { ImportHabitatFeaturesService } from './import-habitat-features-service';
-import * as habitatFeatureSamplingRowValidator from './utils/habitat-feature-sampling-row-validator';
+import { habitatFeatureSamplingRowValidatorDependencies as habitatFeatureSamplingRowValidator } from './utils/habitat-feature-sampling-row-validator';
 
 chai.use(sinonChai);
 

--- a/api/src/services/import-services/habitat-feature/import-habitat-features-service.ts
+++ b/api/src/services/import-services/habitat-feature/import-habitat-features-service.ts
@@ -1,4 +1,6 @@
-import { castArray, compact } from 'lodash';
+import lodash from 'lodash';
+const { castArray, compact } = lodash;
+
 import { WorkSheet } from 'xlsx';
 import { IDBConnection } from '../../../database/db';
 import { CodeRepository } from '../../../repositories/code-repository';
@@ -30,9 +32,9 @@ import { SamplePeriodService } from '../../sample-period-service';
 import { SampleSiteService } from '../../sample-site-service';
 import { TechniqueService } from '../../technique-service';
 import { getSamplePeriodIdFromRowState, getTaxonArrayFromRowState } from '../utils/row-state';
-import { getTaxonMap, TaxonMap } from '../utils/taxon';
+import { taxonDependencies, TaxonMap } from '../utils/taxon';
 import { getHabitatFeatureTypeCellValidator } from './utils/habitat-feature-header-configs';
-import { getHabitatFeatureSamplingInformationRowValidator } from './utils/habitat-feature-sampling-row-validator';
+import { habitatFeatureSamplingRowValidatorDependencies } from './utils/habitat-feature-sampling-row-validator';
 
 const defaultLog = getLogger('services/import-services/import-habitat-features-service');
 
@@ -178,7 +180,7 @@ export class ImportHabitatFeaturesService extends DBService {
     const taxonIdentifiers = this.utils
       .getUniqueArrayCellValues('SPECIES', { delimiter: DELIMITER })
       .filter(Boolean) as string[];
-    const taxonMap = await getTaxonMap(taxonIdentifiers, platformService);
+    const taxonMap = await taxonDependencies.getTaxonMap(taxonIdentifiers, platformService);
 
     // Inject the dependencies and set the static headers, row validators, and dynamic headers
     await Promise.all([
@@ -246,7 +248,7 @@ export class ImportHabitatFeaturesService extends DBService {
 
     // Inject the row validators - handles taxon, sampling information and location validation
     this.utils.config.rowValidators = [
-      getHabitatFeatureSamplingInformationRowValidator({
+      habitatFeatureSamplingRowValidatorDependencies.getHabitatFeatureSamplingInformationRowValidator({
         samplePeriods: samplePeriods,
         sampleSites: sampleSites,
         methodTechniques: methodTechniques,

--- a/api/src/services/import-services/habitat-feature/utils/habitat-feature-attribute-dynamic-headers-config.test.ts
+++ b/api/src/services/import-services/habitat-feature/utils/habitat-feature-attribute-dynamic-headers-config.test.ts
@@ -2,7 +2,10 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CSVRowState } from '../../../../utils/csv-utils/csv-config-validation.interface';
-import * as dynamicHeadersConfig from './habitat-feature-attribute-dynamic-headers-config';
+import {
+  habitatFeatureDynamicHeaderDependencies as dynamicHeadersConfig,
+  getDynamicHabitatFeatureAttributeCellValidator
+} from './habitat-feature-attribute-dynamic-headers-config';
 
 chai.use(sinonChai);
 
@@ -14,8 +17,7 @@ describe('habitat-feature-attribute-dynamic-headers-config', () => {
   describe('getDynamicHabitatFeatureAttributeCellValidator', () => {
     it('should return an empty array when the cell is undefined', () => {
       const habitatFeatureDefinitionMap = new Map();
-      const validator =
-        dynamicHeadersConfig.getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
+      const validator = getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
 
       const result = validator({ cell: undefined } as any);
       expect(result).to.be.deep.equal([]);
@@ -23,8 +25,7 @@ describe('habitat-feature-attribute-dynamic-headers-config', () => {
 
     it('should return an error when the column header does not exist', () => {
       const habitatFeatureDefinitionMap = new Map();
-      const validator =
-        dynamicHeadersConfig.getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
+      const validator = getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
 
       const result = validator({ cell: 'test', header: 'bad' } as any);
       expect(result[0].error).to.contain("'bad' does not exist");
@@ -43,8 +44,7 @@ describe('habitat-feature-attribute-dynamic-headers-config', () => {
         .stub(dynamicHeadersConfig, 'validateQualitativeHabitatFeatureAttributeCell')
         .returns([]);
 
-      const validator =
-        dynamicHeadersConfig.getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
+      const validator = getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
 
       expect(validateQualitativeStub).to.not.have.been.calledOnce;
 
@@ -65,8 +65,7 @@ describe('habitat-feature-attribute-dynamic-headers-config', () => {
         .stub(dynamicHeadersConfig, 'validateQuantitativeHabitatFeatureAttributeCell')
         .returns([]);
 
-      const validator =
-        dynamicHeadersConfig.getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
+      const validator = getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
 
       expect(validateQuantitativeStub).to.not.have.been.calledOnce;
 
@@ -82,8 +81,7 @@ describe('habitat-feature-attribute-dynamic-headers-config', () => {
 
       habitatFeatureDefinitionMap.set('header', habitatFeatureAttributeData);
 
-      const validator =
-        dynamicHeadersConfig.getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
+      const validator = getDynamicHabitatFeatureAttributeCellValidator(habitatFeatureDefinitionMap);
 
       const result = validator({ cell: 'test', header: 'header' } as any);
       expect(result[0].error.toLowerCase()).to.contain('invalid habitat feature attribute type');

--- a/api/src/services/import-services/habitat-feature/utils/habitat-feature-attribute-dynamic-headers-config.ts
+++ b/api/src/services/import-services/habitat-feature/utils/habitat-feature-attribute-dynamic-headers-config.ts
@@ -43,12 +43,18 @@ export const getDynamicHabitatFeatureAttributeCellValidator = (
 
     // Header type is qualitative
     if (isQualitativeHabitatFeatureTypeDefinition(habitatFeatureAttribute)) {
-      return validateQualitativeHabitatFeatureAttributeCell(params, habitatFeatureAttribute);
+      return habitatFeatureDynamicHeaderDependencies.validateQualitativeHabitatFeatureAttributeCell(
+        params,
+        habitatFeatureAttribute
+      );
     }
 
     // Header type is quantitative
     if (isQuantitativeHabitatFeatureTypeDefinition(habitatFeatureAttribute)) {
-      return validateQuantitativeHabitatFeatureAttributeCell(params, habitatFeatureAttribute);
+      return habitatFeatureDynamicHeaderDependencies.validateQuantitativeHabitatFeatureAttributeCell(
+        params,
+        habitatFeatureAttribute
+      );
     }
 
     // Can this path ever be reached?
@@ -142,4 +148,9 @@ export const validateQuantitativeHabitatFeatureAttributeCell = (
   });
 
   return [];
+};
+
+export const habitatFeatureDynamicHeaderDependencies = {
+  validateQualitativeHabitatFeatureAttributeCell,
+  validateQuantitativeHabitatFeatureAttributeCell
 };

--- a/api/src/services/import-services/habitat-feature/utils/habitat-feature-sampling-row-validator.ts
+++ b/api/src/services/import-services/habitat-feature/utils/habitat-feature-sampling-row-validator.ts
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { compact } from 'lodash';
+import lodash from 'lodash';
+const { compact } = lodash;
+
 import { DefaultTimeFormat, DefaultTimeFormatNoSeconds } from '../../../../constants/dates';
 import { ApiGeneralError } from '../../../../errors/api-error';
 import { SurveySamplePeriodDetails } from '../../../../repositories/sample-period-repository';
@@ -211,6 +213,10 @@ export function getHabitatFeatureSamplingInformationRowValidator(
     );
   };
 }
+
+export const habitatFeatureSamplingRowValidatorDependencies = {
+  getHabitatFeatureSamplingInformationRowValidator
+};
 
 /**
  * Validate Habitat feature Date, Latitude, and Longitude all exist - used when sampling information is not provided.

--- a/api/src/services/import-services/marking/import-markings-service.test.ts
+++ b/api/src/services/import-services/marking/import-markings-service.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { WorkSheet } from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVConfig, CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { NestedRecord } from '../../../utils/nested-record';
 import { IAsSelectLookup } from '../../critterbase-service';

--- a/api/src/services/import-services/measurement/import-measurement-service.test.ts
+++ b/api/src/services/import-services/measurement/import-measurement-service.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { v4 } from 'uuid';
 import { getMockDBConnection } from '../../../__mocks__/db';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { NestedRecord } from '../../../utils/nested-record';
-import * as measurementUtils from '../utils/measurement';
+import { measurementDependencies as measurementUtils } from '../utils/measurement';
 import { ImportMeasurementsService } from './import-measurements-service';
 
 describe('import-measurements-service', () => {

--- a/api/src/services/import-services/measurement/utils/measurement-dynamic-headers-config.test.ts
+++ b/api/src/services/import-services/measurement/utils/measurement-dynamic-headers-config.test.ts
@@ -11,12 +11,11 @@ import {
 import { getQualitativeMeasurementFromRowState } from '../../utils/row-state';
 import {
   getDynamicMeasurementCellValidator,
+  measurementDynamicHeaderDependencies as measurement,
   TSNMeasurementDictionary,
   validateQualitativeMeasurementCell,
   validateQuantitativeMeasurementCell
 } from './measurement-dynamic-headers-config';
-
-import * as measurement from './measurement-dynamic-headers-config';
 
 chai.use(sinonChai);
 

--- a/api/src/services/import-services/measurement/utils/measurement-dynamic-headers-config.ts
+++ b/api/src/services/import-services/measurement/utils/measurement-dynamic-headers-config.ts
@@ -60,11 +60,11 @@ export const getDynamicMeasurementCellValidator = (
     }
 
     if (isCBQualitativeMeasurementTypeDefinition(measurement)) {
-      return validateQualitativeMeasurementCell(params, measurement);
+      return measurementDynamicHeaderDependencies.validateQualitativeMeasurementCell(params, measurement);
     }
 
     if (isCBQuantitativeMeasurementTypeDefinition(measurement)) {
-      return validateQuantitativeMeasurementCell(params, measurement);
+      return measurementDynamicHeaderDependencies.validateQuantitativeMeasurementCell(params, measurement);
     }
 
     // Can this path ever be reached?
@@ -147,4 +147,9 @@ export const validateQuantitativeMeasurementCell = (
   });
 
   return [];
+};
+
+export const measurementDynamicHeaderDependencies = {
+  validateQualitativeMeasurementCell,
+  validateQuantitativeMeasurementCell
 };

--- a/api/src/services/import-services/observation/import-observations-service.test.ts
+++ b/api/src/services/import-services/observation/import-observations-service.test.ts
@@ -4,14 +4,14 @@ import sinonChai from 'sinon-chai';
 import { v4 } from 'uuid';
 import { getMockDBConnection } from '../../../__mocks__/db';
 import { CaseInsensitiveMap } from '../../../utils/case-insensitive-map';
-import * as validate from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as validate } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
-import * as taxonRowValidator from '../../../utils/csv-utils/row-validators/taxon-row-validator';
+import { taxonRowValidatorDependencies as taxonRowValidator } from '../../../utils/csv-utils/row-validators/taxon-row-validator';
 import { ObservationService } from '../../observation-services/observation-service';
 import { IItisSearchResult, PlatformService } from '../../platform-service';
-import * as taxonMap from '../utils/taxon';
+import { taxonDependencies as taxonMap } from '../utils/taxon';
 import { ImportObservationsService } from './import-observations-service';
-import * as observationSamplingRowValidator from './utils/observation-sampling-row-validator';
+import { observationSamplingRowValidatorDependencies as observationSamplingRowValidator } from './utils/observation-sampling-row-validator';
 
 chai.use(sinonChai);
 

--- a/api/src/services/import-services/observation/import-observations-service.ts
+++ b/api/src/services/import-services/observation/import-observations-service.ts
@@ -22,7 +22,7 @@ import {
   getTimeCellValidator,
   validateZodCell
 } from '../../../utils/csv-utils/csv-header-configs';
-import { getTaxonRowValidator } from '../../../utils/csv-utils/row-validators/taxon-row-validator';
+import { taxonRowValidatorDependencies } from '../../../utils/csv-utils/row-validators/taxon-row-validator';
 import { getLogger } from '../../../utils/logger';
 import { CritterbaseService, getCritterbaseUserFromConnection } from '../../critterbase-service';
 import { DBService } from '../../db-service';
@@ -50,10 +50,10 @@ import {
   getSamplePeriodIdFromRowState,
   getTaxonFromRowState
 } from '../utils/row-state';
-import { getTaxonMap, getTsnsFromTaxonMap, TaxonMap } from '../utils/taxon';
+import { getTsnsFromTaxonMap, taxonDependencies, TaxonMap } from '../utils/taxon';
 import { getObservationDynamicHeaderCellValidator } from './utils/observation-dynamic-header-config';
 import { getObservationSignCellValidator } from './utils/observation-header-configs';
-import { getObservationSamplingInformationRowValidator } from './utils/observation-sampling-row-validator';
+import { observationSamplingRowValidatorDependencies } from './utils/observation-sampling-row-validator';
 
 const defaultLog = getLogger('services/import/import-observations-service');
 
@@ -185,7 +185,7 @@ export class ImportObservationsService extends DBService {
 
     // Generate shared dependencies
     const taxonIdentifiers = this.utils.getUniqueCellValues('SPECIES').filter(Boolean) as string[];
-    const taxonMap = await getTaxonMap(taxonIdentifiers, platformService);
+    const taxonMap = await taxonDependencies.getTaxonMap(taxonIdentifiers, platformService);
 
     // Inject the dependencies and set the static headers, row validators, and dynamic headers
     await Promise.all([
@@ -251,8 +251,8 @@ export class ImportObservationsService extends DBService {
 
     // Inject the row validators - handles taxon, sampling information and location validation
     this.utils.config.rowValidators = [
-      getTaxonRowValidator(taxonMap, this.utils, 'SPECIES'),
-      getObservationSamplingInformationRowValidator({
+      taxonRowValidatorDependencies.getTaxonRowValidator(taxonMap, this.utils, 'SPECIES'),
+      observationSamplingRowValidatorDependencies.getObservationSamplingInformationRowValidator({
         samplePeriods: samplePeriods,
         sampleSites: sampleSites,
         methodTechniques: methodTechniques,

--- a/api/src/services/import-services/observation/utils/environment-dynamic-headers-config.test.ts
+++ b/api/src/services/import-services/observation/utils/environment-dynamic-headers-config.test.ts
@@ -2,7 +2,10 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CSVRowState } from '../../../../utils/csv-utils/csv-config-validation.interface';
-import * as environment from './environment-dynamic-headers-config';
+import {
+  environmentDynamicHeaderDependencies as environment,
+  getDynamicEnvironmentCellValidator
+} from './environment-dynamic-headers-config';
 
 chai.use(sinonChai);
 
@@ -14,7 +17,7 @@ describe('environment-dynamic-headers-config', () => {
   describe('getDynamicEnvironmentCellValidator', () => {
     it('should return an empty array when the cell is undefined', () => {
       const environmentMap = new Map();
-      const validator = environment.getDynamicEnvironmentCellValidator(environmentMap);
+      const validator = getDynamicEnvironmentCellValidator(environmentMap);
 
       const result = validator({ cell: undefined } as any);
       expect(result).to.be.deep.equal([]);
@@ -22,7 +25,7 @@ describe('environment-dynamic-headers-config', () => {
 
     it('should return an error when the column header does not exist', () => {
       const environmentMap = new Map();
-      const validator = environment.getDynamicEnvironmentCellValidator(environmentMap);
+      const validator = getDynamicEnvironmentCellValidator(environmentMap);
 
       const result = validator({ cell: 'test', header: 'bad' } as any);
       expect(result[0].error).to.contain("'bad' does not exist");
@@ -39,7 +42,7 @@ describe('environment-dynamic-headers-config', () => {
 
       const validateQualitativeStub = sinon.stub(environment, 'validateQualitativeEnvironmentCell').returns([]);
 
-      const validator = environment.getDynamicEnvironmentCellValidator(environmentMap);
+      const validator = getDynamicEnvironmentCellValidator(environmentMap);
 
       expect(validateQualitativeStub).to.not.have.been.calledOnce;
 
@@ -58,7 +61,7 @@ describe('environment-dynamic-headers-config', () => {
 
       const validateQuantitativeStub = sinon.stub(environment, 'validateQuantitativeEnvironmentCell').returns([]);
 
-      const validator = environment.getDynamicEnvironmentCellValidator(environmentMap);
+      const validator = getDynamicEnvironmentCellValidator(environmentMap);
 
       expect(validateQuantitativeStub).to.not.have.been.calledOnce;
 
@@ -74,7 +77,7 @@ describe('environment-dynamic-headers-config', () => {
 
       environmentMap.set('header', environmentData);
 
-      const validator = environment.getDynamicEnvironmentCellValidator(environmentMap);
+      const validator = getDynamicEnvironmentCellValidator(environmentMap);
 
       const result = validator({ cell: 'test', header: 'header' } as any);
       expect(result[0].error.toLowerCase()).to.contain('invalid environment type');

--- a/api/src/services/import-services/observation/utils/environment-dynamic-headers-config.ts
+++ b/api/src/services/import-services/observation/utils/environment-dynamic-headers-config.ts
@@ -45,12 +45,12 @@ export const getDynamicEnvironmentCellValidator = (
 
     // Environment type is qualitative
     if (isQualitativeEnvironmentTypeDefinition(environment)) {
-      return validateQualitativeEnvironmentCell(params, environment);
+      return environmentDynamicHeaderDependencies.validateQualitativeEnvironmentCell(params, environment);
     }
 
     // Environment type is quantitative
     if (isQuantitativeEnvironmentTypeDefinition(environment)) {
-      return validateQuantitativeEnvironmentCell(params, environment);
+      return environmentDynamicHeaderDependencies.validateQuantitativeEnvironmentCell(params, environment);
     }
 
     // Can this path ever be reached?
@@ -136,4 +136,9 @@ export const validateQuantitativeEnvironmentCell = (
   });
 
   return [];
+};
+
+export const environmentDynamicHeaderDependencies = {
+  validateQualitativeEnvironmentCell,
+  validateQuantitativeEnvironmentCell
 };

--- a/api/src/services/import-services/observation/utils/observation-sampling-row-validator.ts
+++ b/api/src/services/import-services/observation/utils/observation-sampling-row-validator.ts
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { compact } from 'lodash';
+import lodash from 'lodash';
+const { compact } = lodash;
+
 import { DefaultTimeFormat, DefaultTimeFormatNoSeconds } from '../../../../constants/dates';
 import { ApiGeneralError } from '../../../../errors/api-error';
 import { SurveySamplePeriodDetails } from '../../../../repositories/sample-period-repository';
@@ -211,6 +213,10 @@ export function getObservationSamplingInformationRowValidator(
     );
   };
 }
+
+export const observationSamplingRowValidatorDependencies = {
+  getObservationSamplingInformationRowValidator
+};
 
 /**
  * Validate Observation Date, Latitude, and Longitude all exist - used when sampling information is not provided.

--- a/api/src/services/import-services/sampling-periods/import-sample-periods-service.test.ts
+++ b/api/src/services/import-services/sampling-periods/import-sample-periods-service.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { WorkSheet } from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVConfig, CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { SamplePeriodService } from '../../sample-period-service';
 import { SampleSiteService } from '../../sample-site-service';

--- a/api/src/services/import-services/telemetry/import-telemetry-service.test.ts
+++ b/api/src/services/import-services/telemetry/import-telemetry-service.test.ts
@@ -4,7 +4,7 @@ import sinonChai from 'sinon-chai';
 import { WorkSheet } from 'xlsx';
 import { getMockDBConnection } from '../../../__mocks__/db';
 import { ExtendedDeploymentRecord } from '../../../repositories/telemetry-repositories/telemetry-deployment-repository.interface';
-import * as csv from '../../../utils/csv-utils/csv-config-validation';
+import { csvValidationDependencies as csv } from '../../../utils/csv-utils/csv-config-validation';
 import { CSVConfig, CSVRowState } from '../../../utils/csv-utils/csv-config-validation.interface';
 import { ImportTelemetryService } from './import-telemetry-service';
 

--- a/api/src/services/import-services/utils/measurement.ts
+++ b/api/src/services/import-services/utils/measurement.ts
@@ -95,7 +95,7 @@ export const isCBQuantitativeMeasurementStub = (measurement: unknown): boolean =
  * @param {CritterbaseService} critterbaseService
  * @returns {*} {Promise<TSNMeasurementDictionary>} Measurement dictionary
  */
-export const getTsnMeasurementDictionary = async (
+const getTsnMeasurementDictionaryCore = async (
   tsns: number[],
   critterbaseService: CritterbaseService
 ): Promise<TSNMeasurementDictionary> => {
@@ -144,4 +144,15 @@ export const getTsnMeasurementDictionary = async (
   });
 
   return measurementDictionary;
+};
+
+export const measurementDependencies = {
+  getTsnMeasurementDictionary: getTsnMeasurementDictionaryCore
+};
+
+export const getTsnMeasurementDictionary = async (
+  tsns: number[],
+  critterbaseService: CritterbaseService
+): Promise<TSNMeasurementDictionary> => {
+  return measurementDependencies.getTsnMeasurementDictionary(tsns, critterbaseService);
 };

--- a/api/src/services/import-services/utils/taxon.ts
+++ b/api/src/services/import-services/utils/taxon.ts
@@ -1,4 +1,6 @@
-import { isNumber, partition } from 'lodash';
+import lodash from 'lodash';
+const { isNumber, partition } = lodash;
+
 import { CaseInsensitiveMap } from '../../../utils/case-insensitive-map';
 import { IItisSearchResult, PlatformService } from '../../platform-service';
 
@@ -11,7 +13,7 @@ export type TaxonMap = CaseInsensitiveMap<string | number, IItisSearchResult>;
  * @param {PlatformService} platformService The platform service
  * @return {*} {Promise<CaseInsensitiveMap<string | number, IItisSearchResult>>} The taxon map - case insensitive
  */
-export const getTaxonMap = async (
+const getTaxonMapCore = async (
   taxonIdentifiers: Array<string | number>,
   platformService: PlatformService
 ): Promise<TaxonMap> => {
@@ -48,6 +50,17 @@ export const getTaxonMap = async (
   });
 
   return taxonMap;
+};
+
+export const taxonDependencies = {
+  getTaxonMap: getTaxonMapCore
+};
+
+export const getTaxonMap = async (
+  taxonIdentifiers: Array<string | number>,
+  platformService: PlatformService
+): Promise<TaxonMap> => {
+  return taxonDependencies.getTaxonMap(taxonIdentifiers, platformService);
 };
 
 /**

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -9,8 +9,8 @@ import { getMockDBConnection } from '../__mocks__/db';
 import { ApiError, ApiErrorType } from '../errors/api-error';
 import { BiohubFeatureType } from '../models/biohub-create';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
-import * as envConfig from '../utils/env-config';
-import * as featureFlagUtils from '../utils/feature-flag-utils';
+import { envConfigDependencies as envConfig } from '../utils/env-config';
+import { featureFlagDependencies as featureFlagUtils } from '../utils/feature-flag-utils';
 import { AttachmentService } from './attachment-service';
 import { CodeService } from './code-service';
 import { SurveyHabitatFeatureService } from './habitat-feature-services/survey-habitat-feature-service';
@@ -164,7 +164,6 @@ describe('PlatformService', () => {
 
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
-      const fs = require('node:fs');
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
 
       const _initiateSubmissionUploadStub = sinon
@@ -217,7 +216,6 @@ describe('PlatformService', () => {
 
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
-      const fs = require('node:fs');
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
       sinon.stub(fs, 'unlinkSync').callsFake(() => {});
 
@@ -300,7 +298,6 @@ describe('PlatformService', () => {
         .returns([{ id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null }]);
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
-      const fs = require('node:fs');
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
       sinon.stub(fs, 'unlinkSync').callsFake(() => {});
 
@@ -678,7 +675,6 @@ describe('PlatformService', () => {
         { id: 'obs-1', type: 'species_observation', properties: {}, content: [], parent: 'test-dataset-id' }
       ]);
 
-      const fs = require('node:fs');
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
       sinon.stub(fs, 'unlinkSync').callsFake(() => {});
 

--- a/api/src/services/survey-service.test.ts
+++ b/api/src/services/survey-service.test.ts
@@ -1,6 +1,8 @@
 import chai, { expect } from 'chai';
 import { Feature } from 'geojson';
-import { flatten } from 'lodash';
+import lodash from 'lodash';
+const { flatten } = lodash;
+
 import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';

--- a/api/src/services/survey-service.ts
+++ b/api/src/services/survey-service.ts
@@ -1,4 +1,6 @@
-import { flatten } from 'lodash';
+import lodash from 'lodash';
+const { flatten } = lodash;
+
 import { IDBConnection } from '../database/db';
 import { PostProprietorData, PostSurveyObject } from '../models/survey-create';
 import { PostSurveyLocationData, PutPartnershipsData, PutSurveyObject } from '../models/survey-update';

--- a/api/src/services/telemetry-services/telemetry-lotek-service.test.ts
+++ b/api/src/services/telemetry-services/telemetry-lotek-service.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../__mocks__/db';
-import * as env from '../../utils/env-config';
+import { envConfigDependencies as env } from '../../utils/env-config';
 import { TelemetryLotekService } from './telemetry-lotek-service';
 
 chai.use(sinonChai);

--- a/api/src/services/telemetry-services/telemetry-lotek-service.ts
+++ b/api/src/services/telemetry-services/telemetry-lotek-service.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
-import { chunk } from 'lodash';
+import lodash from 'lodash';
+const { chunk } = lodash;
+
 import qs from 'qs';
 import { IDBConnection } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';

--- a/api/src/services/telemetry-services/telemetry-vectronic-service.test.ts
+++ b/api/src/services/telemetry-services/telemetry-vectronic-service.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../__mocks__/db';
-import * as env from '../../utils/env-config';
+import { envConfigDependencies as env } from '../../utils/env-config';
 import { TelemetryVectronicService } from './telemetry-vectronic-service';
 
 chai.use(sinonChai);

--- a/api/src/services/telemetry-services/telemetry-vectronic-service.ts
+++ b/api/src/services/telemetry-services/telemetry-vectronic-service.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
-import { chunk } from 'lodash';
+import lodash from 'lodash';
+const { chunk } = lodash;
+
 import qs from 'qs';
 import { TelemetryCredentialVectronicRecord } from '../../database-models/telemetry_credential_vectronic';
 import { IDBConnection } from '../../database/db';

--- a/api/src/services/telemetry-services/telemetry-vendor-service.ts
+++ b/api/src/services/telemetry-services/telemetry-vendor-service.ts
@@ -1,4 +1,6 @@
-import { chunk } from 'lodash';
+import lodash from 'lodash';
+const { chunk } = lodash;
+
 import { TelemetryManualRecord } from '../../database-models/telemetry_manual';
 import { IDBConnection } from '../../database/db';
 import { ApiGeneralError } from '../../errors/api-error';

--- a/api/src/utils/csv-utils/csv-config-utils.ts
+++ b/api/src/utils/csv-utils/csv-config-utils.ts
@@ -1,7 +1,9 @@
-import { countBy, difference } from 'lodash';
+import lodash from 'lodash';
 import { WorkSheet } from 'xlsx';
 import { getHeadersUpperCase, getWorksheetRowObjects } from '../xlsx-utils/worksheet-utils';
 import { CSVCell, CSVConfig, CSVHeaderConfig, CSVRow } from './csv-config-validation.interface';
+
+const { countBy, difference } = lodash;
 
 /**
  * CSV Config Utils - A collection of methods useful when building CSVConfigs

--- a/api/src/utils/csv-utils/csv-config-validation.ts
+++ b/api/src/utils/csv-utils/csv-config-validation.ts
@@ -23,7 +23,7 @@ import {
  * @param {CSVConfigType} config - The CSV configuration
  * @returns {*} {{ errors: Required<CSVError>[]; rows: CSVRowValidated[] }} - The CSV errors and rows
  */
-export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>(
+const validateCSVWorksheetCore = <StaticHeaderType extends Uppercase<string>>(
   worksheet: WorkSheet,
   config: CSVConfig<StaticHeaderType>
 ): { errors: Required<CSVError>[]; rows: CSVRowValidated<StaticHeaderType>[] } => {
@@ -79,6 +79,17 @@ export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>
   }
 
   return { errors: [], rows: rows };
+};
+
+export const csvValidationDependencies = {
+  validateCSVWorksheet: validateCSVWorksheetCore
+};
+
+export const validateCSVWorksheet = <StaticHeaderType extends Uppercase<string>>(
+  worksheet: WorkSheet,
+  config: CSVConfig<StaticHeaderType>
+): { errors: Required<CSVError>[]; rows: CSVRowValidated<StaticHeaderType>[] } => {
+  return csvValidationDependencies.validateCSVWorksheet(worksheet, config);
 };
 
 /**

--- a/api/src/utils/csv-utils/csv-header-configs.ts
+++ b/api/src/utils/csv-utils/csv-header-configs.ts
@@ -488,3 +488,7 @@ export const getArrayCellValidator = (
     return csvCellValidator({ ...params, cell: cellValue });
   };
 };
+
+export const csvHeaderConfigDependencies = {
+  getDescriptionCellValidator
+};

--- a/api/src/utils/csv-utils/row-validators/taxon-row-validator.ts
+++ b/api/src/utils/csv-utils/row-validators/taxon-row-validator.ts
@@ -18,7 +18,7 @@ import { getTaxonCellValidator } from '../csv-header-configs';
  * @param {CSVCellValidatorOptions} [options] cell validator options
  * @returns {*} {CSVCellValidator} The validate cell callback
  */
-export const getTaxonRowValidator = <StaticHeaderType extends Uppercase<string> = Uppercase<string>>(
+const getTaxonRowValidatorCore = <StaticHeaderType extends Uppercase<string> = Uppercase<string>>(
   taxonMap: TaxonMap,
   utils: CSVConfigUtils<StaticHeaderType>,
   taxonStaticHeader: StaticHeaderType,
@@ -45,4 +45,17 @@ export const getTaxonRowValidator = <StaticHeaderType extends Uppercase<string> 
       };
     });
   };
+};
+
+export const taxonRowValidatorDependencies = {
+  getTaxonRowValidator: getTaxonRowValidatorCore
+};
+
+export const getTaxonRowValidator = <StaticHeaderType extends Uppercase<string> = Uppercase<string>>(
+  taxonMap: TaxonMap,
+  utils: CSVConfigUtils<StaticHeaderType>,
+  taxonStaticHeader: StaticHeaderType,
+  options?: CSVCellValidatorOptions
+): CSVRowValidator => {
+  return taxonRowValidatorDependencies.getTaxonRowValidator(taxonMap, utils, taxonStaticHeader, options);
 };

--- a/api/src/utils/env-config.ts
+++ b/api/src/utils/env-config.ts
@@ -101,7 +101,7 @@ type Env = z.infer<typeof EnvSchema>;
  *
  * @returns {*} {Env} Validated environment variables
  */
-export const loadEnvironmentVariables = (): Env => {
+const loadEnvironmentVariablesCore = (): Env => {
   const parsed = EnvSchema.safeParse(process.env);
 
   if (!parsed.success) {
@@ -126,8 +126,21 @@ export const loadEnvironmentVariables = (): Env => {
  * @param {EnvKey} envVariable The environment variable to get
  * @returns {*} {Env[EnvKey]} The environment variable value
  */
-export const getEnvironmentVariable = <EnvKey extends keyof Env>(envVariable: EnvKey): Env[EnvKey] => {
+const getEnvironmentVariableCore = <EnvKey extends keyof Env>(envVariable: EnvKey): Env[EnvKey] => {
   return process.env[envVariable] as Env[EnvKey];
+};
+
+export const envConfigDependencies = {
+  loadEnvironmentVariables: loadEnvironmentVariablesCore,
+  getEnvironmentVariable: getEnvironmentVariableCore
+};
+
+export const loadEnvironmentVariables = (): Env => {
+  return envConfigDependencies.loadEnvironmentVariables();
+};
+
+export const getEnvironmentVariable = <EnvKey extends keyof Env>(envVariable: EnvKey): Env[EnvKey] => {
+  return envConfigDependencies.getEnvironmentVariable(envVariable);
 };
 
 // Extend NodeJS ProcessEnv to include the EnvSchema

--- a/api/src/utils/feature-flag-utils.ts
+++ b/api/src/utils/feature-flag-utils.ts
@@ -3,7 +3,7 @@
  *
  * @return {*}  {(string | undefined)}
  */
-export const getFeatureFlagsString = (): string | undefined => {
+const getFeatureFlagsStringCore = (): string | undefined => {
   return process.env.FEATURE_FLAGS;
 };
 
@@ -12,7 +12,7 @@ export const getFeatureFlagsString = (): string | undefined => {
  *
  * @return {*}  {string[]}
  */
-export const getFeatureFlags = (): string[] => {
+const getFeatureFlagsCore = (): string[] => {
   const featureFlagsString = getFeatureFlagsString();
 
   if (!featureFlagsString) {
@@ -29,6 +29,24 @@ export const getFeatureFlags = (): string[] => {
  * @param {string[]} featureFlags
  * @return {*}  {boolean}
  */
-export const isFeatureFlagPresent = (featureFlags: string[]): boolean => {
+const isFeatureFlagPresentCore = (featureFlags: string[]): boolean => {
   return getFeatureFlags().some((flag) => featureFlags.includes(flag));
+};
+
+export const featureFlagDependencies = {
+  getFeatureFlagsString: getFeatureFlagsStringCore,
+  getFeatureFlags: getFeatureFlagsCore,
+  isFeatureFlagPresent: isFeatureFlagPresentCore
+};
+
+export const getFeatureFlagsString = (): string | undefined => {
+  return featureFlagDependencies.getFeatureFlagsString();
+};
+
+export const getFeatureFlags = (): string[] => {
+  return featureFlagDependencies.getFeatureFlags();
+};
+
+export const isFeatureFlagPresent = (featureFlags: string[]): boolean => {
+  return featureFlagDependencies.isFeatureFlagPresent(featureFlags);
 };

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -109,7 +109,7 @@ export const getS3KeyPrefix = (): string => {
  * @param {string} key the unique key assigned to the file in S3 when it was originally uploaded
  * @returns {Promise<DeleteObjectCommandOutput>} the response from S3 or null if required parameters are null
  */
-export async function deleteFileFromS3(key: string): Promise<DeleteObjectCommandOutput | null> {
+async function deleteFileFromS3Core(key: string): Promise<DeleteObjectCommandOutput | null> {
   const s3Client = _getS3Client();
   if (!key || !s3Client) {
     return null;
@@ -159,7 +159,7 @@ export async function bulkDeleteFilesFromS3(keys: string[]): Promise<DeleteObjec
  * @param {Record<string, string>} [metadata={}] A metadata object to store additional information with the file
  * @returns {Promise<PutObjectCommandOutput>} the response from S3
  */
-export async function uploadFileToS3(
+async function uploadFileToS3Core(
   file: Express.Multer.File,
   key: string,
   metadata: Record<string, string> = {}
@@ -264,7 +264,7 @@ export async function getFileFromS3(key: string, versionId?: string): Promise<Ge
  * @return {Promise<ListObjectsCommandOutput>} All objects at the given path, also including
  * the directory itself.
  */
-export const listFilesFromS3 = async (path: string): Promise<ListObjectsCommandOutput> => {
+const listFilesFromS3Core = async (path: string): Promise<ListObjectsCommandOutput> => {
   const s3Client = _getS3Client();
 
   return s3Client.send(
@@ -282,7 +282,7 @@ export const listFilesFromS3 = async (path: string): Promise<ListObjectsCommandO
  * @param {string} key the key of the object
  * @returns {Promise<HeadObjectCommandOutput}
  */
-export async function getObjectMeta(key: string): Promise<HeadObjectCommandOutput> {
+async function getObjectMetaCore(key: string): Promise<HeadObjectCommandOutput> {
   const s3Client = _getS3Client();
 
   return s3Client.send(new HeadObjectCommand({ Bucket: _getObjectStoreBucketName(), Key: key }));
@@ -294,7 +294,7 @@ export async function getObjectMeta(key: string): Promise<HeadObjectCommandOutpu
  * @param {string} key S3 object key
  * @return {*}  {(Promise<string | null>)} the response from S3 or null if required parameters are null
  */
-export async function getS3SignedURL(key: string): Promise<string | null> {
+async function getS3SignedURLCore(key: string): Promise<string | null> {
   const s3Client = _getS3Client();
 
   if (!key || !s3Client) {
@@ -311,6 +311,40 @@ export async function getS3SignedURL(key: string): Promise<string | null> {
       expiresIn: 300000 // 5 minutes
     }
   );
+}
+
+export const fileUtilsDependencies = {
+  deleteFileFromS3: deleteFileFromS3Core,
+  uploadFileToS3: uploadFileToS3Core,
+  uploadStreamToS3,
+  listFilesFromS3: listFilesFromS3Core,
+  getObjectMeta: getObjectMetaCore,
+  getS3SignedURL: getS3SignedURLCore,
+  generateS3FileKey
+};
+
+export async function deleteFileFromS3(key: string): Promise<DeleteObjectCommandOutput | null> {
+  return fileUtilsDependencies.deleteFileFromS3(key);
+}
+
+export async function uploadFileToS3(
+  file: Express.Multer.File,
+  key: string,
+  metadata: Record<string, string> = {}
+): Promise<PutObjectCommandOutput> {
+  return fileUtilsDependencies.uploadFileToS3(file, key, metadata);
+}
+
+export const listFilesFromS3 = async (path: string): Promise<ListObjectsCommandOutput> => {
+  return fileUtilsDependencies.listFilesFromS3(path);
+};
+
+export async function getObjectMeta(key: string): Promise<HeadObjectCommandOutput> {
+  return fileUtilsDependencies.getObjectMeta(key);
+}
+
+export async function getS3SignedURL(key: string): Promise<string | null> {
+  return fileUtilsDependencies.getS3SignedURL(key);
 }
 
 /**

--- a/api/src/utils/keycloak-utils.ts
+++ b/api/src/utils/keycloak-utils.ts
@@ -1,4 +1,4 @@
-import { JwtPayload } from 'jsonwebtoken';
+import type { JwtPayload } from 'jsonwebtoken';
 import { SOURCE_SYSTEM, SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 
 /**
@@ -204,7 +204,7 @@ export const isServiceClientUserInformation = (
  * @param {object} keycloakToken
  * @return {*}  {(SOURCE_SYSTEM | null)}
  */
-export const getKeycloakSource = (keycloakToken: object): SOURCE_SYSTEM | null => {
+const getKeycloakSourceCore = (keycloakToken: object): SOURCE_SYSTEM | null => {
   const parsedToken = keycloakToken as Record<string, any>;
   const clientId = parsedToken?.clientId?.toUpperCase();
 
@@ -219,4 +219,12 @@ export const getKeycloakSource = (keycloakToken: object): SOURCE_SYSTEM | null =
   }
 
   return null;
+};
+
+export const keycloakUtilsDependencies = {
+  getKeycloakSource: getKeycloakSourceCore
+};
+
+export const getKeycloakSource = (keycloakToken: object): SOURCE_SYSTEM | null => {
+  return keycloakUtilsDependencies.getKeycloakSource(keycloakToken);
 };

--- a/api/src/utils/media/media-utils.test.ts
+++ b/api/src/utils/media/media-utils.test.ts
@@ -5,7 +5,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ArchiveFile, MediaFile } from './media-file';
-import * as media_utils from './media-utils';
+import { mediaUtilsDependencies as media_utils } from './media-utils';
 
 chai.use(sinonChai);
 

--- a/api/src/utils/media/media-utils.ts
+++ b/api/src/utils/media/media-utils.ts
@@ -16,9 +16,9 @@ export const parseUnknownMedia = async (
   rawMedia: Express.Multer.File | GetObjectCommandOutput
 ): Promise<null | MediaFile | ArchiveFile> => {
   if ((rawMedia as Express.Multer.File).originalname) {
-    return parseUnknownMulterFile(rawMedia as Express.Multer.File);
+    return mediaUtilsDependencies.parseUnknownMulterFile(rawMedia as Express.Multer.File);
   } else {
-    return parseUnknownS3File(rawMedia as GetObjectCommandOutput);
+    return mediaUtilsDependencies.parseUnknownS3File(rawMedia as GetObjectCommandOutput);
   }
 };
 
@@ -142,4 +142,14 @@ export const isZipMimetype = (mimetype: string): boolean => {
   return [/application\/zip/, /application\/x-zip-compressed/, /application\/x-rar-compressed/].some((regex) =>
     regex.test(mimetype)
   );
+};
+
+export const mediaUtilsDependencies = {
+  parseUnknownMedia,
+  parseUnknownMulterFile,
+  parseUnknownS3File,
+  parseUnknownZipFile,
+  parseMulterFile,
+  parseS3File,
+  isZipMimetype
 };

--- a/api/src/utils/nested-record.ts
+++ b/api/src/utils/nested-record.ts
@@ -1,4 +1,6 @@
-import { get, setWith } from 'lodash';
+import lodash from 'lodash';
+
+const { get, setWith } = lodash;
 
 type IKey = string | number;
 

--- a/api/src/utils/string-utils.ts
+++ b/api/src/utils/string-utils.ts
@@ -1,4 +1,6 @@
-import { isString } from 'lodash';
+import lodash from 'lodash';
+
+const { isString } = lodash;
 
 /**
  * Safely apply `.toLowerCase()` to a value of unknown type.

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "preserve",
     "lib": ["es2023"],
     "outDir": "dist",
     "target": "es2023",
+    "noEmit": true,
     "sourceMap": true,
     "allowJs": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
@@ -21,8 +22,5 @@
     "strict": true,
     "typeRoots": ["node_modules/@types", "src/types"]
   },
-  "include": ["src"],
-  "ts-node": {
-    "files": true
-  }
+  "include": ["src"]
 }

--- a/api/tsconfig.mocha.json
+++ b/api/tsconfig.mocha.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["src", "mocha-fixtures.ts"]
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-978](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-978)

## Description of Changes

- Migrated API runtime/build/test flow to ESM (`type: module`) with `tsx` for dev/test and SWC for production builds.
- Refactored ESM-incompatible Sinon stubs to seam-based stubbing in shared modules and updated affected tests.
- Added build-time import extension rewrite for compiled output so production container startup resolves ESM imports correctly.

## Testing Notes

- In `api`, run:
  - `npm run typecheck`
  - `npm run test`
  - `npm run coverage`
- Docker checks:
  - `docker build -f api/Dockerfile .`
  - `docker build -f api/.docker/api/Dockerfile .`
- Focus review on path/service tests that previously stubbed module namespaces and on the ESM build output/runtime startup path.