### PR TITLE
SIMSBIOHUB-1108: Fix keycloak login issue

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,6 @@ const App = () => {
             const authConfig: AuthProviderProps = {
               authority: `${config.KEYCLOAK_CONFIG.authority}/realms/${config.KEYCLOAK_CONFIG.realm}/`,
               client_id: config.KEYCLOAK_CONFIG.clientId,
-              resource: config.KEYCLOAK_CONFIG.clientId,
               // Automatically renew the access token before it expires
               automaticSilentRenew: true,
               // Default sign in redirect


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1108](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1108)

## Description of Changes

- Removes the `resource` parameter from the app's OIDC auth config, which was sent on every login request with the client id as its value.
- The BC gov SSO (loginproxy) dev and test Keycloak instances were upgraded to a version that now validates the RFC 8707 `resource` parameter. A bare client id is not a valid resource URI, so Keycloak rejects the login request with `error=invalid_target` and immediately redirects back to the app before the login page ever renders.
- Note: prod loginproxy is still on the older Keycloak version, so prod login currently works, but it will break when the upgrade rolls out to prod. This fix should be released ahead of that.

## Testing Notes

- Run the app locally and click `Log In`. Before this fix, the page immediately reloads with `?error=invalid_target&error_description=The+requested+resource+is+invalid...` in the URL; after, the Keycloak login page loads and login completes normally.
- Root cause was confirmed directly against the authorize endpoint: an identical request with `resource=<client id>` is rejected with `invalid_target` by both dev and test loginproxy, while the same request without it proceeds normally.
- After logging in, sanity-check an authenticated area (e.g. admin pages) to confirm roles and tokens behave as before — no change is expected, since the removed parameter was previously ignored.