### PR TITLE
SIMSBIOHUB-1063: Grant Users Access to their Own Submissions

### DIFF
--- a/api/src/paths/publish/survey.test.ts
+++ b/api/src/paths/publish/survey.test.ts
@@ -4,6 +4,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
+import { SYSTEM_IDENTITY_SOURCE } from '../../constants/database';
 import { dbDependencies as db } from '../../database/db';
 import { HTTPError } from '../../errors/http-error';
 import { PlatformService } from '../../services/platform-service';
@@ -22,6 +23,12 @@ describe('survey', () => {
   });
 
   describe('publishSurvey', () => {
+    const systemUser = {
+      user_guid: '11111111-1111-1111-1111-111111111111',
+      user_identifier: 'JSMITH',
+      identity_source: SYSTEM_IDENTITY_SOURCE.IDIR
+    };
+
     afterEach(() => {
       sinon.restore();
     });
@@ -38,6 +45,7 @@ describe('survey', () => {
 
       const sampleReq = {
         keycloak_token: {},
+        system_user: systemUser,
         body: {
           projectId: 1,
           surveyId: 1,
@@ -66,6 +74,19 @@ describe('survey', () => {
       await requestHandler(sampleReq, sampleRes as unknown as any, mockNext);
 
       expect(actualResult).to.eql({ submission_uuid: '550e8400-e29b-41d4-a716-446655440000' });
+      expect(PlatformService.prototype.submitSurveyToBioHub).to.have.been.calledOnceWith(
+        1,
+        {
+          submissionComment: 'test'
+        },
+        [
+          {
+            guid: systemUser.user_guid,
+            identifier: systemUser.user_identifier,
+            identitySource: systemUser.identity_source
+          }
+        ]
+      );
     });
 
     it('catches error, calls rollback, and re-throws error', async () => {
@@ -77,6 +98,7 @@ describe('survey', () => {
       sinon.stub(PlatformService.prototype, 'submitSurveyToBioHub').rejects(new Error('a test error'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.system_user = systemUser as any;
       mockReq.body = {
         projectId: 1,
         surveyId: 1,
@@ -107,6 +129,7 @@ describe('survey', () => {
 
       const sampleReq = {
         keycloak_token: {},
+        system_user: systemUser,
         body: {
           projectId: 1,
           surveyId: 1,

--- a/api/src/paths/publish/survey.ts
+++ b/api/src/paths/publish/survey.ts
@@ -5,7 +5,7 @@ import { getDBConnection } from '../../database/db';
 import { HTTP400 } from '../../errors/http-error';
 import { BiohubFeatureType, PUBLISHABLE_FEATURE_TYPES } from '../../models/biohub-create';
 import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
-import { PlatformService } from '../../services/platform-service';
+import { BioHubSubmitter, PlatformService } from '../../services/platform-service';
 import { SurveyService } from '../../services/survey-service';
 import { getLogger } from '../../utils/logger';
 
@@ -160,7 +160,14 @@ export function publishSurvey(): RequestHandler {
       }
 
       const platformService = new PlatformService(connection);
-      const response = await platformService.submitSurveyToBioHub(surveyId, data);
+      const submitters: BioHubSubmitter[] = [
+        {
+          guid: req.system_user!.user_guid as string,
+          identifier: req.system_user!.user_identifier,
+          identitySource: req.system_user!.identity_source as BioHubSubmitter['identitySource']
+        }
+      ];
+      const response = await platformService.submitSurveyToBioHub(surveyId, data, submitters);
 
       await connection.commit();
 

--- a/api/src/services/platform-service.test.ts
+++ b/api/src/services/platform-service.test.ts
@@ -6,6 +6,7 @@ import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../__mocks__/db';
+import { SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { ApiError, ApiErrorType } from '../errors/api-error';
 import { BiohubFeatureType } from '../models/biohub-create';
 import { ObservationRecordWithSamplingAndSubcountData } from '../repositories/observation-repository/observation-repository.interface';
@@ -131,7 +132,7 @@ describe('PlatformService', () => {
       const platformService = new PlatformService(mockDBConnection);
 
       try {
-        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
         expect.fail();
       } catch (error) {
         expect((error as Error).message).to.equal('Publishing to BioHub is not currently enabled.');
@@ -173,7 +174,7 @@ describe('PlatformService', () => {
         .rejects(new ApiError(ApiErrorType.UNKNOWN, 'Failed to initiate submission upload to BioHub'));
 
       try {
-        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
         expect.fail('Should have thrown an error');
       } catch (error) {
         const noSurveyAttachments: unknown[] = [];
@@ -197,6 +198,13 @@ describe('PlatformService', () => {
 
       const mockDBConnection = getMockDBConnection();
       const platformService = new PlatformService(mockDBConnection);
+      const submitters = [
+        {
+          guid: '11111111-1111-1111-1111-111111111111',
+          identifier: 'JSMITH',
+          identitySource: SYSTEM_IDENTITY_SOURCE.IDIR
+        }
+      ];
 
       sinon.stub(HistoryPublishService.prototype, 'getSurveyMetadataPublishRecord').resolves(null);
 
@@ -250,7 +258,7 @@ describe('PlatformService', () => {
         .stub(HistoryPublishService.prototype, 'insertSurveyMetadataPublishRecord')
         .resolves();
 
-      const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+      const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, submitters);
 
       const noSurveyAttachments: unknown[] = [];
       const noReportAttachments: unknown[] = [];
@@ -263,7 +271,14 @@ describe('PlatformService', () => {
         'test',
         sinon.match((value) => value instanceof Set)
       );
-      expect(_initiateSubmissionUploadStub).to.have.been.calledOnce;
+      expect(_initiateSubmissionUploadStub).to.have.been.calledOnceWith(
+        'token',
+        1024,
+        { id: '123-456-789', name: 'Test', description: 'Test Description' },
+        'test',
+        null,
+        submitters
+      );
       expect(_uploadTarFilePartsStub).to.have.been.calledOnce;
       expect(_completeSubmissionUploadStub).to.have.been.calledOnceWith(
         'token',
@@ -327,14 +342,15 @@ describe('PlatformService', () => {
         .stub(HistoryPublishService.prototype, 'insertSurveyMetadataPublishRecord')
         .resolves();
 
-      const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+      const response = await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
 
       expect(_initiateSubmissionUploadStub).to.have.been.calledOnceWith(
         'token',
         1024,
         { id: '123-456-789', name: 'Test', description: 'Test Description' },
         'test',
-        existingSubmissionUuid
+        existingSubmissionUuid,
+        []
       );
       expect(insertSurveyMetadataPublishRecordStub).to.have.been.calledOnceWith({
         survey_id: 1,
@@ -738,7 +754,7 @@ describe('PlatformService', () => {
       sinon.stub(PlatformService.prototype, '_uploadTarFileParts').resolves([{ PartNumber: 1, ETag: 'etag-123' }]);
       sinon.stub(PlatformService.prototype, '_completeSubmissionUpload').resolves();
 
-      await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+      await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
 
       // Verify flattening was called
       expect(flattenToBlockModelStub).to.have.been.calledOnce;
@@ -777,7 +793,7 @@ describe('PlatformService', () => {
 
       // Should throw error since flattening is required for the upload flow
       try {
-        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
         expect.fail('Should have thrown an error');
       } catch (error) {
         expect((error as Error).message).to.include('File system error');
@@ -824,7 +840,7 @@ describe('PlatformService', () => {
 
       // Should throw error since TAR creation is required for the upload flow
       try {
-        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' });
+        await platformService.submitSurveyToBioHub(1, { submissionComment: 'test' }, []);
         expect.fail('Should have thrown an error');
       } catch (error) {
         expect((error as Error).message).to.include('TAR creation error');
@@ -1270,7 +1286,8 @@ describe('PlatformService', () => {
         bytes: 1024,
         name: 'Test Survey',
         description: 'Test Description',
-        comment: 'comment'
+        comment: 'comment',
+        submitters: []
       });
       expect(axiosPostStub.getCall(0).args[2]?.headers?.authorization).to.equal('Bearer token');
 
@@ -1333,8 +1350,52 @@ describe('PlatformService', () => {
         bytes: 1024,
         name: 'Test Survey',
         description: 'Test Description',
-        comment: 'comment'
+        comment: 'comment',
+        submitters: []
       });
+    });
+
+    it('sends submitters in the JSON request body', async () => {
+      process.env.BACKBONE_INTERNAL_API_HOST = 'http://backbone-host.dev/';
+      process.env.BACKBONE_SUBMISSION_UPLOAD_PATH = '/api/submission';
+
+      const platformService = new PlatformService(getMockDBConnection());
+      const axiosPostStub = sinon.stub(axios, 'post').resolves({
+        data: {
+          submissionId: 'submission-id',
+          submissionUploadId: 'submission-upload-id',
+          uploadId: 'upload-id',
+          s3UploadId: 's3-upload-id',
+          key: 's3-key',
+          partCount: 1,
+          presignedUrls: [{ partNumber: 1, url: 'https://s3.amazonaws.com/url1', partSizeBytes: 1024 }]
+        }
+      });
+      const submitters = [
+        {
+          guid: '11111111-1111-1111-1111-111111111111',
+          identifier: 'JSMITH',
+          identitySource: SYSTEM_IDENTITY_SOURCE.IDIR
+        }
+      ];
+
+      await platformService._initiateSubmissionUpload(
+        'token',
+        1024,
+        { name: 'Test Survey', description: 'Test Description' } as any,
+        'comment',
+        null,
+        submitters
+      );
+
+      expect(axiosPostStub.getCall(0).args[1]).to.deep.equal({
+        bytes: 1024,
+        name: 'Test Survey',
+        description: 'Test Description',
+        comment: 'comment',
+        submitters
+      });
+      expect(axiosPostStub.getCall(0).args[1]).not.to.have.property('submitter');
     });
 
     it('should return initiate response ids without additional uuid validation', async () => {

--- a/api/src/services/platform-service.ts
+++ b/api/src/services/platform-service.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import qs from 'qs';
 import * as tarStream from 'tar-stream';
 import { URL } from 'url';
+import { SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { IDBConnection } from '../database/db';
 import { ApiError, ApiErrorType, ApiGeneralError } from '../errors/api-error';
 import { formatAxiosError } from '../errors/axios-error';
@@ -70,6 +71,15 @@ export interface ITaxonomyWithEcologicalUnits extends ITaxonomy {
 export type PublishSurveyData = {
   submissionComment: string;
   featureTypes?: BiohubFeatureType[];
+};
+
+export type BioHubSubmitter = {
+  guid: string;
+  identifier: string;
+  identitySource:
+    | SYSTEM_IDENTITY_SOURCE.IDIR
+    | SYSTEM_IDENTITY_SOURCE.BCEID_BASIC
+    | SYSTEM_IDENTITY_SOURCE.BCEID_BUSINESS;
 };
 
 interface IFlattenedBlock {
@@ -445,10 +455,15 @@ export class PlatformService extends DBService {
    *
    * @param {number} surveyId
    * @param {{ submissionComment: string }} data
+   * @param {BioHubSubmitter[]} submitters
    * @return {*}  {Promise<{ submission_uuid: string }>}
    * @memberof PlatformService
    */
-  async submitSurveyToBioHub(surveyId: number, data: PublishSurveyData): Promise<{ submission_uuid: string }> {
+  async submitSurveyToBioHub(
+    surveyId: number,
+    data: PublishSurveyData,
+    submitters: BioHubSubmitter[]
+  ): Promise<{ submission_uuid: string }> {
     const includeFeatureTypes = this.normalizePublishFeatureTypes(data.featureTypes);
 
     defaultLog.debug({ label: 'submitSurveyToBioHub', message: 'params', surveyId });
@@ -531,7 +546,8 @@ export class PlatformService extends DBService {
         tarFileSize,
         surveyDataPackage,
         data.submissionComment,
-        existingSubmissionUuid
+        existingSubmissionUuid,
+        submitters
       );
 
     defaultLog.info({
@@ -1172,6 +1188,7 @@ export class PlatformService extends DBService {
    * @param {PostSurveySubmissionToBioHubObject} surveyDataPackage - Survey data package
    * @param {string} submissionComment - Comment for the submission
    * @param {string | null} existingSubmissionUuid - When set, initiate upload for this existing submission (re-publish)
+   * @param {BioHubSubmitter[]} submitters - Users who should receive access
    * @return {*}  {Promise<SubmissionUploadInitiateResult>}
    * @memberof PlatformService
    */
@@ -1180,7 +1197,8 @@ export class PlatformService extends DBService {
     tarFileSize: number,
     surveyDataPackage: PostSurveySubmissionToBioHubObject,
     submissionComment: string,
-    existingSubmissionUuid: string | null
+    existingSubmissionUuid: string | null,
+    submitters: BioHubSubmitter[] = []
   ): Promise<SubmissionUploadInitiateResult> {
     defaultLog.debug({
       label: '_initiateSubmissionUpload',
@@ -1211,7 +1229,8 @@ export class PlatformService extends DBService {
       bytes: tarFileSize,
       name: surveyDataPackage.name,
       description: surveyDataPackage.description,
-      comment: submissionComment
+      comment: submissionComment,
+      submitters
     };
 
     try {


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1063

## Description of Changes

- Updated survey publishing to use the new `submitters` array.
- Includes only the authenticated user who initiated the publication.

## Testing Notes

- Run both SIMS and BioHub locally.
- Publish a survey from SIMS. 
- Sign in to BioHub as the user who published the survey.
- Confirm the submission appears on the BioHub portal page on the Submissions tab.
