### PR TITLE
SIMSBIOHUB-1007: Cleanup and update GitHub worklflows

### DIFF
--- a/.github/actions/setup-openshift-cli/action.yml
+++ b/.github/actions/setup-openshift-cli/action.yml
@@ -1,0 +1,77 @@
+name: Set up OpenShift CLI (oc)
+description: Download a pinned oc from the mirror (with actions/cache), install to PATH, and optionally log in.
+
+inputs:
+  oc-version:
+    description: OpenShift client version (e.g. 4.16.60)
+    required: false
+    default: "4.16.60"
+  cache-dir:
+    description: Cache root directory (leave empty for $HOME/.cache/oc). Leading ~ is expanded.
+    required: false
+    default: ""
+  login:
+    description: If true, run oc login using env OPENSHIFT_TOKEN
+    required: false
+    default: "false"
+  openshift-server-url:
+    description: Cluster API URL
+    required: false
+    default: "https://api.silver.devops.gov.bc.ca:6443"
+  namespace:
+    description: If non-empty, select this namespace after login (oc project)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve cache directory
+      id: paths
+      shell: bash
+      env:
+        INPUT_CACHE: ${{ inputs.cache-dir }}
+      run: |
+        if [ -z "${INPUT_CACHE}" ]; then
+          CACHED="${HOME}/.cache/oc"
+        else
+          CACHED="${INPUT_CACHE/#\~/${HOME}}"
+        fi
+        echo "cache_dir=${CACHED}" >> "${GITHUB_OUTPUT}"
+
+    - name: Restore cached oc
+      id: cache-oc
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.paths.outputs.cache_dir }}/${{ inputs.oc-version }}/${{ runner.arch }}/oc
+        key: ${{ runner.os }}-oc-${{ inputs.oc-version }}-${{ runner.arch }}
+
+    - name: Download oc (cache miss)
+      if: steps.cache-oc.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        OC_VERSION: ${{ inputs.oc-version }}
+        OC_CACHE_DIR: ${{ steps.paths.outputs.cache_dir }}
+        RUNNER_ARCH: ${{ runner.arch }}
+      run: bash "${{ github.action_path }}/download-oc.sh"
+
+    - name: Install oc to PATH
+      shell: bash
+      env:
+        OC_VERSION: ${{ inputs.oc-version }}
+        OC_CACHE_DIR: ${{ steps.paths.outputs.cache_dir }}
+      run: |
+        sudo install -m 0755 "${OC_CACHE_DIR}/${OC_VERSION}/${{ runner.arch }}/oc" /usr/local/bin/oc
+        oc version --client
+
+    - name: Log in to OpenShift
+      if: inputs.login == 'true'
+      shell: bash
+      env:
+        OPENSHIFT_TOKEN: ${{ env.OPENSHIFT_TOKEN }}
+      run: |
+        oc login --token="${OPENSHIFT_TOKEN}" --server="${{ inputs.openshift-server-url }}"
+        NS="${{ inputs.namespace }}"
+        if [ -n "${NS}" ]; then
+          oc project "${NS}"
+        fi

--- a/.github/actions/setup-openshift-cli/download-oc.sh
+++ b/.github/actions/setup-openshift-cli/download-oc.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Download and extract the OpenShift client for the current machine architecture.
+set -euo pipefail
+: "${OC_VERSION:?}"
+: "${OC_CACHE_DIR:?}"
+: "${RUNNER_ARCH:?}"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) OC_TARBALL="openshift-client-linux-${OC_VERSION}.tar.gz" ;;
+  aarch64 | arm64) OC_TARBALL="openshift-client-linux-arm64-${OC_VERSION}.tar.gz" ;;
+  ppc64le) OC_TARBALL="openshift-client-linux-ppc64le-${OC_VERSION}.tar.gz" ;;
+  *) echo "Unsupported architecture: $ARCH" >&2 && exit 1 ;;
+esac
+
+mkdir -p "${OC_CACHE_DIR}/${OC_VERSION}/${RUNNER_ARCH}"
+curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/${OC_TARBALL}" \
+  -o /tmp/openshift-client.tar.gz
+tar -xzf /tmp/openshift-client.tar.gz -C /tmp oc
+mv /tmp/oc "${OC_CACHE_DIR}/${OC_VERSION}/${RUNNER_ARCH}/oc"
+chmod +x "${OC_CACHE_DIR}/${OC_VERSION}/${RUNNER_ARCH}/oc"

--- a/.github/workflows/addComments.yml
+++ b/.github/workflows/addComments.yml
@@ -8,6 +8,9 @@ on:
       - test
       - prod
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   addOpenshiftURLComment:
     name: Add OpenShift URL Comment

--- a/.github/workflows/cleanPR.yml
+++ b/.github/workflows/cleanPR.yml
@@ -12,6 +12,8 @@ permissions:
   
 env:
   IMAGE_TAG: build-1.0.0-${{ github.event.number }}
+  OC_VERSION: "4.16.60"
+  OC_CACHE_DIR: ~/.cache/oc
 
 jobs:
   clean:
@@ -21,20 +23,17 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
     steps:
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4.16"
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
 
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
 
       # Clean all PR artifacts for the PR using Helm
       - name: Clean PR Artifacts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ concurrency:
 
 env:
   IMAGE_TAG: build-1.0.0-${{ github.event.number }}
+  OC_VERSION: "4.16.60"
+  OC_CACHE_DIR: ~/.cache/oc
+  # Opt composite JS actions (e.g. actions/download-artifact@v6) into Node.js 24 until they ship node24 runtimes.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # Print variables for logging and debugging purposes
@@ -59,7 +63,7 @@ jobs:
           cache-name: cache-repo
         with:
           # Cache repo based on the commit sha that triggered the workflow
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Install Node - for `node` and `npm` commands
@@ -88,7 +92,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -96,20 +100,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Authenticate Docker with OpenShift registry
@@ -131,7 +129,7 @@ jobs:
           docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.APP_NAME }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
@@ -166,7 +164,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -174,20 +172,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Authenticate Docker with OpenShift registry
@@ -209,7 +201,7 @@ jobs:
           docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.APP_NAME }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
@@ -244,7 +236,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -252,20 +244,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Authenticate Docker with OpenShift registry
@@ -281,7 +267,7 @@ jobs:
           docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.APP_NAME }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
@@ -316,7 +302,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -324,20 +310,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Authenticate Docker with OpenShift registry
@@ -359,7 +339,7 @@ jobs:
           docker push ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/$APP_NAME:${{ env.IMAGE_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ vars.OPENSHIFT_REGISTRY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.APP_NAME }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
@@ -403,7 +383,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -411,20 +391,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Deploy the Helm chart

--- a/.github/workflows/deployStatic.yml
+++ b/.github/workflows/deployStatic.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
   
+env:
+  OC_VERSION: "4.16.60"
+  OC_CACHE_DIR: ~/.cache/oc
+
 jobs:
   # Print variables for logging and debugging purposes
   checkEnv:
@@ -61,7 +65,7 @@ jobs:
           cache-name: cache-repo
         with:
           # Cache repo based on the commit sha that triggered the workflow
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
 
   # Build the web frontend app image
@@ -84,7 +88,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
 
       # Checkout the branch if not restored via cache
@@ -92,20 +96,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Authenticate Docker with OpenShift registry
@@ -140,7 +138,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
 
       # Checkout the branch if not restored via cache
@@ -148,20 +146,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Authenticate Docker with OpenShift registry
@@ -196,7 +188,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
 
       # Checkout the branch if not restored via cache
@@ -204,20 +196,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Authenticate Docker with OpenShift registry
@@ -254,7 +240,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha || github.sha }}
 
       # Checkout the branch if not restored via cache
@@ -262,20 +248,14 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
 
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          oc: "4.16"
-
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Deploy the Helm chart
@@ -321,16 +301,16 @@ jobs:
       BRANCH: ${{ github.base_ref || github.ref_name }}
       TOOLS_NAMESPACE: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools
     steps:
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4.16"
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
 
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
 
       - name: Prune old environment image tags
         run: |

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -31,13 +31,13 @@ jobs:
 
       # Cache the repo
       - name: Cache repo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-repo
         env:
           cache-name: cache-repo
         with:
           # Cache repo based on the commit sha that triggered the workflow
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
   lintAndFormat:
@@ -54,12 +54,12 @@ jobs:
 
       # Load repo from cache
       - name: Cache repo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-repo
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache
@@ -69,7 +69,7 @@ jobs:
 
       # api
       - name: Cache api node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-api-node-modules
         with:
@@ -93,7 +93,7 @@ jobs:
 
       # app
       - name: Cache app node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-app-node-modules
         with:
@@ -117,7 +117,7 @@ jobs:
 
       # database
       - name: Cache database node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-database-node-modules
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           cache-name: cache-repo
         with:
           # Cache repo based on the commit sha that triggered the workflow
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
   test:
@@ -59,7 +59,7 @@ jobs:
         env:
           cache-name: cache-repo
         with:
-          path: ${{ github.workspace }}/*
+          path: ${{ github.workspace }}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.event.pull_request.head.sha }}
 
       # Checkout the branch if not restored via cache

--- a/.github/workflows/toDraft.yml
+++ b/.github/workflows/toDraft.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [converted_to_draft]
 
+env:
+  OC_VERSION: "4.16.60"
+  OC_CACHE_DIR: ~/.cache/oc
+
 jobs:
   scaleDownPods:
     name: Scale down the pods for this PR
@@ -14,20 +18,17 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
     steps:
-      # Install oc, which was removed from the ubuntu-latest image in v24.04
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4.16"
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
 
-      # Log in to OpenShift
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v1
+      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
+      - uses: ./.github/actions/setup-openshift-cli
+        env:
+          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
         with:
-          openshift_server_url: https://api.silver.devops.gov.bc.ca:6443
-          openshift_token: ${{ secrets.TOOLS_SA_TOKEN }}
+          oc-version: ${{ env.OC_VERSION }}
+          cache-dir: ${{ env.OC_CACHE_DIR }}
+          login: "true"
 
       - name: Scale down
         run: |


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1007](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1007)

## Description of Changes

- Added a local composite action, **`.github/actions/setup-openshift-cli`**, for download/install of pinned **oc 4.16.60** (with `actions/cache`), `oc login`, and optional `oc project`. Replaced the repeated shell blocks in **deploy**, **deployStatic**, **cleanPR**, and **toDraft**.
- Bumped **Trivy** to **v0.36.0** and **actions/cache** to **v5** so we’re not pulling old Node 20–only dependencies from those actions.
- Set **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** on workflows that still use JS actions on Node 20 (e.g. **`deploy.yml`**, **`addComments.yml`**).

## Testing Notes

- Run a normal PR from a branch in this repo (not a fork) and confirm the OpenShift deploy workflow completes.
- After merge, spot-check static deploy or clean-up if you want extra confidence.
- In the Actions run, confirm there are no new Node 20 deprecation warnings for the steps you care about.