### PR TITLE
SIMSBIOHUB-1023: Fix issue with Animals not displaying

### DIFF
--- a/app/src/contexts/surveyContext.test.tsx
+++ b/app/src/contexts/surveyContext.test.tsx
@@ -20,10 +20,7 @@ const mockBiohubApi = useBiohubApi as Mock;
 const mockUseDataLoader = useDataLoader as Mock;
 const mockUseParams = useParams as Mock;
 
-const createMockDataLoader = (
-  refresh = vi.fn(),
-  data?: unknown
-): DataLoader<[number, number], unknown, unknown> => ({
+const createMockDataLoader = (refresh = vi.fn(), data?: unknown): DataLoader<[number, number], unknown, unknown> => ({
   data,
   error: undefined,
   isLoading: false,
@@ -137,7 +134,9 @@ describe('SurveyContextProvider', () => {
           <SurveyContext.Consumer>{() => <></>}</SurveyContext.Consumer>
         </SurveyContextProvider>
       )
-    ).toThrow("The project ID found in SurveyContextProvider was invalid. Does your current React route provide an 'id' parameter?");
+    ).toThrow(
+      "The project ID found in SurveyContextProvider was invalid. Does your current React route provide an 'id' parameter?"
+    );
   });
 
   it('throws when survey id route param is missing', () => {

--- a/app/src/contexts/surveyContext.test.tsx
+++ b/app/src/contexts/surveyContext.test.tsx
@@ -1,0 +1,156 @@
+import { SurveyContext, SurveyContextProvider } from 'contexts/surveyContext';
+import { useBiohubApi } from 'hooks/useBioHubApi';
+import useDataLoader, { DataLoader } from 'hooks/useDataLoader';
+import { useParams } from 'react-router';
+import { getSurveyForViewResponse } from 'test-helpers/survey-helpers';
+import { cleanup, render, waitFor } from 'test-helpers/test-utils';
+import { Mock } from 'vitest';
+
+vi.mock('hooks/useBioHubApi');
+vi.mock('hooks/useDataLoader');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useParams: vi.fn()
+  };
+});
+
+const mockBiohubApi = useBiohubApi as Mock;
+const mockUseDataLoader = useDataLoader as Mock;
+const mockUseParams = useParams as Mock;
+
+const createMockDataLoader = (
+  refresh = vi.fn(),
+  data?: unknown
+): DataLoader<[number, number], unknown, unknown> => ({
+  data,
+  error: undefined,
+  isLoading: false,
+  isReady: true,
+  hasLoaded: false,
+  load: vi.fn(),
+  refresh,
+  clearError: vi.fn(),
+  clearData: vi.fn()
+});
+
+describe('SurveyContextProvider', () => {
+  const surveyRefresh = vi.fn();
+  const artifactRefresh = vi.fn();
+  const critterRefresh = vi.fn();
+
+  const mockApi = {
+    survey: {
+      getSurveyForView: vi.fn(),
+      getSurveyAttachments: vi.fn(),
+      getSurveyCritters: vi.fn()
+    }
+  };
+
+  beforeEach(() => {
+    mockBiohubApi.mockReturnValue(mockApi);
+    mockUseParams.mockReturnValue({ id: '1', survey_id: '5' });
+
+    mockUseDataLoader.mockImplementation((fetchFn) => {
+      if (fetchFn === mockApi.survey.getSurveyForView) {
+        return createMockDataLoader(surveyRefresh, undefined);
+      }
+
+      if (fetchFn === mockApi.survey.getSurveyAttachments) {
+        return createMockDataLoader(artifactRefresh, undefined);
+      }
+
+      if (fetchFn === mockApi.survey.getSurveyCritters) {
+        return createMockDataLoader(critterRefresh, undefined);
+      }
+
+      throw new Error('Unexpected data loader fetch function');
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('refreshes survey, artifact, and critter data loaders on mount', async () => {
+    render(
+      <SurveyContextProvider>
+        <SurveyContext.Consumer>{() => <></>}</SurveyContext.Consumer>
+      </SurveyContextProvider>
+    );
+
+    await waitFor(() => {
+      expect(surveyRefresh).toHaveBeenCalledWith(1, 5);
+      expect(artifactRefresh).toHaveBeenCalledWith(1, 5);
+      expect(critterRefresh).toHaveBeenCalledWith(1, 5);
+    });
+  });
+
+  it('does not refresh loaders when loaded survey data matches route params', async () => {
+    mockUseDataLoader.mockImplementation((fetchFn) => {
+      if (fetchFn === mockApi.survey.getSurveyForView) {
+        return createMockDataLoader(surveyRefresh, {
+          ...getSurveyForViewResponse,
+          surveyData: {
+            ...getSurveyForViewResponse.surveyData,
+            survey_details: {
+              ...getSurveyForViewResponse.surveyData.survey_details,
+              project_id: 1,
+              id: 5
+            }
+          }
+        });
+      }
+
+      if (fetchFn === mockApi.survey.getSurveyAttachments) {
+        return createMockDataLoader(artifactRefresh, undefined);
+      }
+
+      if (fetchFn === mockApi.survey.getSurveyCritters) {
+        return createMockDataLoader(critterRefresh, undefined);
+      }
+
+      throw new Error('Unexpected data loader fetch function');
+    });
+
+    render(
+      <SurveyContextProvider>
+        <SurveyContext.Consumer>{() => <></>}</SurveyContext.Consumer>
+      </SurveyContextProvider>
+    );
+
+    await waitFor(() => {
+      expect(surveyRefresh).not.toHaveBeenCalled();
+      expect(artifactRefresh).not.toHaveBeenCalled();
+      expect(critterRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  it('throws when project id route param is missing', () => {
+    mockUseParams.mockReturnValue({ survey_id: '5' });
+
+    expect(() =>
+      render(
+        <SurveyContextProvider>
+          <SurveyContext.Consumer>{() => <></>}</SurveyContext.Consumer>
+        </SurveyContextProvider>
+      )
+    ).toThrow("The project ID found in SurveyContextProvider was invalid. Does your current React route provide an 'id' parameter?");
+  });
+
+  it('throws when survey id route param is missing', () => {
+    mockUseParams.mockReturnValue({ id: '1' });
+
+    expect(() =>
+      render(
+        <SurveyContextProvider>
+          <SurveyContext.Consumer>{() => <></>}</SurveyContext.Consumer>
+        </SurveyContextProvider>
+      )
+    ).toThrow(
+      "The survey ID found in SurveyContextProvider was invalid. Does your current React route provide a 'survey_id' parameter?"
+    );
+  });
+});

--- a/app/src/contexts/surveyContext.tsx
+++ b/app/src/contexts/surveyContext.tsx
@@ -96,6 +96,7 @@ export const SurveyContextProvider = (props: PropsWithChildren<Record<never, any
     ) {
       surveyDataLoader.refresh(projectId, surveyId);
       artifactDataLoader.refresh(projectId, surveyId);
+      critterDataLoader.refresh(projectId, surveyId);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1023](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1023)

## Description of Changes

- Restored `critterDataLoader.refresh(projectId, surveyId)` in `SurveyContextProvider` so survey critters are loaded on mount and when navigating between surveys.
- **Root cause:** In #1630, render-time `.load()` calls were removed from `surveyContext.tsx` as part of a cleanup/SonarCloud refactor. Survey and artifact loaders continued to load via the existing `useEffect`, but `critterDataLoader.refresh()` was also removed from that effect, leaving no code path to populate critter data on a fresh page load.
- **User impact:** Animals appeared in the API (`GET /api/project/:id/survey/:id/critters`) but not in the Manage Animals left panel after reload. Creating an animal still worked because `CreateAnimalPage` explicitly calls `critterDataLoader.refresh()` after save.
- **Scope:** This fix applies to all consumers of `surveyContext.critterDataLoader`, including the animals list, animal overview map/table, deployment tables, and the animal autocomplete field.

## Testing Notes

- Navigate to **Manage Animals** (`/admin/projects/:id/surveys/:id/animals/details`) for a survey with existing animals.
- Confirm animals appear in the left panel on initial page load (hard refresh).
- Create a new animal, return to Manage Animals, and confirm it appears without requiring a manual refresh.
- Switch to a different survey and back; confirm the animal list updates correctly.
- Spot-check **Telemetry → Deployments** and **Devices** tables to confirm animal nicknames render (they also read from `surveyContext.critterDataLoader`).
- Spot-check the **Animal Overview** map/table on Manage Animals when no animal is selected.