### PR TITLE
SIMSBIOHUB-1075: Replace `dataset` feature_type with `survey`

### DIFF
--- a/api/src/constants/database.ts
+++ b/api/src/constants/database.ts
@@ -14,7 +14,7 @@ export enum SYSTEM_IDENTITY_SOURCE {
 }
 
 /**
- * The source system for a dataset submission.
+ * The source system for a survey submission.
  *
  * Typically an external system that is participating in BioHub by submitting data to the BioHub Platform Backbone.
  *

--- a/api/src/models/biohub-create.test.ts
+++ b/api/src/models/biohub-create.test.ts
@@ -1005,7 +1005,7 @@ describe('PostSurveyToBiohubObject', () => {
     });
 
     it('sets type', () => {
-      expect(data.type).to.equal('dataset');
+      expect(data.type).to.equal(BiohubFeatureType.SURVEY);
     });
 
     it('sets properties', () => {

--- a/api/src/models/biohub-create.ts
+++ b/api/src/models/biohub-create.ts
@@ -1367,7 +1367,7 @@ export class PostSurveyToBiohubObject implements BioHubSubmissionFeature {
       : [];
 
     this.id = crypto.randomUUID();
-    this.type = BiohubFeatureType.DATASET;
+    this.type = BiohubFeatureType.SURVEY;
     this.properties = {
       survey_id: surveyData.id,
       project_id: surveyData.project_id,
@@ -1737,7 +1737,6 @@ export enum BiohubFeatureType {
   BLOCK = 'block',
   CAPTURE = 'capture',
   CODESET = 'codeset',
-  DATASET = 'dataset',
   ECOLOGICAL_UNIT = 'ecological_unit',
   FILE = 'file',
   HABITAT_FEATURE = 'habitat_feature',
@@ -1751,6 +1750,7 @@ export enum BiohubFeatureType {
   SAMPLE_SITE = 'sample_site',
   SAMPLE_TECHNIQUE = 'sample_technique',
   STRATUM = 'stratum',
+  SURVEY = 'survey',
   STUDY_AREA = 'study_area',
   TELEMETRY = 'telemetry',
   TELEMETRY_DEPLOYMENT = 'telemetry_deployment',

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -5,12 +5,12 @@ import { describe } from 'mocha';
 import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { getMockDBConnection } from '../__mocks__/db';
 import { ApiError, ApiErrorType } from '../errors/api-error';
 import { BiohubFeatureType } from '../models/biohub-create';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
 import { envConfigDependencies as envConfig } from '../utils/env-config';
 import { featureFlagDependencies as featureFlagUtils } from '../utils/feature-flag-utils';
+import { getMockDBConnection } from '../__mocks__/db';
 import { AttachmentService } from './attachment-service';
 import { CodeService } from './code-service';
 import { SurveyHabitatFeatureService } from './habitat-feature-services/survey-habitat-feature-service';
@@ -160,7 +160,9 @@ describe('PlatformService', () => {
 
       sinon
         .stub(PlatformService.prototype, '_flattenToBlockModel')
-        .returns([{ id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null }]);
+        .returns([
+          { id: 'test-survey-root-id', type: BiohubFeatureType.SURVEY, properties: {}, content: [], parent: null }
+        ]);
 
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
@@ -212,7 +214,9 @@ describe('PlatformService', () => {
 
       sinon
         .stub(PlatformService.prototype, '_flattenToBlockModel')
-        .returns([{ id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null }]);
+        .returns([
+          { id: 'test-survey-root-id', type: BiohubFeatureType.SURVEY, properties: {}, content: [], parent: null }
+        ]);
 
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
@@ -295,7 +299,9 @@ describe('PlatformService', () => {
         .resolves({ id: '123-456-789', name: 'Test', description: 'Test Description' } as unknown as any);
       sinon
         .stub(PlatformService.prototype, '_flattenToBlockModel')
-        .returns([{ id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null }]);
+        .returns([
+          { id: 'test-survey-root-id', type: BiohubFeatureType.SURVEY, properties: {}, content: [], parent: null }
+        ]);
       sinon.stub(PlatformService.prototype, '_createTarArchive').resolves();
 
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
@@ -505,7 +511,7 @@ describe('PlatformService', () => {
       expect(response).to.have.property('id');
       expect(response).to.have.property('description', 'a description of the purpose');
       expect(response).to.have.property('comment', 'a comment about the submission');
-      expect(response.content).to.have.property('type', 'dataset');
+      expect(response.content).to.have.property('type', BiohubFeatureType.SURVEY);
       expect(response.content.properties).to.have.property('survey_id', 1);
     });
 
@@ -557,8 +563,8 @@ describe('PlatformService', () => {
       const nestedData = {
         content: {
           id: 'root-id',
-          type: 'dataset',
-          properties: { name: 'Test Dataset' },
+          type: BiohubFeatureType.SURVEY,
+          properties: { name: 'Test Survey' },
           child_features: [
             {
               id: 'child-1',
@@ -583,7 +589,7 @@ describe('PlatformService', () => {
       expect(result).to.have.length(2);
       expect(result.find((b) => b.id === 'root-id')).to.deep.include({
         id: 'root-id',
-        type: 'dataset',
+        type: BiohubFeatureType.SURVEY,
         parent: null,
         content: ['child-1']
       });
@@ -629,9 +635,9 @@ describe('PlatformService', () => {
 
       const nestedData = {
         content: {
-          id: 'dataset-id',
-          type: 'dataset',
-          properties: { name: 'Test Dataset' },
+          id: 'survey-root-id',
+          type: BiohubFeatureType.SURVEY,
+          properties: { name: 'Test Survey' },
           child_features: [
             {
               id: 'observation-id',
@@ -653,12 +659,12 @@ describe('PlatformService', () => {
 
       expect(result).to.have.length(3);
 
-      const datasetBlock = result.find((b) => b.id === 'dataset-id');
-      expect(datasetBlock?.content).to.deep.equal(['observation-id']);
+      const surveyBlock = result.find((b) => b.id === 'survey-root-id');
+      expect(surveyBlock?.content).to.deep.equal(['observation-id']);
       expect(result.find((b) => b.id === 'codeset-id')).to.deep.include({
         id: 'codeset-id',
         type: BiohubFeatureType.CODESET,
-        parent: 'dataset-id',
+        parent: 'survey-root-id',
         content: []
       });
     });
@@ -681,12 +687,12 @@ describe('PlatformService', () => {
       sinon.stub(AttachmentService.prototype, 'getSurveyReportAttachments').resolves([]);
 
       const mockSurveyDataPackage = {
-        id: 'test-dataset-id',
+        id: 'test-survey-root-id',
         name: 'Test Survey',
         description: 'Test Description',
         content: {
-          id: 'test-dataset-id',
-          type: 'dataset',
+          id: 'test-survey-root-id',
+          type: BiohubFeatureType.SURVEY,
           properties: { survey_id: 1 },
           child_features: [
             {
@@ -711,8 +717,8 @@ describe('PlatformService', () => {
       // Stub fs methods that are called but we can't stub directly
       // We'll verify through the _createTarArchive stub instead
       const flattenToBlockModelStub = sinon.stub(PlatformService.prototype, '_flattenToBlockModel').returns([
-        { id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null },
-        { id: 'obs-1', type: 'species_observation', properties: {}, content: [], parent: 'test-dataset-id' }
+        { id: 'test-survey-root-id', type: BiohubFeatureType.SURVEY, properties: {}, content: [], parent: null },
+        { id: 'obs-1', type: 'species_observation', properties: {}, content: [], parent: 'test-survey-root-id' }
       ]);
 
       sinon.stub(fs, 'statSync').callsFake(() => ({ size: 1024 }));
@@ -754,10 +760,10 @@ describe('PlatformService', () => {
       sinon.stub(AttachmentService.prototype, 'getSurveyReportAttachments').resolves([]);
 
       const mockSurveyDataPackage = {
-        id: 'test-dataset-id',
+        id: 'test-survey-root-id',
         name: 'Test Survey',
         description: 'Test Description',
-        content: { id: 'test-id', type: 'dataset' }
+        content: { id: 'test-id', type: BiohubFeatureType.SURVEY }
       };
 
       sinon
@@ -791,12 +797,12 @@ describe('PlatformService', () => {
       sinon.stub(AttachmentService.prototype, 'getSurveyReportAttachments').resolves([]);
 
       const mockSurveyDataPackage = {
-        id: 'test-dataset-id',
+        id: 'test-survey-root-id',
         name: 'Test Survey',
         description: 'Test Description',
         content: {
-          id: 'test-dataset-id',
-          type: 'dataset',
+          id: 'test-survey-root-id',
+          type: BiohubFeatureType.SURVEY,
           properties: { survey_id: 1 }
         }
       };
@@ -807,7 +813,9 @@ describe('PlatformService', () => {
 
       sinon
         .stub(PlatformService.prototype, '_flattenToBlockModel')
-        .returns([{ id: 'test-dataset-id', type: 'dataset', properties: {}, content: [], parent: null }]);
+        .returns([
+          { id: 'test-survey-root-id', type: BiohubFeatureType.SURVEY, properties: {}, content: [], parent: null }
+        ]);
 
       sinon.stub(HistoryPublishService.prototype, 'insertSurveyMetadataPublishRecord').resolves();
 
@@ -843,9 +851,9 @@ describe('PlatformService', () => {
       const platformService = new PlatformService(mockDBConnection);
 
       const pack: any = {};
-      const datasetId = 'test-dataset-id';
+      const archiveRootId = 'test-survey-root-id';
       const blocksByType = new Map<string, any[]>([
-        ['dataset', [{ id: 'd1' }]],
+        [BiohubFeatureType.SURVEY, [{ id: 'd1' }]],
         ['codeset', [{ id: 'c1' }]],
         ['habitat_feature', [{ id: 'h1' }]]
       ]);
@@ -854,12 +862,34 @@ describe('PlatformService', () => {
         .stub(platformService as any, '_addFileToArchive')
         .callsFake(() => Promise.resolve());
 
-      await platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any);
+      await platformService._addJsonFilesToArchive(pack, archiveRootId, blocksByType as any);
 
       const writtenPaths = addFileToArchiveStub.getCalls().map((call) => call.args[2]);
-      expect(writtenPaths).to.include('features/dataset.json');
+      expect(writtenPaths).to.include('features/survey.json');
       expect(writtenPaths).to.include('codes/codeset.json');
       expect(writtenPaths).to.include('features/habitat_feature.json');
+    });
+
+    it('should write survey metadata marker to the archive root', () => {
+      const mockDBConnection = getMockDBConnection();
+      const platformService = new PlatformService(mockDBConnection);
+
+      const pack: any = {
+        entry: sinon.stub().callsFake((_header: unknown, _content: unknown, callback: () => void) => callback()),
+        destroy: sinon.stub()
+      };
+      const blocksByType = new Map<string, any[]>();
+      const addJsonFilesStub = sinon.stub(platformService as any, '_addJsonFiles').resolves();
+
+      platformService._addMetadataFile(pack, 'test-survey-root-id', blocksByType as any);
+
+      expect(pack.entry).to.have.been.calledOnce;
+      expect(pack.entry.firstCall.args[0]).to.deep.include({
+        name: 'test-survey-root-id/.survey-id',
+        size: 'test-survey-root-id'.length
+      });
+      expect(pack.entry.firstCall.args[1].toString()).to.equal('test-survey-root-id');
+      expect(addJsonFilesStub).to.have.been.calledOnceWith(pack, 'test-survey-root-id', blocksByType);
     });
 
     it('should write codeset block properties as codes/codeset.json content when first block has properties', async () => {
@@ -867,7 +897,7 @@ describe('PlatformService', () => {
       const platformService = new PlatformService(mockDBConnection);
 
       const pack: any = {};
-      const datasetId = 'test-dataset-id';
+      const archiveRootId = 'test-survey-root-id';
       const codesetProperties = { life_stage: { id: 'life_stage', label: 'Life Stage', codes: {} } };
       const blocksByType = new Map<string, any[]>([
         ['codeset', [{ id: 'c1', type: 'codeset', properties: codesetProperties, content: [], parent: null }]]
@@ -877,7 +907,7 @@ describe('PlatformService', () => {
         .stub(platformService as any, '_addFileToArchive')
         .callsFake(() => Promise.resolve());
 
-      await platformService._addJsonFilesToArchive(pack, datasetId, blocksByType as any);
+      await platformService._addJsonFilesToArchive(pack, archiveRootId, blocksByType as any);
 
       const codesetCall = addFileToArchiveStub.getCalls().find((call) => call.args[2] === 'codes/codeset.json');
       expect(codesetCall).to.exist;

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -5,12 +5,12 @@ import { describe } from 'mocha';
 import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
 import { ApiError, ApiErrorType } from '../errors/api-error';
 import { BiohubFeatureType } from '../models/biohub-create';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
 import { envConfigDependencies as envConfig } from '../utils/env-config';
 import { featureFlagDependencies as featureFlagUtils } from '../utils/feature-flag-utils';
-import { getMockDBConnection } from '../__mocks__/db';
 import { AttachmentService } from './attachment-service';
 import { CodeService } from './code-service';
 import { SurveyHabitatFeatureService } from './habitat-feature-services/survey-habitat-feature-service';
@@ -95,7 +95,7 @@ describe('PlatformService', () => {
       expect(axiosStub.getCall(0).args[1]?.headers?.authorization).to.equal('Bearer token');
       expect(axiosStub.getCall(0).args[1]?.params.terms).to.deep.equal(['Alces', 'alces']);
 
-      expect(taxon).to.equal(null);
+      expect(taxon).to.be.null;
     });
 
     it('should return a null error thrown', async () => {
@@ -115,7 +115,7 @@ describe('PlatformService', () => {
       expect(axiosStub.getCall(0).args[1]?.headers?.authorization).to.equal('Bearer token');
       expect(axiosStub.getCall(0).args[1]?.params.terms).to.deep.equal(['Alces', 'alces']);
 
-      expect(taxon).to.equal(null);
+      expect(taxon).to.be.null;
     });
   });
 
@@ -1528,7 +1528,7 @@ describe('PlatformService', () => {
 
       const result = await platformService.getSubmissionHistoryForSurvey(surveyId, submissionId);
 
-      expect(result).to.not.equal(null);
+      expect(result).to.not.be.null;
       expect(result).to.have.length(1);
       expect(result?.[0].submissionId).to.equal(bioHubId);
       expect(result?.[0].submissionUploadId).to.equal('upload-uuid-1');
@@ -1563,7 +1563,7 @@ describe('PlatformService', () => {
 
       const result = await platformService.getSubmissionHistoryForSurvey(42, '550e8400-e29b-41d4-a716-446655440000');
 
-      expect(result).to.equal(null);
+      expect(result).to.be.null;
       expect(axiosStub).to.not.have.been.called;
     });
   });

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -11,8 +11,8 @@ import { formatAxiosError } from '../errors/axios-error';
 import {
   BiohubFeatureType,
   PostSurveySubmissionToBioHubObject,
-  PUBLISHABLE_FEATURE_TYPE_PARENTS,
-  PUBLISHABLE_FEATURE_TYPES
+  PUBLISHABLE_FEATURE_TYPES,
+  PUBLISHABLE_FEATURE_TYPE_PARENTS
 } from '../models/biohub-create';
 import { ISurveyAttachment, ISurveyReportAttachment } from '../repositories/attachment-repository';
 import { getEnvironmentVariable } from '../utils/env-config';
@@ -487,15 +487,15 @@ export class PlatformService extends DBService {
     // Flatten and save the survey data package grouped by type
     const flattenedData = this._flattenToBlockModel(surveyDataPackage);
 
-    // Find the dataset ID (root block with type "dataset")
-    const datasetBlock = flattenedData.find((block) => block.type === 'dataset' && block.parent === null);
-    if (!datasetBlock?.id) {
+    // Find the survey ID (root block with type "survey")
+    const surveyBlock = flattenedData.find((block) => block.type === BiohubFeatureType.SURVEY && block.parent === null);
+    if (!surveyBlock?.id) {
       throw new ApiError(
         ApiErrorType.UNKNOWN,
-        'Failed to find dataset ID in survey data package. The dataset block is missing or invalid.'
+        'Failed to find survey ID in survey data package. The survey block is missing or invalid.'
       );
     }
-    const datasetId = datasetBlock.id;
+    const archiveRootId = surveyBlock.id;
 
     // Group blocks by type
     const blocksByType = new Map<string, IFlattenedBlock[]>();
@@ -510,8 +510,8 @@ export class PlatformService extends DBService {
     // Create TAR archive with PAX format and extended attributes using tar-stream
     const submissionsBaseDir = path.join(process.cwd(), 'data', 'submissions');
     fs.mkdirSync(submissionsBaseDir, { recursive: true });
-    const tarFilePath = path.join(submissionsBaseDir, `${datasetId}.tar`);
-    await this._createTarArchive(datasetId, blocksByType, tarFilePath);
+    const tarFilePath = path.join(submissionsBaseDir, `${archiveRootId}.tar`);
+    await this._createTarArchive(archiveRootId, blocksByType, tarFilePath);
 
     defaultLog.info({
       label: 'submitSurveyToBioHub',
@@ -846,14 +846,14 @@ export class PlatformService extends DBService {
   /**
    * Creates a TAR archive with PAX format containing flattened JSON files.
    *
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
    * @param {string} tarFilePath - Full path where the TAR file should be created
    * @return {*}  {Promise<void>}
    * @memberof PlatformService
    */
   async _createTarArchive(
-    datasetId: string,
+    archiveRootId: string,
     blocksByType: Map<string, IFlattenedBlock[]>,
     tarFilePath: string
   ): Promise<void> {
@@ -869,10 +869,10 @@ export class PlatformService extends DBService {
       outputStream.on('error', reject);
     });
 
-    // Add the dataset directory entry
+    // Add the archive root directory entry
     pack.entry(
       {
-        name: `${datasetId}/`,
+        name: `${archiveRootId}/`,
         type: 'directory'
       },
       undefined,
@@ -881,7 +881,7 @@ export class PlatformService extends DBService {
           pack.destroy();
           throw dirErr;
         }
-        this._addMetadataFile(pack, datasetId, blocksByType);
+        this._addMetadataFile(pack, archiveRootId, blocksByType);
       }
     );
 
@@ -892,18 +892,18 @@ export class PlatformService extends DBService {
    * Adds metadata file and JSON files to the TAR archive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
    * @memberof PlatformService
    */
-  _addMetadataFile(pack: tarStream.Pack, datasetId: string, blocksByType: Map<string, IFlattenedBlock[]>): void {
-    // Add a metadata file with the dataset ID
+  _addMetadataFile(pack: tarStream.Pack, archiveRootId: string, blocksByType: Map<string, IFlattenedBlock[]>): void {
+    // Add a metadata file with the archive root ID
     // Note: tar-stream doesn't easily support PAX extended attributes,
-    // so we store the dataset ID in a metadata file instead
-    const metadataContent = Buffer.from(datasetId);
+    // so we store the archive root ID in a metadata file instead
+    const metadataContent = Buffer.from(archiveRootId);
     pack.entry(
       {
-        name: `${datasetId}/.dataset-id`,
+        name: `${archiveRootId}/.survey-id`,
         size: metadataContent.length
       },
       metadataContent,
@@ -913,7 +913,7 @@ export class PlatformService extends DBService {
           throw metadataErr;
         }
         // Start adding JSON files and file blocks (async operation)
-        this._addJsonFiles(pack, datasetId, blocksByType).catch((error) => {
+        this._addJsonFiles(pack, archiveRootId, blocksByType).catch((error) => {
           defaultLog.error({
             label: '_addMetadataFile',
             message: 'Failed to add JSON files and file blocks',
@@ -932,14 +932,14 @@ export class PlatformService extends DBService {
    * blocks are written under `features/`.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
    * @return {*}  {Promise<void>}
    * @memberof PlatformService
    */
   async _addJsonFiles(
     pack: tarStream.Pack,
-    datasetId: string,
+    archiveRootId: string,
     blocksByType: Map<string, IFlattenedBlock[]>
   ): Promise<void> {
     if (blocksByType.size === 0) {
@@ -950,8 +950,8 @@ export class PlatformService extends DBService {
     const fileBlocks = blocksByType.get('file') || [];
 
     await Promise.all([
-      this._addJsonFilesToArchive(pack, datasetId, blocksByType),
-      this._addFileBlocksToArchive(pack, datasetId, fileBlocks)
+      this._addJsonFilesToArchive(pack, archiveRootId, blocksByType),
+      this._addFileBlocksToArchive(pack, archiveRootId, fileBlocks)
     ]);
     pack.finalize();
   }
@@ -961,20 +961,20 @@ export class PlatformService extends DBService {
    * or _addCodesetToArchive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {Map<string, IFlattenedBlock[]>} blocksByType - Map of block types to their flattened blocks
    * @return {Promise<void>} Resolves when all JSON files have been added to the archive
    * @memberof PlatformService
    */
   _addJsonFilesToArchive(
     pack: tarStream.Pack,
-    datasetId: string,
+    archiveRootId: string,
     blocksByType: Map<string, IFlattenedBlock[]>
   ): Promise<void> {
     const promises = Array.from(blocksByType.entries()).map(([type, blocks]) =>
       type === TARBALL_FILE_ROLE.CODESET
-        ? this._addCodesetToArchive(pack, datasetId, blocks)
-        : this._addFeatureToArchive(pack, datasetId, type, blocks)
+        ? this._addCodesetToArchive(pack, archiveRootId, blocks)
+        : this._addFeatureToArchive(pack, archiveRootId, type, blocks)
     );
     return Promise.all(promises).then(() => undefined);
   }
@@ -983,7 +983,7 @@ export class PlatformService extends DBService {
    * Adds a feature JSON file for a specific block type to the TAR archive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {string} type - The block type (feature name)
    * @param {IFlattenedBlock[]} blocks - Flattened blocks of this type
    * @return {Promise<void>} Resolves when the file has been added to the archive
@@ -991,50 +991,54 @@ export class PlatformService extends DBService {
    */
   _addFeatureToArchive(
     pack: tarStream.Pack,
-    datasetId: string,
+    archiveRootId: string,
     type: string,
     blocks: IFlattenedBlock[]
   ): Promise<void> {
     const fileName = `features/${type}.json`;
     const fileContent = Buffer.from(JSON.stringify(blocks, null, 2));
-    return this._addFileToArchive(pack, datasetId, fileName, fileContent);
+    return this._addFileToArchive(pack, archiveRootId, fileName, fileContent);
   }
 
   /**
    * Adds the consolidated codeset JSON file to the TAR archive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {IFlattenedBlock[]} codesetBlocks - Flattened codeset blocks (expected to contain a single codeset feature)
    * @return {Promise<void>} Resolves when the file has been added to the archive
    * @memberof PlatformService
    */
-  _addCodesetToArchive(pack: tarStream.Pack, datasetId: string, codesetBlocks: IFlattenedBlock[]): Promise<void> {
+  _addCodesetToArchive(pack: tarStream.Pack, archiveRootId: string, codesetBlocks: IFlattenedBlock[]): Promise<void> {
     const fileName = 'codes/codeset.json';
     const payload =
       codesetBlocks.length > 0 && codesetBlocks[0].properties !== undefined
         ? codesetBlocks[0].properties
         : codesetBlocks;
     const fileContent = Buffer.from(JSON.stringify(payload, null, 2));
-    return this._addFileToArchive(pack, datasetId, fileName, fileContent);
+    return this._addFileToArchive(pack, archiveRootId, fileName, fileContent);
   }
 
   /**
    * Adds actual file content for file type blocks to the TAR archive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {IFlattenedBlock[]} fileBlocks - Array of file blocks to process
    * @return {Promise<void>} Resolves when all file blocks have been added to the archive
    * @memberof PlatformService
    */
-  async _addFileBlocksToArchive(pack: tarStream.Pack, datasetId: string, fileBlocks: IFlattenedBlock[]): Promise<void> {
+  async _addFileBlocksToArchive(
+    pack: tarStream.Pack,
+    archiveRootId: string,
+    fileBlocks: IFlattenedBlock[]
+  ): Promise<void> {
     if (fileBlocks.length === 0) {
       return;
     }
 
     for (const fileBlock of fileBlocks) {
-      await this._processFileBlock(pack, datasetId, fileBlock);
+      await this._processFileBlock(pack, archiveRootId, fileBlock);
     }
   }
 
@@ -1042,12 +1046,12 @@ export class PlatformService extends DBService {
    * Processes a single file block by downloading from S3 and adding to archive.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {IFlattenedBlock} fileBlock - The file block to process
    * @return {Promise<void>} Resolves when the file block has been processed (added or skipped)
    * @memberof PlatformService
    */
-  async _processFileBlock(pack: tarStream.Pack, datasetId: string, fileBlock: IFlattenedBlock): Promise<void> {
+  async _processFileBlock(pack: tarStream.Pack, archiveRootId: string, fileBlock: IFlattenedBlock): Promise<void> {
     try {
       const artifactKey = fileBlock.properties?.artifact_key as string | undefined;
       const filename = (fileBlock.properties?.filename as string | undefined) || fileBlock.id;
@@ -1063,7 +1067,7 @@ export class PlatformService extends DBService {
       }
 
       const archivePath = `files/${filename}`;
-      await this._addFileToArchive(pack, datasetId, archivePath, fileContent);
+      await this._addFileToArchive(pack, archiveRootId, archivePath, fileContent);
     } catch (error) {
       this._logFileBlockError('Failed to add file block to archive', fileBlock.id, error);
     }
@@ -1133,17 +1137,17 @@ export class PlatformService extends DBService {
    * Adds a single file to the TAR archive from memory.
    *
    * @param {tarStream.Pack} pack - The TAR pack stream
-   * @param {string} datasetId - The dataset ID
+   * @param {string} archiveRootId - The archive root ID
    * @param {string} fileName - Filename to add
    * @param {Buffer} fileContent - File content as a Buffer
    * @return {Promise<void>} Resolves when the file entry has been written to the pack
    * @memberof PlatformService
    */
-  _addFileToArchive(pack: tarStream.Pack, datasetId: string, fileName: string, fileContent: Buffer): Promise<void> {
+  _addFileToArchive(pack: tarStream.Pack, archiveRootId: string, fileName: string, fileContent: Buffer): Promise<void> {
     return new Promise((resolve, reject) => {
       pack.entry(
         {
-          name: `${datasetId}/${fileName}`,
+          name: `${archiveRootId}/${fileName}`,
           size: fileContent.length
         },
         fileContent,

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -11,8 +11,8 @@ import { formatAxiosError } from '../errors/axios-error';
 import {
   BiohubFeatureType,
   PostSurveySubmissionToBioHubObject,
-  PUBLISHABLE_FEATURE_TYPES,
-  PUBLISHABLE_FEATURE_TYPE_PARENTS
+  PUBLISHABLE_FEATURE_TYPE_PARENTS,
+  PUBLISHABLE_FEATURE_TYPES
 } from '../models/biohub-create';
 import { ISurveyAttachment, ISurveyReportAttachment } from '../repositories/attachment-repository';
 import { getEnvironmentVariable } from '../utils/env-config';


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1075

## Description of Changes

- Requires https://github.com/bcgov/biohubbc-platform/pull/496
- Changed BioHub survey publishing so the root metadata feature is now `survey` instead of `dataset`, and the tarball writes it as `features/survey.json`.
- Removed/cleaned remaining API publish-path `dataset` references, including the tar metadata marker, which is now `.survey-id`

## Testing Notes

- Publishing a Survey should succeed
