### PR TITLE
SIMSBIOHUB-1077: Standardize SIMS UI to display telemetry timestamps in UTC

### DIFF
--- a/app/src/contexts/telemetryTableContext.tsx
+++ b/app/src/contexts/telemetryTableContext.tsx
@@ -24,6 +24,7 @@ import { usePersistentState } from 'hooks/usePersistentState';
 import { GetSurveyTelemetryResponse } from 'interfaces/useTelemetryApi.interface';
 import { createContext, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ApiPaginationRequestOptions } from 'types/misc';
+import { combineDateTimeUtc, formatTimestampUtc } from 'utils/datetime';
 import { firstOrNull } from 'utils/Utils';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -664,7 +665,7 @@ export const TelemetryTableContextProvider = (props: IAllTelemetryTableContextPr
           deployment_id: row.deployment_id,
           latitude: Number(row.latitude),
           longitude: Number(row.longitude),
-          acquisition_date: dayjs(`${row.date}T${row.time}`).toISOString(),
+          acquisition_date: combineDateTimeUtc(row.date, row.time),
           transmission_date: null
         }));
 
@@ -674,7 +675,7 @@ export const TelemetryTableContextProvider = (props: IAllTelemetryTableContextPr
           deployment_id: row.deployment_id,
           latitude: Number(row.latitude),
           longitude: Number(row.longitude),
-          acquisition_date: dayjs(`${row.date}T${row.time}`).toISOString(),
+          acquisition_date: combineDateTimeUtc(row.date, row.time),
           transmission_date: null
         }));
 
@@ -786,8 +787,8 @@ export const TelemetryTableContextProvider = (props: IAllTelemetryTableContextPr
         serial: item.serial,
         latitude: item.latitude,
         longitude: item.longitude,
-        date: dayjs(item.acquisition_date).format('YYYY-MM-DD'),
-        time: dayjs(item.acquisition_date).format('HH:mm:ss'),
+        date: formatTimestampUtc(item.acquisition_date, 'YYYY-MM-DD'),
+        time: formatTimestampUtc(item.acquisition_date, 'HH:mm:ss'),
         telemetry_type: item.vendor
       };
     });

--- a/app/src/features/summary/tabular-data/telemetry/TelemetryListContainer.tsx
+++ b/app/src/features/summary/tabular-data/telemetry/TelemetryListContainer.tsx
@@ -10,7 +10,6 @@ import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { SkeletonTable } from 'components/loading/SkeletonLoaders';
 import { NoDataOverlay } from 'components/overlay/NoDataOverlay';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
-import dayjs from 'dayjs';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useDeepCompareEffect } from 'hooks/useDeepCompareEffect';
@@ -18,6 +17,7 @@ import { useSearchParams } from 'hooks/useSearchParams';
 import { IFindTelementryObj } from 'interfaces/useTelemetryApi.interface';
 import { useState } from 'react';
 import { ApiPaginationRequestOptions, StringValues } from 'types/misc';
+import { formatTimestampUtc } from 'utils/datetime';
 import { firstOrNull } from 'utils/Utils';
 import {
   IAllTelemetryAdvancedFilters,
@@ -143,12 +143,12 @@ const TelemetryListContainer = (props: IAllTelemetryListContainerProps) => {
     },
     {
       field: 'acquisition_date',
-      headerName: 'Date',
+      headerName: 'Date (UTC)',
       flex: 1,
       sortable: false,
       renderCell: (params) => (
         <Typography variant="body2">
-          {dayjs(params.row.acquisition_date).format(DATE_FORMAT.MediumDateTimeFormat)}
+          {formatTimestampUtc(params.row.acquisition_date, DATE_FORMAT.MediumDateTimeFormat)}
         </Typography>
       )
     },

--- a/app/src/features/surveys/telemetry/table/TelemetryTable.tsx
+++ b/app/src/features/surveys/telemetry/table/TelemetryTable.tsx
@@ -75,7 +75,12 @@ export const TelemetryTable = (props: IManualTelemetryTableProps) => {
       // TODO: Show animal nickname as a column
       DeviceColDef(),
       GenericDateColDef({ field: 'date', headerName: 'Date', hasError: telemetryTableContext.hasError }),
-      GenericTimeColDef({ field: 'time', headerName: 'Time', hasError: telemetryTableContext.hasError }),
+      GenericTimeColDef({
+        field: 'time',
+        headerName: 'Time (UTC)',
+        description: 'Times are entered and displayed in UTC',
+        hasError: telemetryTableContext.hasError
+      }),
       GenericLatitudeColDef({ field: 'latitude', headerName: 'Latitude', hasError: telemetryTableContext.hasError }),
       GenericLongitudeColDef({ field: 'longitude', headerName: 'Longitude', hasError: telemetryTableContext.hasError }),
       TelemetryTypeColDef()

--- a/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialTelemetryPopup.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialTelemetryPopup.tsx
@@ -1,12 +1,12 @@
 import { IStaticLayerFeature } from 'components/map/components/StaticLayers';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
-import dayjs from 'dayjs';
 import { SurveyMapPopup } from 'features/surveys/view/SurveyMapPopup';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { IAllTelemetry } from 'interfaces/useTelemetryApi.interface';
 import { Popup } from 'react-leaflet';
+import { formatTimestampUtc } from 'utils/datetime';
 
 export interface ISurveySpatialTelemetryPopupProps {
   feature: IStaticLayerFeature;
@@ -44,11 +44,11 @@ export const SurveySpatialTelemetryPopup = (props: ISurveySpatialTelemetryPopupP
       },
       {
         label: 'Date',
-        value: dayjs(telemetry.acquisition_date).format(DATE_FORMAT.MediumDateFormat)
+        value: formatTimestampUtc(telemetry.acquisition_date, DATE_FORMAT.MediumDateFormat)
       },
       {
-        label: 'Time',
-        value: dayjs(telemetry.acquisition_date).format(DATE_FORMAT.TimeFormat)
+        label: 'Time (UTC)',
+        value: formatTimestampUtc(telemetry.acquisition_date, DATE_FORMAT.TimeFormat)
       }
     ];
   };

--- a/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialTelemetryTable.tsx
+++ b/app/src/features/surveys/view/survey-spatial/components/telemetry/SurveySpatialTelemetryTable.tsx
@@ -4,10 +4,12 @@ import { StyledDataGrid } from 'components/data-grid/StyledDataGrid';
 import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { SkeletonTable } from 'components/loading/SkeletonLoaders';
 import { NoDataOverlay } from 'components/overlay/NoDataOverlay';
+import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { useBiohubApi } from 'hooks/useBioHubApi';
 import { useSurveyContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import { useEffect, useState } from 'react';
+import { formatTimestampUtc } from 'utils/datetime';
 
 // Set height so the skeleton loader will match table rows
 const rowHeight = 52;
@@ -115,8 +117,9 @@ export const SurveySpatialTelemetryTable = () => {
     },
     {
       field: 'acquisition_date',
-      headerName: 'Date',
-      flex: 1
+      headerName: 'Date (UTC)',
+      flex: 1,
+      valueFormatter: (params) => formatTimestampUtc(params.value, DATE_FORMAT.MediumDateTimeFormat)
     },
     {
       field: 'latitude',

--- a/app/src/utils/datetime.test.ts
+++ b/app/src/utils/datetime.test.ts
@@ -1,4 +1,4 @@
-import { combineDateTime, formatTimeDifference } from './datetime';
+import { combineDateTime, combineDateTimeUtc, formatTimeDifference, formatTimestampUtc } from './datetime';
 
 describe('combineDateTime', () => {
   it('combines date and time into an ISO string', () => {
@@ -22,6 +22,69 @@ describe('combineDateTime', () => {
 
     const time = combineDateTime('2024-01-01', 'badtime');
     expect(time).toEqual('Invalid Date');
+  });
+});
+
+describe('combineDateTimeUtc', () => {
+  beforeAll(() => {
+    // Pin a non-UTC timezone so a browser-local-parse regression cannot pass on UTC CI machines
+    vi.stubEnv('TZ', 'America/Vancouver');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('treats the incoming date and time as UTC (no browser-local shift)', () => {
+    const result = combineDateTimeUtc('2024-01-01', '22:30:00');
+    expect(result).toEqual('2024-01-01T22:30:00.000Z');
+  });
+
+  it('does not shift the date across the local-timezone midnight boundary', () => {
+    const result = combineDateTimeUtc('2024-01-01', '23:59:59');
+    expect(result).toEqual('2024-01-01T23:59:59.000Z');
+  });
+
+  it('is not affected by daylight savings offsets', () => {
+    const result = combineDateTimeUtc('2024-07-01', '22:30:00');
+    expect(result).toEqual('2024-07-01T22:30:00.000Z');
+  });
+});
+
+describe('formatTimestampUtc', () => {
+  beforeAll(() => {
+    // Pin a non-UTC timezone so a browser-local-render regression cannot pass on UTC CI machines
+    vi.stubEnv('TZ', 'America/Vancouver');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders a UTC-offset postgres timestamp in UTC', () => {
+    const result = formatTimestampUtc('2024-01-01 22:30:00+00', 'HH:mm:ss');
+    expect(result).toEqual('22:30:00');
+  });
+
+  it('renders a non-UTC-offset postgres timestamp as its UTC equivalent', () => {
+    const result = formatTimestampUtc('2024-01-01 14:30:00-08', 'YYYY-MM-DD HH:mm:ss');
+    expect(result).toEqual('2024-01-01 22:30:00');
+  });
+
+  it('renders the UTC calendar date across local date boundaries', () => {
+    const result = formatTimestampUtc('2024-01-02 03:30:00+00', 'YYYY-MM-DD');
+    expect(result).toEqual('2024-01-02');
+  });
+
+  it('handles microsecond precision from timestamptz(6)', () => {
+    const result = formatTimestampUtc('2024-01-01 22:30:00.123456+00', 'HH:mm:ss');
+    expect(result).toEqual('22:30:00');
+  });
+
+  it('returns an empty string for null, undefined or invalid input', () => {
+    expect(formatTimestampUtc(null, 'HH:mm:ss')).toEqual('');
+    expect(formatTimestampUtc(undefined, 'HH:mm:ss')).toEqual('');
+    expect(formatTimestampUtc('not-a-date', 'HH:mm:ss')).toEqual('');
   });
 });
 

--- a/app/src/utils/datetime.ts
+++ b/app/src/utils/datetime.ts
@@ -1,11 +1,13 @@
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import dayjs from 'dayjs';
 import duration, { DurationUnitType } from 'dayjs/plugin/duration';
+import utc from 'dayjs/plugin/utc';
 import { pluralize } from './Utils';
 
 const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 dayjs.extend(duration);
+dayjs.extend(utc);
 
 /**
  * Combine date and time and return ISO string.
@@ -20,6 +22,45 @@ export const combineDateTime = (date: string, time?: string | null) => {
   }
 
   return dayjs(`${date}`).format(TIMESTAMP_FORMAT);
+};
+
+/**
+ * Combine date and time and return an ISO 8601 string, treating the incoming values as UTC.
+ *
+ * The wall-clock value provided is the value returned (no conversion from the browser's local timezone).
+ *
+ * @example combineDateTimeUtc('2024-01-01', '22:30:00') // '2024-01-01T22:30:00.000Z'
+ *
+ * @param {string} date - String date ie: '2024-01-01'
+ * @param {string} time - String time ie: '22:30:00'
+ * @returns {string} ISO 8601 UTC date string
+ */
+export const combineDateTimeUtc = (date: string, time: string): string => {
+  return dayjs.utc(`${date}T${time}`).toISOString();
+};
+
+/**
+ * Format a timestamp in UTC.
+ *
+ * The incoming timestamp may include a timezone offset (ie. postgres timestamptz output: '2024-01-01 14:30:00-08');
+ * the output renders the equivalent UTC wall-clock value (no conversion to the browser's local timezone).
+ *
+ * @param {string | null} [timestamp] - Timestamp string, with or without a timezone offset
+ * @param {string} format - Dayjs format string ie: 'HH:mm:ss'
+ * @returns {string} The timestamp formatted in UTC, or an empty string if the timestamp is falsy or invalid
+ */
+export const formatTimestampUtc = (timestamp: string | null | undefined, format: string): string => {
+  if (!timestamp) {
+    return '';
+  }
+
+  const date = dayjs(timestamp);
+
+  if (!date.isValid()) {
+    return '';
+  }
+
+  return date.utc().format(format);
 };
 
 /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1077](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1077)

## Description of Changes

- Manually entered telemetry times are now treated as UTC. Previously they were parsed as browser-local and shifted to UTC on save, then shifted back on display, so the stored value differed from what was entered.
- Added `combineDateTimeUtc` and `formatTimestampUtc` to `app/src/utils/datetime.ts`, and used them in `telemetryTableContext.tsx` for both save payloads and row hydration.
- Labelled UTC wherever a time is displayed: `Time (UTC)` on the telemetry table and map popup, `Date (UTC)` on the summary telemetry list and survey spatial table. The survey spatial table previously rendered the raw postgres timestamp with no formatting.
- Added unit tests for both helpers. They pin a non-UTC timezone, since on a UTC runner the old and new behaviour are indistinguishable.
- No API, repository or database changes.

Notes for reviewers:

- The shared `GenericTimeColDef` / `TimePickerDataGrid` were not changed, so the observations table is unaffected.
- Records saved before this change were stored shifted and will now display their true stored UTC value. No backfill is feasible, as those rows are indistinguishable from imported or vendor rows; they can be corrected by editing.
- Follow-up, out of scope: the CSV export path hardcodes an `America/Vancouver` conversion (`api/src/services/export-services/export-utils.ts`), which will disagree with the UTC UI.

## Testing Notes

- Run SIMS locally. The local `DB_TZ=America/Vancouver` makes the old behaviour visible.
- On a survey's Telemetry page, confirm the time column header reads `Time (UTC)`.
- Add a manual telemetry record with date `2024-01-01` and time `22:30:00`, then save. Note the grid alone does not prove the fix, since the old bug was self-masking on a same-timezone round trip — the database check is the real assertion.
- Confirm the stored value is `2024-01-01 22:30:00+00` (previously `2024-01-02 06:30:00+00`):

  ```sql
  SET timezone = 'UTC';
  SELECT telemetry_manual_id, acquisition_date FROM biohub.telemetry_manual ORDER BY create_date DESC LIMIT 5;
  ```

- Edit the row's time to `08:15:00`, save, and re-run the query. Expect `08:15:00+00`.
- Check the summary telemetry list and the survey spatial table and map popup against the same values.
- In Chrome DevTools, use Sensors to override the timezone to `Asia/Tokyo` and reload. Every telemetry date and time should be unchanged.
