### PR TITLE
SIMSBIOHUB-1041: Adjust collected_data values in published survey

### DIFF
--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -1017,7 +1017,7 @@ describe('PostSurveyToBiohubObject', () => {
         end_date: 'end_date',
         collected_data: [
           {
-            survey_type_id: '9'
+            survey_type: 'code::type::9'
           }
         ],
         objectives: 'Test survey objectives'

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -1331,8 +1331,9 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     const focalSpeciesArray = buildFocalSpeciesArray(focalSpecies);
 
     // Create collected data array from survey types
-    const collectedDataArray =
-      surveyData.survey_types.map((survey_type_id) => ({ survey_type_id: String(survey_type_id) })) || [];
+    const collectedDataArray = surveyData.survey_types.map((survey_type_id) => ({
+      survey_type: buildCodesetReference('type', survey_type_id, codesetExportContext)
+    }));
 
     // Create stratum features
     const stratumFeatures = mapOrEmpty(strata, (stratum) => new PostStratumToBiohubObject(stratum));


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1041](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1041)

## Description of Changes

- Adjust dataset's `collected_data` value to now emit `{ "survey_type": "code::type::12" }` instead of `{ "survey_type_id": "12" }`, using the existing `type` codeset category that's already included in the tarball's `codes/codeset.json`.

## Testing Notes

- N/A
