### PR TITLE
SIMSBIOHUB-1034: Adjust artifact_key in published survey

### DIFF
--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -632,7 +632,7 @@ export class PostSurveyReportAttachmentsToBiohubObject implements BioHubSubmissi
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.REPORT;
     this.properties = {
-      artifact_key: reportAttachmentRecord.key,
+      artifact_key: 'files/' + reportAttachmentRecord.file_name,
       filename: reportAttachmentRecord.file_name,
       file_type: ATTACHMENT_TYPE.REPORT,
       file_size: reportAttachmentRecord.file_size,


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1034](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1034)

## Description of Changes

- Adjust the value for `artifact_key` to be absolute for the tarball. Eg `files/Moose_Walklines (1).zip` instead of `sims/projects/150/surveys/160/Moose_Walklines (1).zip`

## Testing Notes

- N/A
