### PR TITLE
SIMSBIOHUB-1053: Fix file_size, method_technique, partnerships

### DIFF
--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -605,7 +605,7 @@ export class PostSurveyAttachmentsToBiohubObject implements BioHubSubmissionFeat
       artifact_key: attachmentRecord.key,
       filename: attachmentRecord.file_name,
       file_type: attachmentRecord.file_type,
-      file_size: attachmentRecord.file_size,
+      file_size: Number(attachmentRecord.file_size),
       ...(attachmentRecord.title ? { title: attachmentRecord.title } : {}),
       ...(attachmentRecord.description ? { description: attachmentRecord.description } : {})
     };
@@ -635,7 +635,7 @@ export class PostSurveyReportAttachmentsToBiohubObject implements BioHubSubmissi
       artifact_key: 'files/' + reportAttachmentRecord.file_name,
       filename: reportAttachmentRecord.file_name,
       file_type: ATTACHMENT_TYPE.REPORT,
-      file_size: reportAttachmentRecord.file_size,
+      file_size: Number(reportAttachmentRecord.file_size),
       name: reportAttachmentRecord.title,
       description: reportAttachmentRecord.description,
       year: reportAttachmentRecord.year_published
@@ -707,8 +707,12 @@ export class PostSurveySamplingPeriodToBiohubObject implements BioHubSubmissionF
   properties: Record<string, unknown>;
   child_features: BioHubSubmissionFeature[];
 
-  constructor(samplingPeriodRecord: SurveySamplePeriodDetails) {
+  constructor(
+    samplingPeriodRecord: SurveySamplePeriodDetails,
+    options: { codesetExportContext: CodesetExportContext }
+  ) {
     defaultLog.debug({ label: 'PostSurveySamplingPeriodToBiohubObject', message: 'params', samplingPeriodRecord });
+    const { codesetExportContext } = options;
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.SAMPLE_PERIOD;
@@ -728,8 +732,14 @@ export class PostSurveySamplingPeriodToBiohubObject implements BioHubSubmissionF
           }
         : {}),
       site_identifier: samplingPeriodRecord.survey_sample_site?.name || null,
-      method_technique_id: samplingPeriodRecord.method_technique?.method_technique_id
-        ? String(samplingPeriodRecord.method_technique.method_technique_id)
+      // BioHub validates `method_technique` as a code property, so emit a code reference
+      // (code::method_technique::<id>) rather than the raw numeric id.
+      method_technique: samplingPeriodRecord.method_technique?.method_technique_id
+        ? buildCodesetReference(
+            'method_technique',
+            samplingPeriodRecord.method_technique.method_technique_id,
+            codesetExportContext
+          )
         : null
     };
     this.child_features = [];
@@ -845,11 +855,12 @@ export class PostSurveyHabitatFeatureToBiohubObject implements BioHubSubmissionF
       timestamp = `${habitatFeatureRecord.observed_date}T00:00:00.000Z`;
     }
 
-    // Create associated species array from focal species
+    // Create associated species array from focal species.
+    // BioHub validates `associated_species` as a taxon property (allow_multiple), so each element
+    // must be a bare TSN number, not an object.
     const associatedSpeciesArray =
-      habitatFeatureRecord.survey_habitat_feature_taxons?.map((species: { itis_tsn: number }) => ({
-        taxon_id: species.itis_tsn
-      })) || [];
+      habitatFeatureRecord.survey_habitat_feature_taxons?.map((species: { itis_tsn: number }) => species.itis_tsn) ||
+      [];
 
     this.id = crypto.randomUUID();
     this.type = BiohubFeatureType.HABITAT_FEATURE;
@@ -1247,7 +1258,14 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       return includeFeatureTypes ? includeFeatureTypes.has(featureType) : true;
     };
 
-    const codesetExportContext = buildCodesetExportContext(codesetCategories ?? []);
+    // Append a survey-scoped `method_technique` codeset category so that the `method_technique`
+    // code references emitted on sampling periods can be resolved by BioHub on ingestion.
+    const methodTechniqueCategory = buildMethodTechniqueCodesetCategory(samplingTechniques);
+    const allCodesetCategories = methodTechniqueCategory
+      ? [...(codesetCategories ?? []), methodTechniqueCategory]
+      : (codesetCategories ?? []);
+
+    const codesetExportContext = buildCodesetExportContext(allCodesetCategories);
 
     const observationFeatures = observationRecords.map(
       (observation) =>
@@ -1290,7 +1308,7 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
 
     const samplingPeriodFeatures = mapOrEmpty(
       samplingPeriods,
-      (samplingPeriod) => new PostSurveySamplingPeriodToBiohubObject(samplingPeriod)
+      (samplingPeriod) => new PostSurveySamplingPeriodToBiohubObject(samplingPeriod, { codesetExportContext })
     );
 
     const samplingTechniqueFeatures = mapOrEmpty(
@@ -1344,8 +1362,8 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
     });
 
     // Create codeset feature if codeset categories are available
-    const codesetFeature = codesetCategories?.length
-      ? [new PostCodesetToBiohubObject(codesetCategories, codesetExportContext)]
+    const codesetFeature = allCodesetCategories.length
+      ? [new PostCodesetToBiohubObject(allCodesetCategories, codesetExportContext)]
       : [];
 
     this.id = crypto.randomUUID();
@@ -1487,20 +1505,20 @@ function buildPartnershipsValue(
   _firstNations: { id: number; name: string }[] | undefined,
   options: { codesetExportContext: CodesetExportContext }
 ): {
-  indigenous_partnerships: { name: string }[];
-  stakeholder_partnerships: { name: string }[];
+  indigenous_partnerships: string[];
+  stakeholder_partnerships: string[];
 } | null {
   if (!partnerships) {
     return null;
   }
 
+  // BioHub validates `indigenous_partnerships` and `stakeholder_partnerships` as string properties
+  // (allow_multiple), so each element must be a plain string, not a `{ name }` object.
   const { codesetExportContext } = options;
-  const indigenousPartnerships = (partnerships.indigenous_partnerships || []).map((id) => ({
-    name: buildCodesetReference('first_nations', id, codesetExportContext)
-  }));
-  const stakeholderPartnerships = (partnerships.stakeholder_partnerships || []).map((name) => ({
-    name: name
-  }));
+  const indigenousPartnerships = (partnerships.indigenous_partnerships || []).map((id) =>
+    buildCodesetReference('first_nations', id, codesetExportContext)
+  );
+  const stakeholderPartnerships = (partnerships.stakeholder_partnerships || []).map((name) => name);
 
   if (indigenousPartnerships.length === 0 && stakeholderPartnerships.length === 0) {
     return null;
@@ -1542,6 +1560,35 @@ function buildSurveyDateProperties(surveyData: GetSurveyData): Record<string, st
   }
 
   return props;
+}
+
+/**
+ * Builds a survey-scoped `method_technique` codeset category from the survey's sampling techniques.
+ *
+ * Sampling periods reference their technique via a `code::method_technique::<method_technique_id>`
+ * reference. Method techniques are survey-specific (not a global codeset), so they are published as a
+ * dedicated codeset category keyed by `method_technique_id` to allow BioHub to resolve those references
+ * on ingestion.
+ *
+ * @param {SampleTechniqueRecord[]} [samplingTechniques] - The survey's sampling techniques.
+ * @return {*}  {(CodesetCategory | null)} The codeset category, or null when there are no techniques.
+ */
+function buildMethodTechniqueCodesetCategory(samplingTechniques?: SampleTechniqueRecord[]): CodesetCategory | null {
+  if (!samplingTechniques || samplingTechniques.length === 0) {
+    return null;
+  }
+
+  return {
+    key: 'method_technique',
+    label: 'Method Technique',
+    description: 'Sampling method techniques defined for this survey.',
+    codes: samplingTechniques.map((technique) => ({
+      key: String(technique.method_technique_id),
+      label: technique.method_name,
+      description: technique.description,
+      external_id: null
+    }))
+  };
 }
 
 /**

--- a/api/src/models/complete-biohub-integration.test.ts
+++ b/api/src/models/complete-biohub-integration.test.ts
@@ -118,7 +118,7 @@ describe('Complete BioHub Integration', () => {
       expect(habitatFeature?.properties.name).to.equal('code::habitat_feature_type::1');
       expect(habitatFeature?.properties.count).to.equal(2);
       expect(habitatFeature?.properties.timestamp).to.equal('2024-06-15T14:30:00Z');
-      expect(habitatFeature?.properties.associated_species).to.deep.equal([{ taxon_id: 180543 }]);
+      expect(habitatFeature?.properties.associated_species).to.deep.equal([180543]);
 
       // Verify telemetry device
       const deviceFeature = surveyObj.child_features.find((f) => f.type === 'telemetry_device');

--- a/api/src/models/habitat-features.test.ts
+++ b/api/src/models/habitat-features.test.ts
@@ -46,7 +46,7 @@ describe('Habitat Features BioHub Integration', () => {
       expect(habitatFeatureObj.properties.name).to.equal('code::habitat_feature_type::456');
       expect(habitatFeatureObj.properties.count).to.equal(5);
       expect(habitatFeatureObj.properties.timestamp).to.equal('2024-01-15T10:30:00Z');
-      expect(habitatFeatureObj.properties.associated_species).to.deep.equal([{ taxon_id: 180543 }]);
+      expect(habitatFeatureObj.properties.associated_species).to.deep.equal([180543]);
       expect((habitatFeatureObj.properties.geometry as any).type).to.equal('FeatureCollection');
       expect((habitatFeatureObj.properties.geometry as any).features).to.have.length(1);
       expect((habitatFeatureObj.properties.geometry as any).features[0].geometry.coordinates).to.deep.equal([
@@ -244,9 +244,7 @@ describe('Habitat Features BioHub Integration', () => {
       expect(submissionObj.content.child_features[0].type).to.equal('habitat_feature');
       expect(submissionObj.content.child_features[0].properties.name).to.equal('code::habitat_feature_type::500');
       expect(submissionObj.content.child_features[0].properties.count).to.equal(3);
-      expect(submissionObj.content.child_features[0].properties.associated_species).to.deep.equal([
-        { taxon_id: 179913 }
-      ]);
+      expect(submissionObj.content.child_features[0].properties.associated_species).to.deep.equal([179913]);
     });
   });
 });

--- a/api/src/models/sampling-features.test.ts
+++ b/api/src/models/sampling-features.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import {
+  minimalCodesetExportContext,
   PostSurveySamplingPeriodToBiohubObject,
   PostSurveySamplingSiteToBiohubObject,
   PostSurveySubmissionToBioHubObject,
@@ -86,7 +87,9 @@ describe('Sampling Features BioHub Integration', () => {
         method_technique: null
       };
 
-      const periodFeature = new PostSurveySamplingPeriodToBiohubObject(samplePeriod);
+      const periodFeature = new PostSurveySamplingPeriodToBiohubObject(samplePeriod, {
+        codesetExportContext: minimalCodesetExportContext
+      });
 
       expect(periodFeature.id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(periodFeature.type).to.equal('sample_period');


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1053](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1053)

## Description of Changes

Aligns the data SIMS publishes to BioHub with BioHub's feature-property validation. All changes are in `api/src/models/biohub-create.ts`:

- **`method_technique`** (sample_period): publishes a `code::method_technique::<id>` reference instead of the raw numeric id, and renamed the property from `method_technique_id`. A survey-scoped `method_technique` codeset category (built from the survey's sampling techniques) is now written to `codes/codeset.json` so BioHub can resolve the reference.
- **`associated_species`** (habitat_feature): now an array of bare TSN numbers instead of `{ taxon_id }` objects.
- **`indigenous_partnerships` / `stakeholder_partnerships`** (dataset): now arrays of plain strings instead of `{ name }` objects.
- **`file_size`** (file, report): coerced to a number (the source value is a string).

Requires the corresponding BioHub PR to be deployed together.

## Testing Notes

- Publish a survey that exercises all of the above (sampling periods with techniques, file + report attachments, habitat features with associated species, and partnerships) and confirm BioHub ingests it with no `TYPE_MISMATCH`, `INVALID_TAXON_VALUE`, `UNSUPPORTED_PROPERTY_TYPE`, or `UNRESOLVED_CODE_REFERENCE` errors.
- Confirm `codes/codeset.json` contains a `method_technique` category keyed by `method_technique_id`, and that the sample_period's `method_technique` value matches a key in it.
- Spot-check the published payload: `file_size` is a number, `associated_species` is `[tsn, …]`, partnerships are `["name", …]`.
- Surveys with no sampling techniques should still publish cleanly (no empty/extra codeset category).