### PR TITLE
SIMSBIOHUB-1118: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/addComments.yml
+++ b/.github/workflows/addComments.yml
@@ -8,6 +8,10 @@ on:
       - test
       - prod
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/custom-linter.yml
+++ b/.github/workflows/custom-linter.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   # OpenAPI request bodies should contain the property `required` and be set to true
   #

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE_TAG: build-1.0.0-${{ github.event.number }}
   OC_VERSION: "4.16.60"
@@ -417,6 +420,11 @@ jobs:
   commentTrivyResults:
     name: Comment Trivy Results
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow-level set rather than adding to it, so
+    # contents: read is restated alongside the PR write this job needs to post its comment.
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 20
     if: ${{ github.event.pull_request.merged == false &&
       github.event.pull_request.draft == false }}

--- a/.github/workflows/e2e-pr-test.yml
+++ b/.github/workflows/e2e-pr-test.yml
@@ -5,6 +5,9 @@ name: Cypress Test for PR-Based Deploy
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,6 +2,9 @@ name: e2e
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Checkout the repo once and cache it for use in subsequent jobs
   checkoutRepo:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Checkout the repo once and cache it for use in subsequent jobs
   checkoutRepo:

--- a/.github/workflows/toDraft.yml
+++ b/.github/workflows/toDraft.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [converted_to_draft]
 
+permissions:
+  contents: read
+
 env:
   OC_VERSION: "4.16.60"
   OC_CACHE_DIR: ~/.cache/oc

--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -1,6 +1,10 @@
 name: zap
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   zap_scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1118](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1118)

## Description of Changes

Nine workflows declared no `permissions` block, so every job in them ran with the repository's **default** `GITHUB_TOKEN` scopes — write access to contents, issues, PRs, packages and deployments, inherited by any action or transitive `npm ci` dependency. CodeQL flags this as `actions/missing-workflow-permissions` (15 open Medium alerts on `dev`: #21, #23, #27, #30, #33, #34, #35, #38, #41, #43, #45, #53, #90, #100, #101).

Each workflow now declares least-privilege scopes explicitly, following the pattern already used in `sweepPRs.yml` and `updateCodecovBaseline.yml`.

`contents: read` only — `custom-linter.yml`, `lint-format.yml`, `test.yml`, `e2e-test.yaml`, `e2e-pr-test.yml`, `toDraft.yml`, and `deploy.yml` at the workflow level.

Write scopes, for the three jobs that genuinely write to GitHub:

| Workflow | Scope | Why |
|---|---|---|
| `addComments.yml` | `pull-requests: write` | Posts the OpenShift URL comment (`peter-evans/create-or-update-comment`) |
| `deploy.yml` → `commentTrivyResults` | `pull-requests: write` | Posts the Trivy summary (`github.rest.issues.createComment`). Scoped to that job, not the whole workflow |
| `zap.yml` | `issues: write` | `zaproxy/action-full-scan` defaults to `allow_issue_writing: true` and files an issue with the report |

Deliberately not granted: `security-events: write` (Trivy writes SARIF to a workflow artifact, not the code-scanning API) and any `actions` scope (same-run artifact up/download uses the runtime token). Codecov and OpenShift authenticate with their own secrets, not `GITHUB_TOKEN`.

`addComments.yml` is not in the alert list — it postdates the last scan — but has the identical defect, so it is included rather than left for a follow-up.

The five workflows that already declared permissions are untouched.

## Testing Notes

CI-config only; no application code and no runtime behaviour change. This PR exercises most of the changed workflows against itself:

- **Test Checks**, **Linting and Formatting Checks** and **Custom Linter** should pass as before.
- **Add Comments** should post the OpenShift URL comment on this PR — direct proof of the `pull-requests: write` grant.
- **PR-Based Deploy on OpenShift** should build, push and deploy the Helm chart. If this PR surfaces Critical/High Trivy findings the Trivy comment should appear (proving the job-level scope); if not, the job logs `No vulnerabilities found`, also a pass.
- `zap.yml`, `e2e-test.yaml` and `e2e-pr-test.yml` are `workflow_dispatch`-only, not triggered here, and were reviewed by inspection.

All 14 workflow files were verified to parse as valid YAML with a `permissions` block resolving on every one. The alerts themselves close once this merges to `dev` and CodeQL re-runs.
